### PR TITLE
add `unpublish` to `shouldPublish` option of `transformEntry` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The transform function is expected to return an object with the desired target f
     - `fields` is an object containing each of the `from` fields. Each field will contain their current localized values (i.e. `from == {myField: {'en-US': 'my field value'}}`)
     - `locale` one of the locales in the space being transformed
   The return value must be an object with the same keys as specified in `to`. Their values will be written to the respective entry fields for the current locale (i.e. `{nameField: 'myNewValue'}`). If it returns `undefined`, this the values for this locale on the entry will be left untouched.
-- **`shouldPublish : boolean`** _(optional)_ – If `true`, the transformed entries will be published. If `false`, both will remain in draft state (default `true`)
+- **`shouldPublish : boolean | 'unpublish'`** _(optional)_ – If `true`, the transformed entries will be published. If `false`, both will remain in updated state, and if `unpublish`, they will be unpublished to a draft state (default `true`)
 
 ##### `transformEntries` Example
 

--- a/src/lib/action/entry-transform.ts
+++ b/src/lib/action/entry-transform.ts
@@ -7,7 +7,7 @@ class EntryTransformAction extends APIAction {
   private contentTypeId: string
   private fromFields: string[]
   private transformEntryForLocale: Function
-  private shouldPublish: boolean|'preserve'
+  private shouldPublish: boolean|'preserve'|'unpublish'
 
   constructor (contentTypeId: string, fromFields: string[], transformation: Function, shouldPublish: boolean|'preserve' = true) {
     super()
@@ -52,6 +52,8 @@ class EntryTransformAction extends APIAction {
         await api.saveEntry(entry.id)
         if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && entry.isPublished) ) {
           await api.publishEntry(entry.id)
+        } else if (this.shouldPublish === 'unpublish') {
+          await api.unpublishEntry(entry.id)
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR adds the option to unpublish entries that have been processed by the `transformEntry` function

## Description

In addition to `true` and `false` as options for the `shouldPublish` configuration option, this adds a `unpublish` option that makes an api call to unpublish the entry being transformed.

## Motivation and Context

This is for the situation where the validations of one or more content types are changed such that existing entries would now fail validations and not be publishable without updates. If you are releasing a new version of your frontend and know that only entries which pass the updated content model validation changes will work, this is a way to show your content creators and editors which entries need to be updated to work with the updated frontend. 

I did this because of a question in the Contentful Community slack: https://contentful-community.slack.com/archives/CDY4JBMTJ/p1551255690020000

## Todos

- This could potentially be spun out from the `shouldPublish` option into a `validateEntry` function that checks entries to see if they would pass validation and unpublishes only the ones that fail the revalidation.
- Might also want to add this similar functionality to the `deriveLinkedEntries` and `transformEntriesToType` functions
