### PR TITLE
feat: Add support for throwing instead of process.exit(1) on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ npm install contentful-migration
 ### Usage as a library
 
 ```javascript
-const runMigration = require('contentful-migration/built/bin/cli').default
+const runMigration = require('contentful-migration/built/bin/cli').runMigration
 const options = {
   filePath: '<migration-file-path>',
   spaceId: '<space-id>',
@@ -446,7 +446,7 @@ You can check out the [examples](/examples) to learn more about the migrations D
 Each example file is prefixed with a sequence number, specifying the order in which you're supposed to run the migrations, as follows:
 
 ```javascript
-const runMigration = require('contentful-migration/built/bin/cli').default
+const runMigration = require('contentful-migration/built/bin/cli').runMigration
 
 const options = {
   spaceId: '<space-id>',

--- a/examples/usage-as-lib.js
+++ b/examples/usage-as-lib.js
@@ -1,0 +1,24 @@
+const { runMigration } = require('../built/bin/cli');
+
+async function main (filePath) {
+  let statusCode = 0;
+
+  try {
+    await runMigration({
+      spaceId: process.env.CONTENTFUL_SPACE_ID,
+      accessToken: process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
+      environmentId: 'master',
+      yes: true,
+      filePath
+    });
+  } catch (e) {
+    statusCode = 1;
+    console.log('Catching Error');
+  } finally {
+    console.log('Cleaning Up');
+  }
+
+  process.exit(statusCode);
+}
+
+main(process.argv[2]);

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -15,6 +15,15 @@ import writeErrorsToLog from './lib/write-errors-to-log'
 import { RequestBatch } from '../lib/offline-api/index'
 import { ParseResult } from '../lib/migration-parser'
 import { getConfig } from './lib/config'
+import ValidationError from '../lib/interfaces/errors'
+
+class ManyError extends Error {
+  public errors: (Error | ValidationError)[]
+  constructor (message: string, errors: (Error | ValidationError)[]) {
+    super(message)
+    this.errors = errors
+  }
+}
 
 class BatchError extends Error {
   public batch: RequestBatch
@@ -25,8 +34,18 @@ class BatchError extends Error {
     this.errors = errors
   }
 }
-const run = async function (argv) {
+
+const makeTerminatingFunction = ({ shouldThrow }) => (error: Error) => {
+  if (shouldThrow) {
+    throw error
+  } else {
+    process.exit(1)
+  }
+}
+
+const createRun = ({ shouldThrow }) => async function run (argv) {
   let migrationFunction
+  const terminate = makeTerminatingFunction({ shouldThrow })
   try {
     migrationFunction = require(argv.filePath)
   } catch (e) {
@@ -60,20 +79,20 @@ const run = async function (argv) {
         chalk`🚨  {bold.red Migration unsuccessful}`
       ].join('\n')
       console.error(message)
-      process.exit(1)
+      terminate(new Error(message))
     }
     console.error(e)
-    process.exit(1)
+    terminate(e)
   }
 
   if (parseResult.hasStepsValidationErrors()) {
     renderStepsErrors(parseResult.stepsValidationErrors)
-    process.exit(1)
+    terminate(new ManyError('Step Validation Errors', parseResult.stepsValidationErrors))
   }
 
   if (parseResult.hasPayloadValidationErrors()) {
     renderStepsErrors(parseResult.payloadValidationErrors)
-    process.exit(1)
+    terminate(new ManyError('Payload Validation Errors', parseResult.payloadValidationErrors))
   }
 
   const migrationName = path.basename(argv.filePath, '.js')
@@ -86,13 +105,13 @@ const run = async function (argv) {
 
   if (parseResult.hasValidationErrors()) {
     renderValidationErrors(batches)
-    process.exit(1)
+    terminate(new ManyError('Validation Errors', parseResult.getValidationErrors()))
   }
 
   if (parseResult.hasRuntimeErrors()) {
     renderRuntimeErrors(batches, errorsFile)
     await writeErrorsToLog(parseResult.getRuntimeErrors(), errorsFile)
-    process.exit(1)
+    terminate(new ManyError('Runtime Errors', parseResult.getRuntimeErrors()))
   }
 
   await renderPlan(batches)
@@ -170,4 +189,5 @@ const run = async function (argv) {
   }
 }
 
-export default run
+export const runMigration = createRun({ shouldThrow: true })
+export default createRun({ shouldThrow: false })

--- a/src/lib/migration-parser.ts
+++ b/src/lib/migration-parser.ts
@@ -44,6 +44,12 @@ class ParseResult {
       return errors.concat(batch.runtimeErrors)
     }, [])
   }
