### PR TITLE
Allow "nodes" validation for all blocks and inlines

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -1,47 +1,47 @@
-import * as Joi from 'joi';
+import * as Joi from 'joi'
 
 const validation = (name, constraint) => Joi.object({
   [name]: constraint,
   message: Joi.string()
-});
+})
 
 const range = (type) => Joi.object({
   min: Joi[type]().allow(null),
   max: Joi[type]().allow(null)
-});
+})
 
 const rangeForDate = () => Joi.object({
   before: Joi.string().optional().allow(null),
   after: Joi.string().optional().allow(null),
   min: Joi.string().optional().allow(null),
   max: Joi.string().optional().allow(null)
-});
+})
 
-const linkContentType = validation('linkContentType', Joi.array().items(Joi.string()));
-const inValidation = validation('in', Joi.array());
-const linkMimetypeGroup = validation('linkMimetypeGroup', Joi.array().items(Joi.string()));
-const size = validation('size', range('number'));
-const rangeValidation = validation('range', range('number'));
+const linkContentType = validation('linkContentType', Joi.array().items(Joi.string()))
+const inValidation = validation('in', Joi.array())
+const linkMimetypeGroup = validation('linkMimetypeGroup', Joi.array().items(Joi.string()))
+const size = validation('size', range('number'))
+const rangeValidation = validation('range', range('number'))
 
 const regexp = validation('regexp', Joi.object({
   pattern: Joi.string(),
   flags: Joi.string().allow(null).optional()
-}));
+}))
 
 const prohibitRegexp = validation('prohibitRegexp', Joi.object({
   pattern: Joi.string(),
   flags: Joi.string().allow(null).optional()
-}));
+}))
 
-const unique = validation('unique', Joi.boolean());
-const dateRange = validation('dateRange', rangeForDate());
+const unique = validation('unique', Joi.boolean())
+const dateRange = validation('dateRange', rangeForDate())
 
 const assetImageDimensions = validation('assetImageDimensions', Joi.object({
   width: range('number'),
   height: range('number')
-}));
+}))
 
-const assetFileSize = validation('assetFileSize', range('number'));
+const assetFileSize = validation('assetFileSize', range('number'))
 
 const nodes = validation('nodes', Joi.object({
   'embedded-entry-block': Joi.array(),
@@ -50,9 +50,9 @@ const nodes = validation('nodes', Joi.object({
   'entry-hyperlink': Joi.array(),
   'asset-hyperlink': Joi.array(),
   'hyperlink': Joi.array()
-}));
+}))
 
-const enabledMarks = validation('enabledMarks', Joi.array().items(Joi.string().valid('bold', 'italic', 'code', 'underline')));
+const enabledMarks = validation('enabledMarks', Joi.array().items(Joi.string().valid('bold', 'italic', 'code', 'underline')))
 
 const enabledNodeTypes = validation('enabledNodeTypes', Joi.array().items(Joi.string().valid(
   'heading-1',
@@ -71,7 +71,7 @@ const enabledNodeTypes = validation('enabledNodeTypes', Joi.array().items(Joi.st
   'entry-hyperlink',
   'asset-hyperlink',
   'embedded-entry-inline'
-)));
+)))
 
 const fieldValidations = Joi.alternatives().try(
   linkContentType,
@@ -88,6 +88,6 @@ const fieldValidations = Joi.alternatives().try(
   nodes,
   enabledMarks,
   enabledNodeTypes
-);
+)
 
-export default fieldValidations;
+export default fieldValidations

--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -1,55 +1,58 @@
-import * as Joi from 'joi'
+import * as Joi from 'joi';
 
 const validation = (name, constraint) => Joi.object({
   [name]: constraint,
   message: Joi.string()
-})
+});
 
 const range = (type) => Joi.object({
   min: Joi[type]().allow(null),
   max: Joi[type]().allow(null)
-})
+});
 
 const rangeForDate = () => Joi.object({
   before: Joi.string().optional().allow(null),
   after: Joi.string().optional().allow(null),
   min: Joi.string().optional().allow(null),
   max: Joi.string().optional().allow(null)
-})
+});
 
