### PR TITLE
feat: Support export default in migrations

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -47,6 +47,18 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
   const terminate = makeTerminatingFunction({ shouldThrow })
   try {
     migrationFunction = require(argv.filePath)
+    
+    // Support ES Module syntax `export default migrationFunction` like in use with TS-Node
+    if (typeof migrationFunction !== 'function') {
+      if (typeof migrationFunction.default === 'function') {
+        migrationFunction = migrationFunction.default
+      } else {
+        const message = chalk`{red.bold The ${argv.filePath} script did not export a function. Did you export default?}\n`
+        console.error(message)
+        console.error(e)
+        terminate(new Error(message))
+      }
+    }
   } catch (e) {
     const message = chalk`{red.bold The ${argv.filePath} script could not be parsed, as it seems to contain syntax errors.}\n`
     console.error(message)


### PR DESCRIPTION
## Summary

This makes it so migrations can export their migration functions using ES module syntax in TS-Node or after running through webpack.

```typescript
import { MigrationFunction } from 'contentful-migration'

const migrate: MigrationFunction = (migration) => {
  const dog = migration.createContentType('dog');
  const name = dog.createField('name');
  name.type('Symbol').required(true);
}

export default migrate
```

## Motivation and Context

I had been receiving this error:

```
TypeError: migrationCreator is not a function
    at node_modules/contentful-migration/src/lib/migration-steps/index.ts:335:12
```

Saw some others as well:

* https://github.com/contentful/contentful-migration/issues/124
* https://github.com/contentful/contentful-migration/issues/103

