### PR TITLE
Fix vulnrerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "^5.2.0",
-    "nixt": "^0.5.0",
+    "nixt": "^0.5.1",
     "nock": "^9.4.2",
     "nyc": "^11.2.1",
     "rewire": "^2.5.2",


### PR DESCRIPTION
## Summary

[string.js](https://github.com/jprichardson/string.js/issues/212) which is a dependency of [nixt](https://github.com/vesln/nixt/pull/18) is vulnerable.
This PR fixes that.
Even though the vulnerable code is not used it's good to remove it.