### PR TITLE
chore: "Usage as a library" example error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const options = {
 }
 runMigration(options)
   .then(() => console.log('Migration Done!'))
-  .catch((e) => console.error)
+  .catch((e) => console.error(e))
 ```
 
 In your migration description file, export a function that accepts the `migration` object as its argument. For example:


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Fix "Usage as a library" example error logging

## Description

Now pass the error object to `console.error`

## Motivation and Context

That example was wrong, so I'm fixing it.