### PR TITLE
fix: fetch entries of all CTs when required by an intent

### DIFF
--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -27,8 +27,14 @@ export default class Fetcher implements APIFetcher {
     }
 
     const filter = {
-      'sys.contentType.sys.id[in]': ids.join(','),
       'sys.archivedAt[exists]': 'false'
+    }
+
+    // If we want to load all entries, we do not need to add the filter specification
+    // that loads just the entries for related content types
+    // If we do, then we specify the list of CTs that we want entries for
+    if (!loadAllEntries) {
+      filter['sys.contentType.sys.id[in]'] = ids.join(',')
     }
 
     const entries = await this.fetchAllPaginatedItems<APIEntry>('/entries', filter)

--- a/test/unit/lib/migration-parser.spec.ts
+++ b/test/unit/lib/migration-parser.spec.ts
@@ -25,7 +25,7 @@ describe('Migration parser', function () {
           }
         }
 
-        if (config.url.indexOf('/entries?sys.contentType.sys.id[in]=foo,cat&sys.archivedAt[exists]=false&skip=0') !== -1) {
+        if (config.url.indexOf('/entries?sys.archivedAt[exists]=false&sys.contentType.sys.id[in]=foo,cat&skip=0') !== -1) {
           return {
             total: 2,
             skip: 0,
@@ -130,7 +130,7 @@ describe('Migration parser', function () {
           }
         }
 
-        if (config.url === '/entries?sys.contentType.sys.id[in]=foo&sys.archivedAt[exists]=false&skip=0') {
+        if (config.url === '/entries?sys.archivedAt[exists]=false&sys.contentType.sys.id[in]=foo&skip=0') {
           return {
             total: 2,
             skip: 0,


### PR DESCRIPTION
When an intent returns `true` for `requiresAllEntries` we need to skip the content type scoping of entries we fetch, and fetch all existing entries out there.

This was accidentally broken during https://github.com/contentful/contentful-migration/pull/160
Now it is covered by unit tests too so we hopefully can avoid this regression in the future.