### PR TITLE
fix(offline-api): Change CT to content type in the error message

### DIFF
--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -201,7 +201,7 @@ class OfflineAPI {
     const hasContentType = this.modifiedContentTypes.has(id)
 
     if (!hasContentType) {
-      throw new Error(`Cannot save CT ${id} because it does not exist`)
+      throw new Error(`Cannot save the content type (id: ${id}) because it does not exist`)
     }
 
     const ct = await this.getContentType(id)


### PR DESCRIPTION
We have an erorr message `cannot save CT sldihfsd because it does not exist` which might be confusion a tiny bit for folks who does not know what CT stands for.
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):