### PR TITLE
Allow null values for flags in regexp validations

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -18,7 +18,7 @@ const rangeValidation = validation('range', range('number'))
 
 const regexp = validation('regexp', Joi.object({
   pattern: Joi.string(),
-  flags: Joi.string()
+  flags: Joi.string().allow(null).optional()
 }))
 
 const unique = validation('unique', Joi.boolean())

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -131,5 +131,22 @@ describe('payload validation', function () {
         []
       ])
     })
+
+    it('allows null values for optional validation properties', async function () {
+      const errors = await validateBatches(function up (migration) {
+        const person = migration.createContentType('person')
+          .name('Person')
+          .description('A Person')
+
+        person.createField('fullName')
+          .name('Full Name')
+          .type('Symbol')
+          .validations([{ regexp: { pattern: '^[A-Za-z\s]+$', flags: null } }])
+      }, [])
+
+      expect(errors).to.eql([
+        []
+      ])
+    })
   })
 })


### PR DESCRIPTION
When a regexp validation is created through contentful ui, if no flag is
provided, it is set as `null`. After that, you are unable to update that
content model via migration-cli. This allows null values for that
validation property. Fixes #64 

I wasn't sure exactly where to put the test for this, but I think this was a reasonable place. Please advise if you prefer anything different.