### PR TITLE
Enable linting for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 script:
   - npm run lint
+  - npm run build-dev
   - npm run coverage-report
 
 cache:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "clean": "rimraf built",
-    "build": "npm run clean && tsc -p .",
+    "build": "npm run clean && tsc -p tsconfig.json",
+    "build-dev": "npm run clean && tsc -p tsconfig-dev.json",
     "prepare": "npm run build",
     "test": "NOCK_RECORD=0 npm run build && npm run test-unit && npm run test-integration && npm run test-e2e && npm run lint",
     "test-watch": "npm run test-unit -- --watch",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cover": "nyc --no-clean -s npm run test-unit && nyc --no-clean -s npm run test-integration && nyc --no-clean -s npm run test-e2e && nyc report",
     "coverage": "npm run build && npm run cover && nyc report --reporter=text-lcov > coverage.lcov",
     "coverage-report": "npm run coverage && codecov && rm -rf ./nyc_output && rm coverage.lcov",
-    "lint": "eslint 'examples/**/*.js' 'test/**/*.js' 'src/**/*.js' && tslint --project tsconfig.json --config tslint.json",
+    "lint": "eslint 'examples/**/*.js' 'test/**/*.js' 'src/**/*.js' && tslint --project tsconfig-dev.json --config tslint.json",
     "semantic-release": "semantic-release",
     "travis-deploy-once": "travis-deploy-once"
   },

--- a/test/unit/bin/lib/config.spec.ts
+++ b/test/unit/bin/lib/config.spec.ts
@@ -5,15 +5,15 @@ import { getConfig } from '../../../../src/bin/lib/config'
 
 const fileConfig = {
   cmaToken: process.env.CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN
-};
+}
 
 describe('Config', function () {
   beforeEach(function () {
-    writeFileSync(resolve('/tmp', '.contentfulrc.json'), JSON.stringify(fileConfig));
-  });
+    writeFileSync(resolve('/tmp', '.contentfulrc.json'), JSON.stringify(fileConfig))
+  })
 
   it('reads the contentfulrc.json', async function () {
-    const config = getConfig({});
+    const config = getConfig({})
     expect(config.accessToken).to.eql(process.env.CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN)
   })
 
@@ -21,13 +21,13 @@ describe('Config', function () {
     const token = process.env.CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN
 
     process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN = 'schnitzel'
-    const config = getConfig({});
+    const config = getConfig({})
     expect(config.accessToken).to.eql('schnitzel')
     process.env.CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN = token
   })
 
   it('prefers handed in config over env config', async function () {
-    const config = getConfig({accessToken: 'fooMyBar'});
+    const config = getConfig({accessToken: 'fooMyBar'})
     expect(config.accessToken).to.eql('fooMyBar')
   })
 })

--- a/test/unit/lib/actions/entry-transform.spec.ts
+++ b/test/unit/lib/actions/entry-transform.spec.ts
@@ -38,11 +38,11 @@ describe('Entry Action', function () {
       }))
     ]
     const api = new OfflineApi(new Map(), entries, ['en-US'])
-    api.startRecordingRequests(null)
+    await api.startRecordingRequests(null)
 
     try {
       await action.applyTo(api)
-      api.stopRecordingRequests()
+      await api.stopRecordingRequests()
       const batches = await api.getRequestBatches()
       expect(batches[0].runtimeErrors).to.eql([ourError, ourError])
     } catch (err) {
@@ -86,10 +86,10 @@ describe('Entry Action', function () {
       }))
     ]
     const api = new OfflineApi(new Map(), entries, ['en-US', 'hawaii'])
-    api.startRecordingRequests(null)
+    await api.startRecordingRequests(null)
 
     await action.applyTo(api)
