### PR TITLE
Added configureEntryEditor definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,14 @@ export interface ContentType {
   changeFieldId (oldId: string, newId: string): void
 
   /**
+   * 
+   * @param widgetNamespace The namespace of the widget. Use 'builtin' for standard widgets or 'extension' for UI extensions.
+   * @param widgetId The new widget ID for the field.
+   * @param settings Widget settings
+   */
+  configureEntryEditor(widgetNamespace: 'builtin' | 'extension', widgetId: string, settings?: IEditorInterfaceOptions): void
+
+  /**
    * Changes the control of given field's ID.
    *
    * @param fieldId The ID of the field.


### PR DESCRIPTION
## Summary

Adding TypeScript definition for `configureEntryEditor`.

## Description

Added the `configureEntryEditor` definition within the `ContentType`'s definition