### PR TITLE
fix: log errors when requiring migration scripts

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -51,6 +51,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
   } catch (e) {
     const message = chalk`{red.bold The ${argv.filePath} script could not be parsed, as it seems to contain syntax errors.}\n`
     console.error(message)
+    console.error(e)
     terminate(new Error(message))
   }
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Logs any errors that are thrown when requiring migration scripts.

## Motivation and Context

Previously when a migration contained syntax errors or could not be `require`d, users would only get a generic message:

>The migrations/cm001-create-seo-fields.js script could not be parsed, as it seems to contain syntax errors.

This is not very helpful because it does not describe the underlying issue.