-    api.stopRecordingRequests()
+    await api.stopRecordingRequests()
     const batches = await api.getRequestBatches()
     expect(batches[0].requests[0].data.fields).to.eql({
       name: {
@@ -136,10 +136,10 @@ describe('Entry Action', function () {
       }))
     ]
     const api = new OfflineApi(new Map(), entries, ['en-US', 'hawaii'])
-    api.startRecordingRequests(null)
+    await api.startRecordingRequests(null)
 
     await action.applyTo(api)
-    api.stopRecordingRequests()
+    await api.stopRecordingRequests()
     const batches = await api.getRequestBatches()
     expect(batches[0].requests).to.eql([])
   })

--- a/test/unit/lib/content-types-in-chunks.spec.ts
+++ b/test/unit/lib/content-types-in-chunks.spec.ts
@@ -7,6 +7,8 @@ import {migration as migrationSteps } from '../../../src/lib/migration-steps'
 import IntentList from '../../../src/lib/intent-list'
 import Fetcher from '../../../src/lib/fetcher'
 
+const noOp = () => undefined
+
 describe('Content Type fetcher', function () {
   it('fetches all the Content Types in the plan', async function () {
     const intents = await migrationSteps(function up (migration) {
@@ -32,7 +34,7 @@ describe('Content Type fetcher', function () {
 
       migration.deleteContentType('dog')
       migration.deleteContentType('plant')
-    }, () => {}, {})
+    }, noOp, {})
 
     const request = sinon.stub()
 

--- a/test/unit/lib/deleted-ct-entries.spec.ts
+++ b/test/unit/lib/deleted-ct-entries.spec.ts
@@ -7,12 +7,14 @@ import makeApiContentType from '../../helpers/make-api-content-type'
 import { ContentType } from '../../../src/lib/entities/content-type'
 import { expect } from 'chai'
 
+const noOp = () => undefined
+
 describe('Entries fetcher', function () {
   it('adds entries info to content types', async function () {
     const intents = await migrationSteps(function up (migration) {
       migration.deleteContentType('foo')
       migration.deleteContentType('bar')
-    }, () => {}, {})
+    }, noOp, {})
 
     const request = sinon.stub()
     request

--- a/test/unit/lib/fetcher.spec.ts
+++ b/test/unit/lib/fetcher.spec.ts
@@ -7,6 +7,8 @@ import Fetcher from '../../../src/lib/fetcher'
 import { ContentType } from '../../../src/lib/entities/content-type'
 import { APIEditorInterfaces } from '../../../src/lib/interfaces/content-type'
 
+const noOp = () => undefined
+
 describe('Fetcher', function () {
   it('fetches all required Entries in the plan', async function () {
     const intents = await buildIntents(function up (migration) {
@@ -70,7 +72,7 @@ describe('Fetcher', function () {
     const intents = await buildIntents(function up (migration) {
       migration.deleteContentType('foo')
       migration.deleteContentType('bar')
-    }, () => {}, {})
+    }, noOp, {})
 
     const request = sinon.stub()
     request
@@ -149,7 +151,7 @@ describe('Fetcher', function () {
 
       migration.deleteContentType('dog')
       migration.deleteContentType('plant')
-    }, () => {}, {})
+    }, noOp, {})
 
     const request = sinon.stub()
 
@@ -250,7 +252,7 @@ describe('Fetcher', function () {
           }
         }
       })
-    }, () => {}, {})
+    }, noOp, {})
 
     const request = sinon.stub()
 
@@ -304,7 +306,7 @@ describe('Fetcher', function () {
       foo.changeEditorInterface('title', 'singleLine')
       const bar = migration.editContentType('bar')
       bar.changeEditorInterface('desc', 'markdown')
-    }, () => {}, {})
+    }, noOp, {})
 
     const request = sinon.stub()
     request

--- a/test/unit/lib/intent-list/intent-list.spec.ts
+++ b/test/unit/lib/intent-list/intent-list.spec.ts
@@ -3,6 +3,8 @@ import { expect } from 'chai'
 import IntentList from '../../../../src/lib/intent-list/index'
 import { migration as parseIntoIntents } from '../../../../src/lib/migration-steps/index'
 
+const noOp = () => undefined
+
 describe('Intent List', function () {
   it('initializes correctly', async function () {
     const intents = await parseIntoIntents(function up (migration) {
@@ -34,7 +36,7 @@ describe('Intent List', function () {
       address.createField('houseExtension', {
         type: 'Symbol'
       })
-    }, () => {}, {})
+    }, noOp, {})
     const intentList = new IntentList(intents)
     expect(intentList.getIntents().length).to.equal(15)
   })
@@ -57,7 +59,7 @@ describe('Intent List', function () {
 
       person.editField('fullName').localized(true)
       fullName.required(true)
-    }, () => {}, {})
+    }, noOp, {})
 
     const intentList = new IntentList(intents)
     const compressedList = intentList.compressed()

--- a/test/unit/lib/intent-validator/updates.spec.ts
+++ b/test/unit/lib/intent-validator/updates.spec.ts
@@ -109,7 +109,7 @@ describe('migration-steps validation', function () {
 
   describe('when passing the wrong type for a prop', function () {
     it('returns all the validation errors', async function () {
-      const invalidFunction = function () {}
+      const invalidFunction = function () { return undefined }
       const validationErrors = await validateSteps(function up (migration) {
         const person = migration.createContentType('person', {
           description: ['Array']

--- a/test/unit/lib/intent-validator/validate-steps.ts
+++ b/test/unit/lib/intent-validator/validate-steps.ts
@@ -3,6 +3,8 @@
 import { migration as createSteps } from '../../../../src/lib/migration-steps'
 import IntentList from '../../../../src/lib/intent-list'
 
+const noOp = () => undefined
+
 const stripCallsites = (errors) => {
   return errors.map((error) => {
     delete error.details.intent.package
@@ -15,7 +17,7 @@ const stripCallsites = (errors) => {
 
 export default function createValidator (validators) {
   return async function (migration) {
-    const steps = await createSteps(migration, () => {}, {})
+    const steps = await createSteps(migration, noOp, {})
 
     const stepList = new IntentList(steps)
 

--- a/test/unit/lib/intent/composed-intent.spec.ts
+++ b/test/unit/lib/intent/composed-intent.spec.ts
@@ -5,8 +5,10 @@ import { expect } from 'chai'
 import { PlanMessage } from '../../../../src/lib/interfaces/plan-message'
 import chalk from 'chalk'
 
+const noOp = () => undefined
+
 const composedIntent = async function (migration): Promise<ComposedIntent> {
-  const intents = await migrationSteps(migration, () => {}, {})
+  const intents = await migrationSteps(migration, noOp, {})
   const list = new IntentList(intents)
 
   return list.compressed().getIntents()[0] as ComposedIntent

--- a/test/unit/lib/intent/editorinterface-copy.spec.ts
+++ b/test/unit/lib/intent/editorinterface-copy.spec.ts
@@ -5,8 +5,10 @@ import IntentList from '../../../../src/lib/intent-list'
 import { Intent } from '../../../../src/lib/interfaces/intent'
 import chalk from 'chalk'
 
+const noOp = () => undefined
+
 const composedIntent = async function (migration): Promise<Intent[]> {
-  const intents = await migrationSteps(migration, () => {}, {})
+  const intents = await migrationSteps(migration, noOp, {})
   const list = new IntentList(intents)
 
   return list.compressed().getIntents()

--- a/test/unit/lib/intent/editorinterface-copy.spec.ts
+++ b/test/unit/lib/intent/editorinterface-copy.spec.ts
@@ -33,4 +33,3 @@ describe('EditorInterfaceCopyIntent', function () {
     })
   })
 })
-

--- a/test/unit/lib/intent/editorinterface-reset.spec.ts
+++ b/test/unit/lib/intent/editorinterface-reset.spec.ts
@@ -5,8 +5,10 @@ import IntentList from '../../../../src/lib/intent-list'
 import { Intent } from '../../../../src/lib/interfaces/intent'
 import chalk from 'chalk'
 
+const noOp = () => undefined
+
 const composedIntent = async function (migration): Promise<Intent[]> {
-  const intents = await migrationSteps(migration, () => {}, {})
+  const intents = await migrationSteps(migration, noOp, {})
   const list = new IntentList(intents)
 
   return list.compressed().getIntents()

--- a/test/unit/lib/intent/editorinterface-reset.spec.ts
+++ b/test/unit/lib/intent/editorinterface-reset.spec.ts
@@ -33,4 +33,3 @@ describe('EditorInterfaceResetIntent', function () {
     })
   })
 })
-

--- a/test/unit/lib/intent/editorinterface-update.spec.ts
+++ b/test/unit/lib/intent/editorinterface-update.spec.ts
@@ -5,8 +5,10 @@ import { PlanMessage } from '../../../../src/lib/interfaces/plan-message'
 import IntentList from '../../../../src/lib/intent-list'
 import { Intent } from '../../../../src/lib/interfaces/intent'
 
+const noOp = () => undefined
+
 const composedIntent = async function (migration): Promise<Intent[]> {
-  const intents = await migrationSteps(migration, () => {}, {})
+  const intents = await migrationSteps(migration, noOp, {})
   const list = new IntentList(intents)
 
   return list.compressed().getIntents()

--- a/test/unit/lib/migration-chunks/validation/validate-chunks.ts
+++ b/test/unit/lib/migration-chunks/validation/validate-chunks.ts
@@ -3,6 +3,8 @@ import IntentList from '../../../../../src/lib/intent-list'
 import validate from '../../../../../src/lib/migration-chunks/validation'
 import { ContentType } from '../../../../../src/lib/entities/content-type'
 
+const noOp = () => undefined
+
 const stripCallsites = (errors) => {
   return errors.map((error) => {
     delete error.details.intent.package
@@ -14,7 +16,7 @@ const stripCallsites = (errors) => {
 }
 
 const validateChunks = async function (migration, testCts: any[]) {
-  const intents = await migrationSteps(migration, () => {}, {})
+  const intents = await migrationSteps(migration, noOp, {})
   const list = new IntentList(intents)
 
   const existingCts: ContentType[] = testCts.map((ct) => {

--- a/test/unit/lib/offline-api/build-payloads.ts
+++ b/test/unit/lib/offline-api/build-payloads.ts
@@ -4,8 +4,10 @@ import { ContentType, EditorInterfaces } from '../../../../src/lib/entities/cont
 import { OfflineAPI } from '../../../../src/lib/offline-api/index'
 import { migration } from '../../../../src/lib/migration-steps'
 
+const noOp = () => undefined
+
 const buildPayloads = async function (runMigration, contentTypes: APIContentType[]) {
-  const intents = await migration(runMigration, () => {}, {})
+  const intents = await migration(runMigration, noOp, {})
   const list = new IntentList(intents)
 
   const existingCTs: Map<String, ContentType> = new Map()

--- a/test/unit/lib/offline-api/validation/validate-batches.ts
+++ b/test/unit/lib/offline-api/validation/validate-batches.ts
@@ -3,8 +3,10 @@ import { ContentType } from '../../../../../src/lib/entities/content-type'
 import { OfflineAPI } from '../../../../../src/lib/offline-api/index'
 import { migration } from '../../../../../src/lib/migration-steps'
 
+const noOp = () => undefined
+
 const validateBatches = async function (runMigration, contentTypes) {
-  const intents = await migration(runMigration, () => {}, {})
+  const intents = await migration(runMigration, noOp, {})
   const list = new IntentList(intents)
 
   const existingCTs: Map<String, ContentType> = new Map()

--- a/tsconfig-dev.json
+++ b/tsconfig-dev.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "outDir": "./built",
+    "allowJs": true,
+    "target": "es2017",
+    "module": "commonjs",
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "esnext"
+    ],
+    "sourceMap": true,
+    "typeRoots": [
+      "./typings",
+      "./node_modules/@types"
+    ],
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": [
+    "./src/**/*",
+    "./test/**/*"
+  ]
+}


### PR DESCRIPTION
Previously we were skipping the tests when linting typescript files.  
Now we always build and lint the test folders as well during the CI test run.