### PR TITLE
Improvements to editor interface migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,21 +267,31 @@ Edits the field of provided `id`.
 Shorthand method to omit a field, publish its content type, and then delete the field.
 This implies that associated content for the field will be lost.
 
-`id : string` – The ID of the field to delete.
+**`id : string`** – The ID of the field to delete.
 
 #### `changeFieldId (currentId, newId)` : void
 
 Changes the field's ID.
 
-`currentId : string` – The current ID of the field.
-`newId : string` – The new ID for the field.
+**`currentId : string`** – The current ID of the field.
+**`newId : string`** – The new ID for the field.
 
-#### `changeEditorInterface (fieldId, widgetId)` : void
+#### `changeEditorInterface (fieldId, widgetId[, settings])` : void
 
 Changes the editor interface of given field's ID.
 
-`fieldId : string` – The ID of the field.
-`widgetId : string` – The new widget ID for the field.
+**`fieldId : string`** – The ID of the field.
+
+**`widgetId : string`** – The new widget ID for the field. See the [editor interface documentation](https://www.contentful.com/developers/docs/concepts/editor-interfaces/) for a list of available widgets.
+
+**`settings : Object`** – Widget settings, with the following options:
+
+- **`helpText : string`** – This help text will show up below the field.
+- **`trueLabel : string`** _(only for fields of type boolean)_ – Shows this text next to the radio button that sets this value to `true`. Defaults to “Yes”.
+- **`falseLabel : string`** _(only for fields of type boolean)_ – Shows this text next to the radio button that sets this value to `false`. Defaults to “No”.
+- **`stars : number`** _(only for fields of type rating)_ – Number of stars to select from. Defaults to 5.
+- **`format : string`** _(only for fields of type datePicker)_ – One of “dateonly”, “time”, “timeZ” (default). Specifies whether to show the clock and/or timezone inputs.
+- **`ampm : string`** _(only for fields of type datePicker)_ – Specifies which type of clock to use. Must be one of the stringss “12” or “24” (default).
 
 ### Field
 

--- a/src/lib/intent/editorinterface-update.ts
+++ b/src/lib/intent/editorinterface-update.ts
@@ -34,12 +34,22 @@ export default class EditorInterfaceUpdateIntent extends Intent {
     ]
   }
   toPlanMessage (): PlanMessage {
+    const { fieldId, settings } = this.payload.editorInterface
+    let createDetails = [chalk`{italic widgetId}: "${this.payload.editorInterface.widgetId}"`]
+
+    Object.keys(this.payload.editorInterface.settings).forEach(settingName =>
+      createDetails.push(chalk`{italic ${settingName}}: "${settings[settingName]}"`)
+    )
+
     return {
       heading: chalk`Update editor interface for Content Type {bold.yellow ${this.getContentTypeId()}}`,
-      details: [
-        chalk`Field {italic ${this.payload.editorInterface.fieldId}}: ${this.payload.editorInterface.widgetId}`
-      ],
-      sections: []
+      details: [],
+      sections: [
+        {
+          heading: chalk`Update field {yellow ${fieldId}}`,
+          details: createDetails
+        }
+      ]
     }
   }
 }

--- a/src/lib/interfaces/content-type.ts
+++ b/src/lib/interfaces/content-type.ts
@@ -30,8 +30,8 @@ interface APIContentType {
 
 interface APIEditorInterfaceSettings {
   helpText?: string,
-  trueLabel?: boolean,
-  falseLabel?: boolean,
+  trueLabel?: string,
+  falseLabel?: string,
   bulkEditing?: boolean,
   stars?: number,
   format?: string,


### PR DESCRIPTION
## Changes 

_When changing the editor interface of a field, I'd like to see those changes listed in the intents before approving the migration._

- Include field settings in editor interface intent
- Fix true/false label types
- Extend documentation for `changeEditorInterface`

<img width="405" alt="Screenshot of the added details when updating an editor interface" src="https://user-images.githubusercontent.com/11017722/39958095-517b9b2c-55fe-11e8-9e80-86b43eaed9e9.png">

> I'm not sure if this is the proper way of doing it — one thing that bothers me is that there's no spacing between the editor interface intent and the next intent. I couldn't figure out how to add it.
> Happy to be pointed in the right direction :) 
