### PR TITLE
fix runMigration as lib should throw instead of swallowing errors

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -187,6 +187,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
       err.errors.forEach((err) => console.error(chalk`{red ${err}}\n\n`))
       await Promise.all(serverErrorsWritten)
       console.error(`Please check the errors log for more details: ${errorsFile}`)
+      terminate(err)
     }
   } else {
     console.warn(chalk`⚠️  {bold.yellow Migration aborted}`)


### PR DESCRIPTION
## Summary 
The run function swallows errors right now in a try catch block. When
used as a library with shouldThrow = true, this function should
rethrow the error so that the parent function knows that the process
was unsuccessful.

## Description
Add a simple `if (shouldThrow) throw err` at the bottom of the run
function.

## Motivation and Context
Our CI passes but the migration fails.