### PR TITLE
fix ContentTransformIntentValidator

### DIFF
--- a/src/lib/intent-validator/content-transform.ts
+++ b/src/lib/intent-validator/content-transform.ts
@@ -23,7 +23,7 @@ class ContentTransformIntentValidator extends SchemaValidator {
       from: Joi.array().items(Joi.string()).required(),
       to: Joi.array().items(Joi.string()).required(),
       transformEntryForLocale: Joi.func().required(),
-      shouldPublish: Joi.boolean()
+      shouldPublish: Joi.alternatives().try(Joi.boolean(), Joi.string().valid('preserve'))
     }
   }
 }

--- a/test/unit/lib/intent-validator/content-transform.spec.ts
+++ b/test/unit/lib/intent-validator/content-transform.spec.ts
@@ -157,7 +157,7 @@ describe('Content transformation', function () {
                 type: 'contentType/transformEntries'
               }
             },
-            message: '"undefined" is not a valid type for the content transformation property "shouldPublish". Expected "alternatives".',
+            message: '"yes please" is not a valid value for the content transformation property "shouldPublish". Expected type boolean or string value "preserve".',
             type: 'InvalidType'
           }
         ])

--- a/test/unit/lib/intent-validator/content-transform.spec.ts
+++ b/test/unit/lib/intent-validator/content-transform.spec.ts
@@ -157,7 +157,7 @@ describe('Content transformation', function () {
                 type: 'contentType/transformEntries'
               }
             },
-            message: '"string" is not a valid type for the content transformation property "shouldPublish". Expected "boolean".',
+            message: '"undefined" is not a valid type for the content transformation property "shouldPublish". Expected "alternatives".',
             type: 'InvalidType'
           }
         ])


### PR DESCRIPTION
## Summary

shouldPublish should accept 'preserve' in addition to boolean values

## Description

Add 'preserve' as a valid option to validations for shouldPublish field

## Motivation and Context

https://github.com/contentful/contentful-migration/pull/143#issuecomment-451451263
