### PR TITLE
validation should be asset-block instead of asset-inline

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -46,7 +46,7 @@ const assetFileSize = validation('assetFileSize', range('number'))
 const nodes = validation('nodes', Joi.object({
   'embedded-entry-block': Joi.array(),
   'embedded-entry-inline': Joi.array(),
-  'embedded-asset-inline': Joi.array(),
+  'embedded-asset-block': Joi.array(),
   'entry-hyperlink': Joi.array(),
   'asset-hyperlink': Joi.array(),
   'hyperlink': Joi.array()

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -162,7 +162,7 @@ describe('payload validation', function () {
             { nodes: {
               'embedded-entry-block': [{ size: { max: 4 } }],
               'embedded-entry-inline': [{ size: { max: 4 } }],
-              'embedded-asset-inline': [{ size: { max: 4 } }],
+              'embedded-asset-block': [{ size: { max: 4 } }],
               'entry-hyperlink': [{ size: { max: 4 } }],
               'asset-hyperlink': [{ size: { max: 4 } }],
               'hyperlink': [{ size: { max: 4 } }]


### PR DESCRIPTION

## Summary
embedded-asset-inline doesn't exists and should be embedded-asset-block instead

## Motivation and Context
migration fails when using "embedded-asset-inline" in validation

-   [x] Implemented feature
-   [ ] Feature with pending implementation