+
+  getValidationErrors () {
+    return this.batches.reduce((errors, batch) => {
+      return errors.concat(batch.validationErrors)
+    }, [])
+  }
 }
 
 const createMigrationParser = function (makeRequest: Function, config: ClientConfig): (migrationCreator: (migration: any) => any) => Promise<ParseResult> {

--- a/test/end-to-end/assertions.js
+++ b/test/end-to-end/assertions.js
@@ -5,6 +5,11 @@ const { expect } = require('chai');
 
 module.exports = {
   errors: {
+    recovery: result => {
+      const withoutAnsiCodes = stripAnsi(result.stdout);
+      expect(withoutAnsiCodes).to.include('Catching Error');
+      expect(withoutAnsiCodes).to.include('Cleaning Up');
+    },
     field: {
       invalidPropertyWithSuggestion: function (invalid, valid) {
         return result => {

--- a/test/end-to-end/cli-as-lib.js
+++ b/test/end-to-end/cli-as-lib.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const nixt = require('nixt');
+
+const SPACE_ID = process.env.CONTENTFUL_INTEGRATION_SOURCE_SPACE;
+const ACCESS_TOKEN = process.env.CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN;
+const cli = () => {
+  return nixt()
+    .env('CONTENTFUL_SPACE_ID', SPACE_ID)
+    .env('CONTENTFUL_MANAGEMENT_ACCESS_TOKEN', ACCESS_TOKEN)
+    .base('node ./examples/usage-as-lib.js ')
+    .clone();
+};
+
+module.exports = cli;

--- a/test/end-to-end/error-recovery.spec.js
+++ b/test/end-to-end/error-recovery.spec.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const assert = require('./assertions');
+const cliAsLib = require('./cli-as-lib');
+
+describe('cli-as-lib', () => {
+  describe('04-steps-errors.js', function () {
+    it('should throw and allow for cleanup code to execute', function (done) {
+      this.timeout(10000);
+
+      cliAsLib()
+        .run(require.resolve(`../../examples/04-steps-errors.js`))
+        .expect(assert.errors.recovery)
+        .end(done);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When using the package as a library, it's a good idea to throw an error
instead of exiting with code 1. This way the user can recover from the
mistake somehow (e.g. deleting a throwaway environment on during continuous
integration).

This seems like it solves #111 too. 

## Description

- When using the `runMigration` export, make the function throw instead of process.exit(1).
- When using the `default` export, proceed as before by running process.exit(1) on errors. 

## Motivation and Context

I'm making continuous integration scripts that creates and deletes throwaway branches on CircleCI to test that the migration scripts are valid before they are merged. When the migration fails, I would like it to delete the newly created branch. This is currently impossible because this library will `process.exit(1)` for me. 

Actual run-migration code:
```js
async function main() {
  let statusCode = 0;
  try {
    await createEnvironment();
    await runMigrations();
  } catch (e) {
    console.error(e);
    statusCode = 1;
  } finally {
    await deleteEnvironment();
  }

  process.exit(statusCode);
}
```

Without this PR, the code above is unable to execute the `finally` block after errors.  

I'm open to feedback / suggestions on how to improve this.