-const linkContentType = validation('linkContentType', Joi.array().items(Joi.string()))
-const inValidation = validation('in', Joi.array())
-const linkMimetypeGroup = validation('linkMimetypeGroup', Joi.array().items(Joi.string()))
-const size = validation('size', range('number'))
-const rangeValidation = validation('range', range('number'))
+const linkContentType = validation('linkContentType', Joi.array().items(Joi.string()));
+const inValidation = validation('in', Joi.array());
+const linkMimetypeGroup = validation('linkMimetypeGroup', Joi.array().items(Joi.string()));
+const size = validation('size', range('number'));
+const rangeValidation = validation('range', range('number'));
 
 const regexp = validation('regexp', Joi.object({
   pattern: Joi.string(),
   flags: Joi.string().allow(null).optional()
-}))
+}));
 
 const prohibitRegexp = validation('prohibitRegexp', Joi.object({
   pattern: Joi.string(),
   flags: Joi.string().allow(null).optional()
-}))
+}));
 
-const unique = validation('unique', Joi.boolean())
-const dateRange = validation('dateRange', rangeForDate())
+const unique = validation('unique', Joi.boolean());
+const dateRange = validation('dateRange', rangeForDate());
 
 const assetImageDimensions = validation('assetImageDimensions', Joi.object({
   width: range('number'),
   height: range('number')
-}))
+}));
 
-const assetFileSize = validation('assetFileSize', range('number'))
+const assetFileSize = validation('assetFileSize', range('number'));
 
 const nodes = validation('nodes', Joi.object({
   'embedded-entry-block': Joi.array(),
   'embedded-entry-inline': Joi.array(),
-  'entry-hyperlink': Joi.array()
-}))
+  'embedded-asset-inline': Joi.array(),
+  'entry-hyperlink': Joi.array(),
+  'asset-hyperlink': Joi.array(),
+  'hyperlink': Joi.array()
+}));
 
-const enabledMarks = validation('enabledMarks', Joi.array().items(Joi.string().valid('bold', 'italic', 'code', 'underline')))
+const enabledMarks = validation('enabledMarks', Joi.array().items(Joi.string().valid('bold', 'italic', 'code', 'underline')));
 
 const enabledNodeTypes = validation('enabledNodeTypes', Joi.array().items(Joi.string().valid(
   'heading-1',
@@ -68,7 +71,7 @@ const enabledNodeTypes = validation('enabledNodeTypes', Joi.array().items(Joi.st
   'entry-hyperlink',
   'asset-hyperlink',
   'embedded-entry-inline'
-)))
+)));
 
 const fieldValidations = Joi.alternatives().try(
   linkContentType,
@@ -85,6 +88,6 @@ const fieldValidations = Joi.alternatives().try(
   nodes,
   enabledMarks,
   enabledNodeTypes
-)
+);
 
-export default fieldValidations
+export default fieldValidations;

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -1,7 +1,7 @@
-'use strict'
+'use strict';
 
-import { expect } from 'chai'
-import validateBatches from './validate-batches'
+import { expect } from 'chai';
+import validateBatches from './validate-batches';
 
 describe('payload validation', function () {
   describe('fieldValidations', function () {
@@ -9,13 +9,13 @@ describe('payload validation', function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true }, { unique: true }])
-      }, [])
+          .validations([{ unique: true }, { unique: true }]);
+      }, []);
 
       expect(errors).to.eql([
         [
@@ -24,20 +24,20 @@ describe('payload validation', function () {
             message: `A field can't have duplicates in the validations array. Duplicate: "{"unique":true}"`
           }
         ]
-      ])
-    })
+      ]);
+    });
 
     it('errors on unknown validations key', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true }, { size: { min: 5, max: 10 } }, { foo: true }])
