### PR TITLE
editorInterface methods do not reset custom editor extension

### DIFF
--- a/src/lib/entities/content-type.ts
+++ b/src/lib/entities/content-type.ts
@@ -152,9 +152,9 @@ class EditorInterfaces {
     })
 
     const result: {
-      controls: any,
-      sidebar?: any,
-      editor?: any
+      controls: APIEditorInterfaceControl[],
+      sidebar?: APIEditorInterfaceSidebar[],
+      editor?: APIEditorIntefaceEditor
     } = {
       controls
     }

--- a/src/lib/entities/content-type.ts
+++ b/src/lib/entities/content-type.ts
@@ -1,4 +1,4 @@
-import { APIContentType, Field, APIEditorInterfaceControl, APIEditorInterfaces, APIEditorInterfaceSettings, APIEditorInterfaceSidebar } from '../interfaces/content-type'
+import { APIContentType, Field, APIEditorInterfaceControl, APIEditorInterfaces, APIEditorInterfaceSettings, APIEditorInterfaceSidebar, APIEditorIntefaceEditor } from '../interfaces/content-type'
 import { cloneDeep, find, filter, findIndex, pull, forEach } from 'lodash'
 
 class Fields {
@@ -82,11 +82,13 @@ class EditorInterfaces {
   private _version: number
   private _controls: APIEditorInterfaceControl[]
   private _sidebar?: APIEditorInterfaceSidebar[]
+  private _editor?: APIEditorIntefaceEditor
 
   constructor (apiEditorInterfaces: APIEditorInterfaces) {
     this._version = apiEditorInterfaces.sys.version
     this._controls = apiEditorInterfaces.controls
     this._sidebar = apiEditorInterfaces.sidebar || undefined
+    this._editor = apiEditorInterfaces.editor || undefined
   }
 
   get version () {
@@ -140,23 +142,31 @@ class EditorInterfaces {
   }
 
   toAPI (): object {
-    let result: APIEditorInterfaceControl[] = []
+    let controls: APIEditorInterfaceControl[] = []
     forEach(this._controls, (c) => {
-      result.push({
+      controls.push({
         fieldId: c.fieldId,
         widgetId: c.widgetId,
         settings: c.settings
       })
     })
+
+    const result: {
+      controls: any,
+      sidebar?: any,
+      editor?: any
+    } = {
+      controls
+    }
+
     if (this._sidebar) {
-      return {
-        controls: result,
-        sidebar: this._sidebar
-      }
+      result.sidebar = this._sidebar
     }
-    return {
-      controls: result
+    if (this._editor) {
+      result.editor = this._editor
     }
+
+    return result
   }
 }
 

--- a/src/lib/interfaces/content-type.ts
+++ b/src/lib/interfaces/content-type.ts
@@ -52,12 +52,19 @@ interface APIEditorInterfaceSidebar {
   settings?: { [key: string]: any }
 }
 
+interface APIEditorIntefaceEditor {
+  widgetId: string,
+  widgetNamespace: 'builtin' | 'extension',
+  settings?: { [key: string]: any }
+}
+
 interface APIEditorInterfaces {
   sys: {
     version: number
-  }
-  controls: APIEditorInterfaceControl[]
-  sidebar?: APIEditorInterfaceSidebar[]
+  },
+  controls: APIEditorInterfaceControl[],
+  sidebar?: APIEditorInterfaceSidebar[],
+  editor?: APIEditorIntefaceEditor
 }
 
 export {
@@ -67,5 +74,6 @@ export {
   APIEditorInterfaces,
   APIEditorInterfaceControl,
   APIEditorInterfaceSettings,
-  APIEditorInterfaceSidebar
+  APIEditorInterfaceSidebar,
+  APIEditorIntefaceEditor
 }

--- a/test/unit/lib/offline-api/build-payloads.ts
+++ b/test/unit/lib/offline-api/build-payloads.ts
@@ -17,7 +17,8 @@ const buildPayloads = async function (runMigration, contentTypes: APIContentType
       version: 1
     },
     controls: [],
-    sidebar: undefined
+    sidebar: undefined,
+    editor: undefined
   })
   const editorInterfacesByContentType: Map<String, EditorInterfaces> = new Map()
 


### PR DESCRIPTION
## Summary

Fix for a new custom editor extensions feature.

## Description

Change in editorInterface implementation so migrations don't override `editor` property if it was set already.