### PR TITLE
fix(typing): 'axios' import in typings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 script:
   - npm run lint
   - npm run build-dev
+  - npm run test-typescript-declaration
   - npm run coverage-report
 
 cache:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import * as axios from 'axios'
 
 export interface Movement {
   toTheTop(): void

--- a/package-lock.json
+++ b/package-lock.json
@@ -10859,9 +10859,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.7.0",
     "tslint-config-standard": "^6.0.1",
-    "typescript": "^2.5.3",
+    "typescript": "^3.5.3",
     "uuid": "^3.3.2",
     "zlib": "^1.0.5"
   },


### PR DESCRIPTION
We correctly import `axios` in the type definitions `index.d.ts`.

To ensure that typings are checked on CI we run `npm run test-typescript-declaration`. This requires us to upgrade typescript to the latest version.