### PR TITLE
fix: shouldPublish preserve no longer publishes "Changed" status entries

### DIFF
--- a/src/lib/action/entry-transform-to-type.ts
+++ b/src/lib/action/entry-transform-to-type.ts
@@ -90,8 +90,9 @@ class EntryTransformToTypeAction extends APIAction {
         }
 
       }
+      const currentlyChanged = entry.isChanged
       await api.saveEntry(targetEntry.id)
-      if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && entry.isPublished) ) {
+      if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && (entry.isPublished && !currentlyChanged)) ) {
         await api.publishEntry(targetEntry.id)
       }
 
@@ -105,8 +106,9 @@ class EntryTransformToTypeAction extends APIAction {
             link.element.replaceArrayLinkForLocale(link.field, link.locale, link.index, newEntryId)
           }
 
+          const elementCurrentlyChanged = link.element.isChanged
           await api.saveEntry(link.element.id)
-          if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && link.element.isPublished) ) {
+          if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && (link.element.isPublished && !elementCurrentlyChanged)) ) {
             await api.publishEntry(link.element.id)
           }
         }

--- a/src/lib/action/entry-transform.ts
+++ b/src/lib/action/entry-transform.ts
@@ -49,8 +49,9 @@ class EntryTransformAction extends APIAction {
 
       }
       if (changesForThisEntry) {
+        const currentlyChanged = entry.isChanged
         await api.saveEntry(entry.id)
-        if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && entry.isPublished) ) {
+        if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && (entry.isPublished && !currentlyChanged)) ) {
           await api.publishEntry(entry.id)
         }
       }

--- a/src/lib/entities/entry.ts
+++ b/src/lib/entities/entry.ts
@@ -67,6 +67,10 @@ class Entry {
     return isDefined(this._publishedVersion)
   }
 
+  get isChanged () {
+    return isDefined(this._publishedVersion) && this._version > this._publishedVersion + 1
+  }
+
   get publishedVersion () {
     return this._publishedVersion
   }


### PR DESCRIPTION
## Summary

Should help resolve #223. `shouldPublish` set to `preserve` should not publish entries that are in "Changed" status.

## Motivation and Context

If a Contentful user has made changes to a Published entry that are "Saved" but not "Published", `preserve` currently publishes the entry. This causes issues because the entry might not be ready, or might be missing fields that are marked as required, causing the migration to fail.

## Todos

-   [x] Works with `entry-transform`
-   [x] Works with `entry-transform-to-type`