### PR TITLE
Consistent signature of changeFieldControl() in README, index.d.ts and index.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
       - [`editField(id[, opts])` : [Field](#field)](#editfieldid-opts--fieldfield)
       - [`deleteField(id)` : void](#deletefieldid--void)
       - [`changeFieldId (currentId, newId)` : void](#changefieldid-currentid-newid--void)
-      - [`changeFieldControl (fieldId, widgetId, widgetNamespace[, settings])` : void](#changefieldcontrol-fieldid-widgetid-widgetnamespace-settings--void)
+      - [`changeFieldControl (fieldId, widgetNamespace, widgetId[, settings])` : void](#changefieldcontrol-fieldid-widgetnamespace-widgetid-settings--void)
       - [`resetFieldControl (fieldId)` : void](#resetfieldcontrol-fieldid--void)
       - [`copyFieldControl (sourceFieldId, destinationFieldId)` : void](#copyfieldcontrol-sourcefieldid-destinationfieldid--void)
       - [`addSidebarWidget (widgetNamespace, widgetId[, settings, insertBeforeWidgetId])` : void](#addsidebarwidget-widgetnamespace-widgetid-settings-insertbeforewidgetid--void)
@@ -523,17 +523,17 @@ module.exports = function (migration) {
 };
 ```
 
-#### `changeFieldControl (fieldId, widgetId, widgetNamespace[, settings])` : void
+#### `changeFieldControl (fieldId, widgetNamespace, widgetId[, settings])` : void
 
 Changes control interface of given field's ID.
 
 **`fieldId : string`** – The ID of the field.
 
-**`widgetId : string`** – The new widget ID for the field. See the [editor interface documentation](https://www.contentful.com/developers/docs/concepts/editor-interfaces/) for a list of available widgets.
-
 **`widgetNamespace : string`** – The namespace of the widget, one of the following values:
 - `builtin` (Standard widget)
 - `extension` (Custom UI extension)
+
+**`widgetId : string`** – The new widget ID for the field. See the [editor interface documentation](https://www.contentful.com/developers/docs/concepts/editor-interfaces/) for a list of available widgets.
 
 **`settings : Object`** – Widget settings and extension instance parameters. Key-value pairs of type (string, number | boolean | string). For builtin widgets, the the following options are available:
 

--- a/examples/16-change-field-control.js
+++ b/examples/16-change-field-control.js
@@ -34,5 +34,5 @@ module.exports = function (migration) {
     type: 'Symbol',
     required: true
   });
-  blogPost.changeFieldControl('slug', 'slugEditor', 'builtin', { setting: 'value' });
+  blogPost.changeFieldControl('slug', 'builtin', 'slugEditor', { setting: 'value' });
 };

--- a/examples/17-change-field-control-for-existing-content-type.js
+++ b/examples/17-change-field-control-for-existing-content-type.js
@@ -6,5 +6,5 @@ module.exports = function (migration) {
 
   blogPost
     .resetFieldControl('slug')
-    .changeFieldControl('slug', 'singleLine', 'builtin');
+    .changeFieldControl('slug', 'builtin', 'singleLine');
 };

--- a/examples/18-change-field-control-for-existing-content-type-adding-help-text.js
+++ b/examples/18-change-field-control-for-existing-content-type-adding-help-text.js
@@ -6,8 +6,8 @@ module.exports = function (migration) {
 
   blogPost.changeFieldControl(
     'slug',
-    'slugEditor',
     'builtin',
+    'slugEditor',
     { helpText: 'This is the slug for the entry, it will be used for the URL' }
   );
 };

--- a/examples/21-copy-field-control.js
+++ b/examples/21-copy-field-control.js
@@ -14,6 +14,6 @@ module.exports = function (migration) {
     name: 'Instruction',
     type: 'Text'
   });
-  recipe.changeFieldControl('description', 'markdown', 'builtin');
+  recipe.changeFieldControl('description', 'builtin', 'markdown');
   recipe.copyFieldControl('description', 'instruction');
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -152,8 +152,8 @@ export interface ContentType {
   /**
    * Changes the control of given field's ID.
    *
-   * @param widgetNamespace The namespace of the widget. Use 'builtin' for standard widgets or 'extension' for UI extensions.
    * @param fieldId The ID of the field.
+   * @param widgetNamespace The namespace of the widget. Use 'builtin' for standard widgets or 'extension' for UI extensions.
    * @param widgetId The new widget ID for the field.
    * @param settings Widget settings
    */

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -145,7 +145,7 @@ class ContentType extends DispatchProxy {
     ))
   }
 
-  changeFieldControl (fieldId, widgetId, widgetNamespace, settings) {
+  changeFieldControl (fieldId, widgetNamespace, widgetId, settings) {
     const callsite = getFirstExternalCaller()
     this.dispatch(actionCreators.contentType.changeEditorInterface(
       this.id,
@@ -162,7 +162,7 @@ class ContentType extends DispatchProxy {
   /** deprecated, use changeFieldControl instead */
   changeEditorInterface (fieldId, widgetId, settings, widgetNamespace) {
     deprecatedMethod('changeEditorInterface', 'changeFieldControl')
-    return this.changeFieldControl(fieldId, widgetId, widgetNamespace, settings)
+    return this.changeFieldControl(fieldId, widgetNamespace, widgetId, settings)
   }
 
   copyFieldControl (sourceFieldId, destinationFieldId) {

--- a/test/unit/lib/migration-steps/migration-steps.spec.js
+++ b/test/unit/lib/migration-steps/migration-steps.spec.js
@@ -702,8 +702,8 @@ describe('migration-steps', function () {
       const plan = yield migration(function (migration) {
         migration
           .editContentType('book')
-          .changeFieldControl('title', 'markdown', 'builtin')
-          .changeFieldControl('desc', 'singleLine', 'builtin');
+          .changeFieldControl('title', 'builtin', 'markdown')
+          .changeFieldControl('desc', 'builtin', 'singleLine');
       });
 
       expect(stripCallsites(plan)).to.eql([


### PR DESCRIPTION
## Summary

Fixes inconsistency in changeFieldControl signature raised in issue #198

Same as for the sidebar methods, widgetNamespace should always be mandatory and always precede widgetId. This is due to the fact that widgetId is only unique in said namespace.