### PR TITLE
Provide Management API client instance to migration functions

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -70,7 +70,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
     return client.rawRequest(config)
   }
 
-  const migrationParser = createMigrationParser(makeRequest, clientConfig)
+  const migrationParser = createMigrationParser(makeRequest, { ...clientConfig, client, yes: argv.yes })
 
   let parseResult: ParseResult
 


### PR DESCRIPTION
## Description

I'm working on a migration that needs to modify Entry data in Contentful that would leverage the Management API. Since there is a client instance already created in the cli runner, it makes sense to provide the client instance to migration functions so that tasks can be performed.

Also providing the `--apply` cli argument value as well so that different logic can occur when the confirmation dialogue is skipped

