### PR TITLE
Make typings compatible with strict typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 import * as axios from '@contentful/axios'
 
 export interface Movement {
-  toTheTop()
-  toTheBottom()
-  beforeField(field: string)
-  afterField(field: string)
+  toTheTop(): void
+  toTheBottom(): void
+  beforeField(field: string): void
+  afterField(field: string): void
 }
 
 type FieldType = 'Symbol' | 'Text' | 'Integer' | 'Number' | 'Date' | 'Boolean' | 'Object' | 'Location' | 'RichText' | 'Array' | 'Link'


### PR DESCRIPTION
Before, TypeScript projects using the `strict` compiler settings were unable to compile when `contentful-migration` was imported. The following error was displayed

    error TS7010: 'toTheTop', which lacks return-type annotation, implicitly has an 'any' return type.
