### PR TITLE
feat(deriveEntry): n to n

### DIFF
--- a/examples/15-derive-entry-n-to-1.js
+++ b/examples/15-derive-entry-n-to-1.js
@@ -1,6 +1,7 @@
 // In this example, we want to turn the dog's owner field into its own entry
 // and link it back to the dog. To do this, we create an "owner"
 // content type and a link field on the "dog" content type.
+// The link field is a singular Entry link field. (See example 19 if you want to create an Array link field.)
 // In the identity function, we define the criterion for when a new owner should
 // be created: If the name joined by a hyphen is the same, then the same owner entry is
 // linked.

--- a/examples/19-derive-entry-n-to-n.js
+++ b/examples/19-derive-entry-n-to-n.js
@@ -1,0 +1,45 @@
+// In this example, we want to turn the dog's owner field into its own entry
+// and link it back to the dog. To do this, we create an "owner"
+// content type and a link field on the "dog" content type. The link field will be of
+// type 'Array', and the derived entry will be the first item in that Array field.
+// In the identity function, we define the criterion for when a new owner should
+// be created: If the name joined by a hyphen is the same, then the same owner entry is
+// linked.
+// In the deriveLinkedEntries function, we define what values should go into the new
+// owner entries. We don't create any values for the locale 'en-US' on the derived entries.
+
+module.exports = function (migration) {
+  const owner = migration.createContentType('owner').name('Owner').description('An owner of a dog');
+  owner.createField('firstName').type('Symbol').name('First Name');
+  owner.createField('lastName').type('Symbol').name('Last Name');
+  owner.displayField('firstName');
+
+  const dog = migration.editContentType('dog');
+  dog.createField('ownersRef').type('Array').items({type: 'Link'}).name('The Owner');
+
+  migration.deriveLinkedEntries({
+    contentType: 'dog',
+    derivedContentType: 'owner',
+    from: ['owner'],
+    toReferenceField: 'ownersRef',
+    derivedFields: ['firstName', 'lastName'],
+    identityKey: async (fromFields) => {
+      return fromFields.owner['en-US'].toLowerCase().replace(' ', '-');
+    },
+    shouldPublish: true,
+    deriveEntryForLocale: async (inputFields, locale) => {
+      if (locale !== 'en-US') {
+        return;
+      }
+      const [firstName, lastName] = inputFields.owner[locale].split(' ');
+
+      return {
+        firstName,
+        lastName
+      };
+    }
+  });
+
+  dog.deleteField('owner');
+  dog.changeFieldId('ownersRef', 'owners');
+};

