### PR TITLE
fix: throw on missing or invalid file

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -49,9 +49,9 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
   try {
     migrationFunction = require(argv.filePath)
   } catch (e) {
-    console.error(chalk`{red.bold The ${argv.filePath} script could not be parsed, as it seems to contain syntax errors.}\n`)
-    console.error(e)
-    return
+    const message = chalk`{red.bold The ${argv.filePath} script could not be parsed, as it seems to contain syntax errors.}\n`
+    console.error(message)
+    terminate(new Error(message))
   }
 
   const application = argv.managementApplication || `contentful.migration-cli/${version}`


### PR DESCRIPTION
## Summary

Changes `runMigration` to throw when a migration file is missing or is invalid.

## Description

When a migration file is missing or invalid, the script exits without indicating an error which can be caught programmatically. It's impossible to see the error state when using `runMigration` as a library, even though the possibility to indicate this by throwing is present.

This PR changes this behavior so the function throws in this cases.

## Motivation and Context

The code calling `runMigration` will treat a migration as successfully even if the migration script is missing or invalid.

