### PR TITLE
docs(README): Update README to include "Entry title" phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Creates a content type with provided `id` and returns a reference to the newly c
 
 - **`name : string`** – Name of the content type.
 - **`description : string`** – Description of the content type.
-- **`displayField : string`** – ID of the field to use as the display field for the content type.
+- **`displayField : string`** – ID of the field to use as the display field for the content type. This is referred to as the "Entry title" in the web application.
 
 #### `editContentType(id[, opts])` : [ContentType](#content-type)
 


### PR DESCRIPTION
## Summary

Updates the README to include the web-app description of a field to the corresponding content model field

## Description

This adds the phrase "Entry title" to the description for the `displayName` option on the Content Model documentation, since that is what a web-app user might know the field as

## Motivation and Context

Just an instance where the wording differs between the web app and the under-the-hood schema. I think adding this kind of clarification can help bridge the knowledge gap for anyone used to using the web app GUI

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/16481282/70159706-59ba5080-1687-11ea-95ff-0c5c8025b49a.png)