--- a/examples/20-derive-entry-n-to-n.js
+++ b/examples/20-derive-entry-n-to-n.js
@@ -15,8 +15,7 @@ module.exports = function (migration) {
   owner.displayField('firstName');
 
   const dog = migration.editContentType('dog');
-  dog.createField('ownersRef').type('Array').items({type: 'Link'}).name('The Owner');
-
+  dog.createField('ownersRef').type('Array').items({type: 'Link', linkType: 'Entry'}).name('The Owner');
   migration.deriveLinkedEntries({
     contentType: 'dog',
     derivedContentType: 'owner',
@@ -24,6 +23,7 @@ module.exports = function (migration) {
     toReferenceField: 'ownersRef',
     derivedFields: ['firstName', 'lastName'],
     identityKey: async (fromFields) => {
+      debugger
       return fromFields.owner['en-US'].toLowerCase().replace(' ', '-');
     },
     shouldPublish: true,
@@ -41,5 +41,4 @@ module.exports = function (migration) {
   });
 
   dog.deleteField('owner');
-  dog.changeFieldId('ownersRef', 'owners');
 };

--- a/examples/20-derive-entry-n-to-n.js
+++ b/examples/20-derive-entry-n-to-n.js
@@ -15,7 +15,7 @@ module.exports = function (migration) {
   owner.displayField('firstName');
 
   const dog = migration.editContentType('dog');
-  dog.createField('ownersRef').type('Array').items({type: 'Link', linkType: 'Entry'}).name('The Owner');
+  dog.createField('ownersRef').type('Array').items({ type: 'Link', linkType: 'Entry' }).name('The Owner');
   migration.deriveLinkedEntries({
     contentType: 'dog',
     derivedContentType: 'owner',
@@ -23,7 +23,6 @@ module.exports = function (migration) {
     toReferenceField: 'ownersRef',
     derivedFields: ['firstName', 'lastName'],
     identityKey: async (fromFields) => {
-      debugger
       return fromFields.owner['en-US'].toLowerCase().replace(' ', '-');
     },
     shouldPublish: true,

--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -98,7 +98,7 @@ class EntryDeriveAction extends APIAction {
       const field = sourceContentType.fields.getField(this.referenceField)
       entry.setField(this.referenceField, {})
       for (const locale of locales) {
-        const sys =  {
+        const sys = {
           type: 'Link',
           linkType: 'Entry',
           id: newEntryId

--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -94,7 +94,7 @@ class EntryDeriveAction extends APIAction {
           await api.publishEntry(targetEntry.id)
         }
       }
-
+      debugger
       entry.setField(this.referenceField, {})
       for (const locale of locales) {
         entry.setFieldForLocale(this.referenceField, locale, {

--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -1,6 +1,7 @@
 import EntryDerive from '../interfaces/entry-derive'
 import { APIAction } from './action'
 import { OfflineAPI } from '../offline-api'
+import { ContentType } from '../entities/content-type'
 import Entry from '../entities/entry'
 import * as _ from 'lodash'
 
@@ -27,6 +28,7 @@ class EntryDeriveAction extends APIAction {
   async applyTo (api: OfflineAPI) {
     const entries: Entry[] = await api.getEntriesForContentType(this.contentTypeId)
     const locales: string[] = await api.getLocalesForSpace()
+    const sourceContentType: ContentType = await api.getContentType(this.contentTypeId)
 
     for (const entry of entries) {
       const inputs = _.pick(entry.fields, this.fromFields)
@@ -74,7 +76,6 @@ class EntryDeriveAction extends APIAction {
         // Usually you would not want to derive the contents again
         // But what if the previous round may not have been complete
         // for example one optional field was missing in the previous iteration
-
         const targetEntry = await api.createEntry(this.derivedContentType, newEntryId)
 
         // we are not skipping this source entry and the target entry does not yet exist,
@@ -95,15 +96,16 @@ class EntryDeriveAction extends APIAction {
         }
       }
       debugger
+      const field = sourceContentType.fields.getField(this.referenceField)
       entry.setField(this.referenceField, {})
       for (const locale of locales) {
-        entry.setFieldForLocale(this.referenceField, locale, {
-          sys: {
-            type: 'Link',
-            linkType: 'Entry',
-            id: newEntryId
-          }
-        })
+        const sys =  {
+          type: 'Link',
+          linkType: 'Entry',
+          id: newEntryId
+        }
+        const fieldValue = (field.type === 'Array') ? [{sys}] : {sys}
+        entry.setFieldForLocale(this.referenceField, locale, fieldValue)
       }
 
       await api.saveEntry(entry.id)

--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -95,7 +95,6 @@ class EntryDeriveAction extends APIAction {
           await api.publishEntry(targetEntry.id)
         }
       }
-      debugger
       const field = sourceContentType.fields.getField(this.referenceField)
       entry.setField(this.referenceField, {})
       for (const locale of locales) {

--- a/test/unit/lib/actions/entry-derive.spec.js
+++ b/test/unit/lib/actions/entry-derive.spec.js
@@ -8,8 +8,21 @@ import { Entry } from '../../../../src/lib/entities/entry'
 import makeApiEntry from '../../../helpers/make-api-entry'
 import ContentType from '../../../../src/lib/entities/content-type';
 
+const entries = [
+  new Entry(makeApiEntry({
+    id: '246',
+    contentTypeId: 'dog',
+    version: 1,
+    fields: {
+      owner: {
+        'en-US': 'john doe'
+      }
+    }
+  }))
+]
+
 describe.only('Entry Derive', function () {
-  it('derives an entry from n to 1', async function () {
+  it.only('derives an entry from n to 1', async function () {
     const action = new EntryDeriveAction('dog', {
       derivedContentType: 'owner',
       from: ['owner'],
@@ -24,7 +37,6 @@ describe.only('Entry Derive', function () {
           return
         }
         const [firstName, lastName] = inputFields.owner[locale].split(' ');
-
         return {
           firstName,
           lastName
@@ -32,44 +44,39 @@ describe.only('Entry Derive', function () {
       }
     })
 
-    const entries = [
-      new Entry(makeApiEntry({
-        id: '246',
-        contentTypeId: 'dog',
-        version: 1,
-        fields: {
-          owner: {
-            'en-US': 'john doe'
-          }
-        }
-      })),
-      new Entry(makeApiEntry({
-        id: '123',
-        contentTypeId: 'dog',
-        version: 1,
-        fields: {
-          owner: {
-            'en-US': 'johnny depp'
-          }
-        }
-      }))
-    ]
-    const api = new OfflineApi(new Map(), entries, ['en-US', 'de-DE'])
+    const contentTypes = new Map()
+    contentTypes.set('dog', new ContentType({
+        sys: {
+          id: 'dog'
+        },
+        fields: [{
+          name: 'ownerRef',
+          id: 'ownerRef',
+          type: 'Symbol'
+        }]
+      })
+    )
+
+    const api = new OfflineApi(contentTypes, entries, ['en-US'])
     api.startRecordingRequests(null)
 
     await action.applyTo(api)
     api.stopRecordingRequests()
     debugger
     const batches = await api.getRequestBatches()
-    //expect we create entry (send firstName and lastName fields)
-    //expect publish
-      //expect we update dog to link to new entry
-    expect(batches).to.eq(true)
+    expect(batches[0].requests.length).to.eq(4)
+    const createTargetEntryFields = batches[0].requests[0].data.fields
+    const updateEntryWithLinkFields = batches[0].requests[2].data.fields
+    expect(createTargetEntryFields.firstName['en-US']).to.eq('john') //target entry has first and last name
+    expect(createTargetEntryFields.lastName['en-US']).to.eq('doe')
+    expect(typeof updateEntryWithLinkFields.ownerRef['en-US'].sys).to.eq('object') //request to update entry is n to 1 link
+    expect(updateEntryWithLinkFields.ownerRef['en-US'].sys.type).to.eq('Link')
+    expect(updateEntryWithLinkFields.ownerRef['en-US'].sys.id).to.eq(batches[0].requests[0].data.sys.id) //id of linked object is same as id of target object
   })
 
-  it.only('derives an entry from n to n', async function () {
-    const cts = new Map()
-    cts.set('dog', new ContentType(
+  it('derives an entry from n to n', async function () {
+    const contentTypes = new Map()
+    contentTypes.set('dog', new ContentType(
       {
         sys: {
           id: 'dog'
@@ -118,19 +125,7 @@ describe.only('Entry Derive', function () {
       }
     })
 
-    const entries = [
-      new Entry(makeApiEntry({
-        id: '246',
-        contentTypeId: 'dog',
-        version: 1,
-        fields: {
-          owner: {
-            'en-US': 'john doe'
-          }
-        }
-      }))
-    ]
-    const api = new OfflineApi(cts, entries, ['en-US'])
+    const api = new OfflineApi(contentTypes, entries, ['en-US'])
     api.startRecordingRequests(null)
 
     await action.applyTo(api)

--- a/test/unit/lib/actions/entry-derive.spec.js
+++ b/test/unit/lib/actions/entry-derive.spec.js
@@ -4,10 +4,13 @@ import { expect } from 'chai'
 
 import { EntryDeriveAction } from '../../../../src/lib/action/entry-derive'
 import OfflineApi from '../../../../src/lib/offline-api/index'
+import { Entry } from '../../../../src/lib/entities/entry'
+import makeApiEntry from '../../../helpers/make-api-entry'
+import ContentType from '../../../../src/lib/entities/content-type';
 
 describe.only('Entry Derive', function () {
-  it('derives an entry from n to n', async function () {
-    const action = new EntryDeriveAction('ctid', {
+  it('derives an entry from n to 1', async function () {
+    const action = new EntryDeriveAction('dog', {
       derivedContentType: 'owner',
       from: ['owner'],
       toReferenceField: 'ownerRef',
@@ -29,13 +32,116 @@ describe.only('Entry Derive', function () {
       }
     })
 
-    const api = new OfflineApi(new Map(), [], ['en-US', 'de-DE'])
+    const entries = [
+      new Entry(makeApiEntry({
+        id: '246',
+        contentTypeId: 'dog',
+        version: 1,
+        fields: {
+          owner: {
+            'en-US': 'john doe'
+          }
+        }
+      })),
+      new Entry(makeApiEntry({
+        id: '123',
+        contentTypeId: 'dog',
+        version: 1,
+        fields: {
+          owner: {
+            'en-US': 'johnny depp'
+          }
+        }
+      }))
+    ]
+    const api = new OfflineApi(new Map(), entries, ['en-US', 'de-DE'])
     api.startRecordingRequests(null)
 
     await action.applyTo(api)
     api.stopRecordingRequests()
     debugger
     const batches = await api.getRequestBatches()
-    expect(true).to.eq(true)
+    //expect we create entry (send firstName and lastName fields)
+    //expect publish
+      //expect we update dog to link to new entry
+    expect(batches).to.eq(true)
+  })
+
+  it.only('derives an entry from n to n', async function () {
+    const cts = new Map()
+    cts.set('dog', new ContentType(
+      {
+        sys: {
+          id: 'dog'
+        },
+      name: 'dog content type',
+      fields: [{
+        name: 'owners',
+        id: 'owners',
+        type: 'Array',
+        items: {
+          type: 'Link',
+          linkType: 'Entry'
+        }
+      },
+      {
+        id: 'owner',
+        name: 'owner',
+        type: 'Symbol',
+        localized: true
+      },
+      {
+        name: 'age',
+        type: 'Number'
+      }
+    ]
+    }))
+    const action = new EntryDeriveAction('dog', {
+      derivedContentType: 'owner',
+      from: ['owner'],
+      toReferenceField: 'owners',
+      derivedFields: ['firstName', 'lastName'],
+      identityKey: async (fromFields) => {
+        return fromFields.owner['en-US'].toLowerCase().replace(' ', '-');
+      },
+      shouldPublish: true,
+      deriveEntryForLocale: async (inputFields, locale) => {
+        if (locale !== 'en-US') {
+          return
+        }
+        const [firstName, lastName] = inputFields.owner[locale].split(' ');
+
+        return {
+          firstName,
+          lastName
+        }
+      }
+    })
+
+    const entries = [
+      new Entry(makeApiEntry({
+        id: '246',
+        contentTypeId: 'dog',
+        version: 1,
+        fields: {
+          owner: {
+            'en-US': 'john doe'
+          }
+        }
+      }))
+    ]
+    const api = new OfflineApi(cts, entries, ['en-US'])
+    api.startRecordingRequests(null)
+
+    await action.applyTo(api)
+    api.stopRecordingRequests()
+    debugger
+    const batches = await api.getRequestBatches()
+    //expect we create entry (send firstName and lastName fields)
+    //expect publish
+    //expect we update dog to link to new entry
+    expect(batches).to.eq(true)
   })
 })
+
+//add example migration for n to n

--- a/test/unit/lib/actions/entry-derive.spec.js
+++ b/test/unit/lib/actions/entry-derive.spec.js
@@ -1,0 +1,41 @@
+'use strict'
+
+import { expect } from 'chai'
+
+import { EntryDeriveAction } from '../../../../src/lib/action/entry-derive'
+import OfflineApi from '../../../../src/lib/offline-api/index'
+
+describe.only('Entry Derive', function () {
+  it('derives an entry from n to n', async function () {
+    const action = new EntryDeriveAction('ctid', {
+      derivedContentType: 'owner',
+      from: ['owner'],
+      toReferenceField: 'ownerRef',
+      derivedFields: ['firstName', 'lastName'],
+      identityKey: async (fromFields) => {
+        return fromFields.owner['en-US'].toLowerCase().replace(' ', '-');
+      },
+      shouldPublish: true,
+      deriveEntryForLocale: async (inputFields, locale) => {
+        if (locale !== 'en-US') {
+          return
+        }
+        const [firstName, lastName] = inputFields.owner[locale].split(' ');
+
+        return {
+          firstName,
+          lastName
+        }
+      }
+    })
+
+    const api = new OfflineApi(new Map(), [], ['en-US', 'de-DE'])
+    api.startRecordingRequests(null)
+
+    await action.applyTo(api)
+    api.stopRecordingRequests()
+    debugger
+    const batches = await api.getRequestBatches()
+    expect(true).to.eq(true)
+  })
+})

--- a/test/unit/lib/actions/entry-derive.spec.js
+++ b/test/unit/lib/actions/entry-derive.spec.js
@@ -1,11 +1,11 @@
-'use strict'
+'use strict';
 
-import { expect } from 'chai'
+import { expect } from 'chai';
 
-import { EntryDeriveAction } from '../../../../src/lib/action/entry-derive'
-import OfflineApi from '../../../../src/lib/offline-api/index'
-import { Entry } from '../../../../src/lib/entities/entry'
-import makeApiEntry from '../../../helpers/make-api-entry'
+import { EntryDeriveAction } from '../../../../src/lib/action/entry-derive';
+import OfflineApi from '../../../../src/lib/offline-api/index';
+import { Entry } from '../../../../src/lib/entities/entry';
+import makeApiEntry from '../../../helpers/make-api-entry';
 import ContentType from '../../../../src/lib/entities/content-type';
 
 describe('Entry Derive', function () {
@@ -21,28 +21,28 @@ describe('Entry Derive', function () {
       shouldPublish: true,
       deriveEntryForLocale: async (inputFields, locale) => {
         if (locale !== 'en-US') {
-          return
+          return;
         }
         const [firstName, lastName] = inputFields.owner[locale].split(' ');
         return {
           firstName,
           lastName
-        }
+        };
       }
-    })
+    });
 
-    const contentTypes = new Map()
+    const contentTypes = new Map();
     contentTypes.set('dog', new ContentType({
-        sys: {
-          id: 'dog'
-        },
-        fields: [{
-          name: 'ownerRef',
-          id: 'ownerRef',
-          type: 'Symbol'
-        }]
-      })
-    )
+      sys: {
+        id: 'dog'
+      },
+      fields: [{
+        name: 'ownerRef',
+        id: 'ownerRef',
+        type: 'Symbol'
+      }]
+    })
+    );
 
     const entries = [
       new Entry(makeApiEntry({
@@ -55,22 +55,22 @@ describe('Entry Derive', function () {
           }
         }
       }))
-    ]
+    ];
 
-    const api = new OfflineApi(contentTypes, entries, ['en-US'])
-    api.startRecordingRequests(null)
-    await action.applyTo(api)
-    api.stopRecordingRequests()
-    const batches = await api.getRequestBatches()
-    expect(batches[0].requests.length).to.eq(4)
-    const createTargetEntryFields = batches[0].requests[0].data.fields
-    const updateEntryWithLinkFields = batches[0].requests[2].data.fields
-    expect(createTargetEntryFields.firstName['en-US']).to.eq('john') //target entry has first and last name
-    expect(createTargetEntryFields.lastName['en-US']).to.eq('doe')
-    expect(typeof updateEntryWithLinkFields.ownerRef['en-US'].sys).to.eq('object') //request to update entry is n to 1 link
-    expect(updateEntryWithLinkFields.ownerRef['en-US'].sys.type).to.eq('Link')
-    expect(updateEntryWithLinkFields.ownerRef['en-US'].sys.id).to.eq(batches[0].requests[0].data.sys.id) //id of linked object is same as id of target object
-  })
+    const api = new OfflineApi(contentTypes, entries, ['en-US']);
+    api.startRecordingRequests(null);
+    await action.applyTo(api);
+    api.stopRecordingRequests();
+    const batches = await api.getRequestBatches();
+    expect(batches[0].requests.length).to.eq(4);
+    const createTargetEntryFields = batches[0].requests[0].data.fields;
+    const updateEntryWithLinkFields = batches[0].requests[2].data.fields;
+    expect(createTargetEntryFields.firstName['en-US']).to.eq('john'); // target entry has first and last name
+    expect(createTargetEntryFields.lastName['en-US']).to.eq('doe');
+    expect(typeof updateEntryWithLinkFields.ownerRef['en-US'].sys).to.eq('object'); // request to update entry is n to 1 link
+    expect(updateEntryWithLinkFields.ownerRef['en-US'].sys.type).to.eq('Link');
+    expect(updateEntryWithLinkFields.ownerRef['en-US'].sys.id).to.eq(batches[0].requests[0].data.sys.id); // id of linked object is same as id of target object
+  });
 
   it('derives an entry from n to n', async function () {
     const action = new EntryDeriveAction('dog', {
@@ -84,41 +84,41 @@ describe('Entry Derive', function () {
       shouldPublish: true,
       deriveEntryForLocale: async (inputFields, locale) => {
         if (locale !== 'en-US') {
-          return
+          return;
         }
         const [firstName, lastName] = inputFields.owner[locale].split(' ');
 
         return {
           firstName,
           lastName
-        }
+        };
       }
-    })
+    });
 
-    const contentTypes = new Map()
+    const contentTypes = new Map();
     contentTypes.set('dog', new ContentType(
       {
         sys: {
           id: 'dog'
         },
-      name: 'dog content type',
-      fields: [{
-        name: 'owners',
-        id: 'owners',
-        type: 'Array',
-        items: {
-          type: 'Link',
-          linkType: 'Entry'
+        name: 'dog content type',
+        fields: [{
+          name: 'owners',
+          id: 'owners',
+          type: 'Array',
+          items: {
+            type: 'Link',
+            linkType: 'Entry'
+          }
+        },
+        {
+          id: 'owner',
+          name: 'owner',
+          type: 'Symbol',
+          localized: true
         }
-      },
-      {
-        id: 'owner',
-        name: 'owner',
-        type: 'Symbol',
-        localized: true
-      }
-    ]
-    }))
+        ]
+      }));
 
     const entries = [
       new Entry(makeApiEntry({
@@ -131,21 +131,21 @@ describe('Entry Derive', function () {
           }
         }
       }))
-    ]
+    ];
 
-    const api = new OfflineApi(contentTypes, entries, ['en-US'])
-    api.startRecordingRequests(null)
-    await action.applyTo(api)
-    api.stopRecordingRequests()
-    const batches = await api.getRequestBatches()
-    debugger
-    expect(batches[0].requests.length).to.eq(4)
-    const createTargetEntryFields = batches[0].requests[0].data.fields
-    const updateEntryWithLinkFields = batches[0].requests[2].data.fields
-    expect(createTargetEntryFields.firstName['en-US']).to.eq('johnny') //target entry has first and last name
-    expect(createTargetEntryFields.lastName['en-US']).to.eq('depp')
-    expect(typeof updateEntryWithLinkFields.owners['en-US'][0].sys).to.eq('object') //request to update entry is n to n link
-    expect(updateEntryWithLinkFields.owners['en-US'][0].sys.type).to.eq('Link')
-    expect(updateEntryWithLinkFields.owners['en-US'][0].sys.id).to.eq(batches[0].requests[0].data.sys.id) //id of linked object is same as id of target object
-  })
-})
+    const api = new OfflineApi(contentTypes, entries, ['en-US']);
+    api.startRecordingRequests(null);
+    await action.applyTo(api);
+    api.stopRecordingRequests();
+    const batches = await api.getRequestBatches();
+
+    expect(batches[0].requests.length).to.eq(4);
+    const createTargetEntryFields = batches[0].requests[0].data.fields;
+    const updateEntryWithLinkFields = batches[0].requests[2].data.fields;
+    expect(createTargetEntryFields.firstName['en-US']).to.eq('johnny'); // target entry has first and last name
+    expect(createTargetEntryFields.lastName['en-US']).to.eq('depp');
+    expect(typeof updateEntryWithLinkFields.owners['en-US'][0].sys).to.eq('object'); // request to update entry is n to n link
+    expect(updateEntryWithLinkFields.owners['en-US'][0].sys.type).to.eq('Link');
+    expect(updateEntryWithLinkFields.owners['en-US'][0].sys.id).to.eq(batches[0].requests[0].data.sys.id); // id of linked object is same as id of target object
+  });
+});


### PR DESCRIPTION
fixes #127 
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

When the reference field for a deriveEntry migration is an array of linked entries, the derived entry now becomes the first item in an array. (Previously, the derived entry was linked as a single entry, ignoring the type of the reference field). Also add a new example showing this behavior.
