### PR TITLE
fix: editorInterface methods do not reset custom sidebar anymore

### DIFF
--- a/src/lib/entities/content-type.ts
+++ b/src/lib/entities/content-type.ts
@@ -1,4 +1,4 @@
-import { APIContentType, Field, APIEditorInterfaceControl, APIEditorInterfaces, APIEditorInterfaceSettings } from '../interfaces/content-type'
+import { APIContentType, Field, APIEditorInterfaceControl, APIEditorInterfaces, APIEditorInterfaceSettings, APIEditorInterfaceSidebar } from '../interfaces/content-type'
 import { cloneDeep, find, filter, findIndex, pull, forEach } from 'lodash'
 
 class Fields {
@@ -81,10 +81,12 @@ class Fields {
 class EditorInterfaces {
   private _version: number
   private _controls: APIEditorInterfaceControl[]
+  private _sidebar?: APIEditorInterfaceSidebar[]
 
   constructor (apiEditorInterfaces: APIEditorInterfaces) {
     this._version = apiEditorInterfaces.sys.version
     this._controls = apiEditorInterfaces.controls
+    this._sidebar = apiEditorInterfaces.sidebar || undefined
   }
 
   get version () {
@@ -146,6 +148,12 @@ class EditorInterfaces {
         settings: c.settings
       })
     })
+    if (this._sidebar) {
+      return {
+        controls: result,
+        sidebar: this._sidebar
+      }
+    }
     return {
       controls: result
     }

--- a/src/lib/interfaces/content-type.ts
+++ b/src/lib/interfaces/content-type.ts
@@ -40,8 +40,16 @@ interface APIEditorInterfaceSettings {
 
 interface APIEditorInterfaceControl {
   fieldId: string,
-  widgetId: string,
+  widgetId?: string,
+  widgetNamespace?: 'builtin' | 'extension',
   settings?: APIEditorInterfaceSettings
+}
+
+interface APIEditorInterfaceSidebar {
+  widgetId: string,
+  widgetNamespace: 'builtin' | 'extension',
+  disabled?: boolean,
+  settings?: { [key: string]: any }
 }
 
 interface APIEditorInterfaces {
@@ -49,6 +57,7 @@ interface APIEditorInterfaces {
     version: number
   }
   controls: APIEditorInterfaceControl[]
+  sidebar?: APIEditorInterfaceSidebar[]
 }
 
 export {
@@ -57,5 +66,6 @@ export {
   Field,
   APIEditorInterfaces,
   APIEditorInterfaceControl,
-  APIEditorInterfaceSettings
+  APIEditorInterfaceSettings,
+  APIEditorInterfaceSidebar
 }

--- a/test/unit/lib/offline-api/build-payloads.ts
+++ b/test/unit/lib/offline-api/build-payloads.ts
@@ -16,7 +16,8 @@ const buildPayloads = async function (runMigration, contentTypes: APIContentType
     sys: {
       version: 1
     },
-    controls: []
+    controls: [],
+    sidebar: undefined
   })
   const editorInterfacesByContentType: Map<String, EditorInterfaces> = new Map()
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary
 
Fixes https://github.com/contentful/contentful-migration/issues/173

## Description

`editorInterface` payload can have custom sidebar configuration saved. Currently all related methods just override `sidebar` configuration. This PR fixes the behavior, so if `sidebar` configuration isn't overwritten if present in the initial payload.