### PR TITLE
fix: add missing `yes` param to migration config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ export interface RunMigrationConfig {
   environmentId?: string
   proxy?: string
   rawProxy?: boolean
+  yes?: boolean
 }
 
 export function runMigration (config: RunMigrationConfig): Promise<any>


### PR DESCRIPTION

## Summary

This adds the missing `yes` param to the migration config in the definitions file so that confirmation can be skipped when calling `runMigration` in typescript.

## Motivation and Context

Noticed that this was missing while working on a project which is using the contentful migration tool via typescript in an automated context; we added `// @ts-ignore` as a workaround, but it would be nice to have it fixed properly.