-      }, [])
+          .validations([{ unique: true }, { size: { min: 5, max: 10 } }, { foo: true }]);
+      }, []);
 
       expect(errors).to.eql([
         [
@@ -46,20 +46,20 @@ describe('payload validation', function () {
             message: `A field can't have "foo" as a validation.`
           }
         ]
-      ])
-    })
+      ]);
+    });
 
     it('errors with correct invalid key on unknown validations key', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true }, { size: { min: 5, max: 10 }, somethingUnknown: 'foo', msg: 'error' }])
-      }, [])
+          .validations([{ unique: true }, { size: { min: 5, max: 10 }, somethingUnknown: 'foo', msg: 'error' }]);
+      }, []);
 
       expect(errors).to.eql([
         [
@@ -68,20 +68,20 @@ describe('payload validation', function () {
             message: `A field can't have the combination "size", "somethingUnknown" and "msg" as a validation.`
           }
         ]
-      ])
-    })
+      ]);
+    });
 
     it('errors on wrong validation parameter (object)', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ size: 2 }])
-      }, [])
+          .validations([{ size: 2 }]);
+      }, []);
 
       expect(errors).to.eql([
         [
@@ -90,20 +90,20 @@ describe('payload validation', function () {
             message: `"size" validation expected to be "object", but got "number"`
           }
         ]
-      ])
-    })
+      ]);
+    });
 
     it('errors on wrong validation parameter (primitive)', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: 'nope' }])
-      }, [])
+          .validations([{ unique: 'nope' }]);
+      }, []);
 
       expect(errors).to.eql([
         [
@@ -112,41 +112,67 @@ describe('payload validation', function () {
             message: `"unique" validation expected to be "boolean", but got "string"`
           }
         ]
-      ])
-    })
+      ]);
+    });
 
     it('allows custom error message key', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true, message: 'must be uniq' }, { size: { min: 5, max: 10 }, message: 'must fit' }])
-      }, [])
+          .validations([{ unique: true, message: 'must be uniq' }, { size: { min: 5, max: 10 }, message: 'must fit' }]);
+      }, []);
 
       expect(errors).to.eql([
         []
-      ])
-    })
+      ]);
+    });
 
     it('allows null values for optional validation properties', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person')
+          .description('A Person');
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ regexp: { pattern: '^[A-Za-z\s]+$', flags: null } }])
-      }, [])
+          .validations([{ regexp: { pattern: '^[A-Za-z\s]+$', flags: null } }]);
+      }, []);
 
       expect(errors).to.eql([
         []
-      ])
-    })
-  })
-})
+      ]);
+    });
+
+    it('can validate all blocks and inlines for RichText', async function () {
+      const errors = await validateBatches(function up (migration) {
+        const novel = migration.createContentType('novel')
+          .name('Novel')
+          .description('A Lovely Novel');
+
+        novel.createField('chapter')
+          .name('Chapter')
+          .type('RichText')
+          .validations([
+            { nodes: {
+              'embedded-entry-block': [{ size: { max: 4 } }],
+              'embedded-entry-inline': [{ size: { max: 4 } }],
+              'embedded-asset-inline': [{ size: { max: 4 } }],
+              'entry-hyperlink': [{ size: { max: 4 } }],
+              'asset-hyperlink': [{ size: { max: 4 } }],
+              'hyperlink': [{ size: { max: 4 } }]
+            } }
+          ]);
+      }, []);
+
+      expect(errors).to.eql([
+        []
+      ]);
+    });
+  });
+});

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-import { expect } from 'chai';
-import validateBatches from './validate-batches';
+import { expect } from 'chai'
+import validateBatches from './validate-batches'
 
 describe('payload validation', function () {
   describe('fieldValidations', function () {
@@ -9,13 +9,13 @@ describe('payload validation', function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true }, { unique: true }]);
-      }, []);
+          .validations([{ unique: true }, { unique: true }])
+      }, [])
 
       expect(errors).to.eql([
         [
@@ -24,20 +24,20 @@ describe('payload validation', function () {
             message: `A field can't have duplicates in the validations array. Duplicate: "{"unique":true}"`
           }
         ]
-      ]);
-    });
+      ])
+    })
 
     it('errors on unknown validations key', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true }, { size: { min: 5, max: 10 } }, { foo: true }]);
