### PR TITLE
Respect shouldPublish flag when set to false

### DIFF
--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -2,6 +2,8 @@ import EntryDerive from '../interfaces/entry-derive'
 import { APIAction } from './action'
 import { OfflineAPI } from '../offline-api'
 import { ContentType } from '../entities/content-type'
+import isDefined from '../utils/is-defined'
+
 import Entry from '../entities/entry'
 import * as _ from 'lodash'
 
@@ -22,7 +24,7 @@ class EntryDeriveAction extends APIAction {
     this.derivedContentType = entryDerivation.derivedContentType
     this.deriveEntryForLocale = entryDerivation.deriveEntryForLocale
     this.identityKey = entryDerivation.identityKey
-    this.shouldPublish = entryDerivation.shouldPublish || true
+    this.shouldPublish = isDefined(entryDerivation.shouldPublish) ? entryDerivation.shouldPublish : true
   }
 
   async applyTo (api: OfflineAPI) {

--- a/src/lib/entities/entry.ts
+++ b/src/lib/entities/entry.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash'
 import APIEntry from '../interfaces/api-entry'
-import { isNullOrUndefined } from 'util'
+import isDefined from '../utils/is-defined'
 
 class Entry {
   private _id: string
@@ -64,7 +64,7 @@ class Entry {
   }
 
   get isPublished () {
-    return !isNullOrUndefined(this._publishedVersion)
+    return isDefined(this._publishedVersion)
   }
 
   get publishedVersion () {

--- a/src/lib/utils/is-defined.ts
+++ b/src/lib/utils/is-defined.ts
@@ -1,0 +1,3 @@
+export default function isDefined<T> (value: T | undefined | null): value is T {
+  return value !== undefined && value !== null
+}


### PR DESCRIPTION
Fixes https://github.com/contentful/contentful-migration/issues/156

The problem is that we always defaulted it back to `true` when any falsy value was passed.
I also removed use of `util/isNullOrUndefined` because it is deprecated since Node 4.