-      }, []);
+          .validations([{ unique: true }, { size: { min: 5, max: 10 } }, { foo: true }])
+      }, [])
 
       expect(errors).to.eql([
         [
@@ -46,20 +46,20 @@ describe('payload validation', function () {
             message: `A field can't have "foo" as a validation.`
           }
         ]
-      ]);
-    });
+      ])
+    })
 
     it('errors with correct invalid key on unknown validations key', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true }, { size: { min: 5, max: 10 }, somethingUnknown: 'foo', msg: 'error' }]);
-      }, []);
+          .validations([{ unique: true }, { size: { min: 5, max: 10 }, somethingUnknown: 'foo', msg: 'error' }])
+      }, [])
 
       expect(errors).to.eql([
         [
@@ -68,20 +68,20 @@ describe('payload validation', function () {
             message: `A field can't have the combination "size", "somethingUnknown" and "msg" as a validation.`
           }
         ]
-      ]);
-    });
+      ])
+    })
 
     it('errors on wrong validation parameter (object)', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ size: 2 }]);
-      }, []);
+          .validations([{ size: 2 }])
+      }, [])
 
       expect(errors).to.eql([
         [
@@ -90,20 +90,20 @@ describe('payload validation', function () {
             message: `"size" validation expected to be "object", but got "number"`
           }
         ]
-      ]);
-    });
+      ])
+    })
 
     it('errors on wrong validation parameter (primitive)', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: 'nope' }]);
-      }, []);
+          .validations([{ unique: 'nope' }])
+      }, [])
 
       expect(errors).to.eql([
         [
@@ -112,48 +112,48 @@ describe('payload validation', function () {
             message: `"unique" validation expected to be "boolean", but got "string"`
           }
         ]
-      ]);
-    });
+      ])
+    })
 
     it('allows custom error message key', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ unique: true, message: 'must be uniq' }, { size: { min: 5, max: 10 }, message: 'must fit' }]);
-      }, []);
+          .validations([{ unique: true, message: 'must be uniq' }, { size: { min: 5, max: 10 }, message: 'must fit' }])
+      }, [])
 
       expect(errors).to.eql([
         []
-      ]);
-    });
+      ])
+    })
 
     it('allows null values for optional validation properties', async function () {
       const errors = await validateBatches(function up (migration) {
         const person = migration.createContentType('person')
           .name('Person')
-          .description('A Person');
+          .description('A Person')
 
         person.createField('fullName')
           .name('Full Name')
           .type('Symbol')
-          .validations([{ regexp: { pattern: '^[A-Za-z\s]+$', flags: null } }]);
-      }, []);
+          .validations([{ regexp: { pattern: '^[A-Za-z\s]+$', flags: null } }])
+      }, [])
 
       expect(errors).to.eql([
         []
-      ]);
-    });
+      ])
+    })
 
     it('can validate all blocks and inlines for RichText', async function () {
       const errors = await validateBatches(function up (migration) {
         const novel = migration.createContentType('novel')
           .name('Novel')
-          .description('A Lovely Novel');
+          .description('A Lovely Novel')
 
         novel.createField('chapter')
           .name('Chapter')
@@ -167,12 +167,12 @@ describe('payload validation', function () {
               'asset-hyperlink': [{ size: { max: 4 } }],
               'hyperlink': [{ size: { max: 4 } }]
             } }
-          ]);
-      }, []);
+          ])
+      }, [])
 
       expect(errors).to.eql([
         []
-      ]);
-    });
-  });
-});
+      ])
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary
Fixes "nodes" validation for RichText adding support for all blocks and inlines.
<!-- Give a short summary what your PR is introducing/fixing. -->

## Description
added "nodes" validation for 
```
'embedded-asset-inline'
'asset-hyperlink'
'hyperlink'
```

## Motivation and Context
Using the migration tool fails to properly migrate since it doesn't allow the use of 
```
'embedded-asset-inline'
'asset-hyperlink'
'hyperlink'
```
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
