### PR TITLE
Feat/add edit and delete tag support

### DIFF
--- a/examples/03-long-example.js
+++ b/examples/03-long-example.js
@@ -35,6 +35,9 @@ module.exports = function (migration) {
     required: false
   });
 
+  const tag = migration.createTag('longexampletag');
+  tag.name('long example marketing');
+
   person.createField('pet', {
     name: 'Their pet',
     type: 'Link',

--- a/examples/28-create-tag.js
+++ b/examples/28-create-tag.js
@@ -1,4 +1,3 @@
-// Basic example: create new tag.
 module.exports = function (migration) {
   migration.createTag('sampletag', {
     name: 'marketing'

--- a/examples/29-modify-tag.js
+++ b/examples/29-modify-tag.js
@@ -1,0 +1,5 @@
+// Basic example: modify existing tag.
+module.exports = function (migration) {
+  const sampleTag = migration.editTag('sampletag');
+  sampleTag.name('better marketing');
+};

--- a/examples/29-modify-tag.js
+++ b/examples/29-modify-tag.js
@@ -1,5 +1,5 @@
-// Basic example: modify existing tag.
 module.exports = function (migration) {
   const sampleTag = migration.editTag('sampletag');
   sampleTag.name('better marketing');
-};
+}
+;

--- a/examples/30-delete-tag.js
+++ b/examples/30-delete-tag.js
@@ -1,3 +1,3 @@
 module.exports = function (migration) {
-  migration.deleteTag('sampleTag');
+  migration.deleteTag('sampletag');
 };

--- a/examples/30-delete-tag.js
+++ b/examples/30-delete-tag.js
@@ -1,0 +1,3 @@
+module.exports = function (migration) {
+  migration.deleteTag('sampleTag');
+};

--- a/src/lib/action/tag-delete.ts
+++ b/src/lib/action/tag-delete.ts
@@ -1,0 +1,17 @@
+import { APIAction } from './action'
+import OfflineAPI from '../offline-api/index'
+
+class TagDeleteAction extends APIAction {
+  private tagId: string
+
+  constructor (tagId: string) {
+    super()
+    this.tagId = tagId
+  }
+
+  async applyTo (api: OfflineAPI) {
+    await api.deleteTag(this.tagId)
+  }
+}
+
+export { TagDeleteAction }

--- a/src/lib/intent-validator/tag-update.ts
+++ b/src/lib/intent-validator/tag-update.ts
@@ -1,6 +1,10 @@
 import SchemaValidator from './schema-validator'
 import * as Joi from 'joi'
 
+// TODO: We check this here and as part of the offline-api
+// validation. Which is the right place?
+const MAX_NAME_LENGTH = 256
+
 class TagUpdateStepValidator extends SchemaValidator {
   protected article = 'a'
   protected displayName = 'tag'
@@ -11,7 +15,7 @@ class TagUpdateStepValidator extends SchemaValidator {
 
   get schema () {
     return {
-      name: Joi.string().required()
+      name: Joi.string().max(MAX_NAME_LENGTH).required()
     }
   }
 }

--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -167,6 +167,10 @@ export default abstract class Intent implements IntentInterface {
     return false
   }
 
+  isTagDelete (): boolean {
+    return false
+  }
+
   isTagIntent (): boolean {
     return false
   }

--- a/src/lib/intent/composed-intent.ts
+++ b/src/lib/intent/composed-intent.ts
@@ -182,7 +182,7 @@ export default class ComposedIntent implements Intent {
 
     const mainHeading = firstIntent.toPlanMessage().heading
 
-    const contentTypeUpdates = this.intents.filter((intent) => intent.isContentTypeUpdate())
+    const contentTypeOrTagUpdates = this.intents.filter((intent) => intent.isContentTypeUpdate() || intent.isTagUpdate())
 
     const fieldCreates = this.intents.filter((intent) => intent.isFieldCreate())
     const editorInterfaceUpdates = this.intents.filter((intent) => intent.isEditorInterfaceUpdate())
@@ -197,7 +197,7 @@ export default class ComposedIntent implements Intent {
     const onlyFieldUpdatesByField = groupBy(onlyFieldUpdates, (intent) => intent.getFieldId())
     const createdFieldUpdatesByField = groupBy(createdFieldUpdates, (intent) => intent.getFieldId())
 
-    const topLevelDetails = flatten(contentTypeUpdates.map((updateIntent) => updateIntent.toPlanMessage().details))
+    const topLevelDetails = flatten(contentTypeOrTagUpdates.map((updateIntent) => updateIntent.toPlanMessage().details))
 
     const sidebarUpdates = flatten(this.intents
       .filter((intent) => intent.isSidebarUpdate())

--- a/src/lib/intent/composed-intent.ts
+++ b/src/lib/intent/composed-intent.ts
@@ -155,6 +155,10 @@ export default class ComposedIntent implements Intent {
     return false
   }
 
+  isTagDelete (): boolean {
+    return false
+  }
+
   toActions () {
     return flatten(this.intents.map((intent) => intent.toActions()))
   }

--- a/src/lib/intent/index.ts
+++ b/src/lib/intent/index.ts
@@ -23,7 +23,6 @@ import TagCreateIntent from './tag-create'
 import TagUpdateIntent from './tag-update'
 import TagDeleteIntent from './tag-delete'
 
-
 export {
   Intent as default,
   Intent,

--- a/src/lib/intent/index.ts
+++ b/src/lib/intent/index.ts
@@ -21,7 +21,7 @@ import EntryEditorResetToDefaultIntent from './entryeditor-reset-to-default'
 import EntryEditorConfigureIntent from './entryeditor-configure'
 import TagCreateIntent from './tag-create'
 import TagUpdateIntent from './tag-update'
-import TagDeleteIntent from './tag-update'
+import TagDeleteIntent from './tag-delete'
 
 
 export {

--- a/src/lib/intent/index.ts
+++ b/src/lib/intent/index.ts
@@ -21,6 +21,8 @@ import EntryEditorResetToDefaultIntent from './entryeditor-reset-to-default'
 import EntryEditorConfigureIntent from './entryeditor-configure'
 import TagCreateIntent from './tag-create'
 import TagUpdateIntent from './tag-update'
+import TagDeleteIntent from './tag-update'
+
 
 export {
   Intent as default,
@@ -46,5 +48,6 @@ export {
   EntryEditorResetToDefaultIntent as EntryEditorResetToDefault,
   EntryEditorConfigureIntent as EntryEditorConfigure,
   TagCreateIntent as TagCreate,
-  TagUpdateIntent as TagUpdate
+  TagUpdateIntent as TagUpdate,
+  TagDeleteIntent as TagDelete
 }

--- a/src/lib/intent/tag-delete.ts
+++ b/src/lib/intent/tag-delete.ts
@@ -1,0 +1,49 @@
+import Intent from './base-intent'
+import { TagDeleteAction } from '../action/tag-delete'
+import chalk from 'chalk'
+import { PlanMessage } from '../interfaces/plan-message'
+
+export default class TagDeleteIntent extends Intent {
+  isTagIntent (): boolean {
+    return true
+  }
+
+  getTagId (): string {
+    return this.payload.tagId
+  }
+
+  isTagDelete () {
+    return true
+  }
+
+  groupsWith (): boolean {
+    return false
+  }
+
+  endsGroup (): boolean {
+    return true
+  }
+
+  shouldSave (): boolean {
+    return false
+  }
+
+  shouldPublish (): boolean {
+    // TODO: Do we need this in general in tag classes?
+    return false
+  }
+
+  toActions () {
+    return [
+      new TagDeleteAction(this.getTagId())
+    ]
+  }
+
+  toPlanMessage (): PlanMessage {
+    return {
+      heading: chalk`Delete Content Type {bold.yellow ${this.getTagId()}}`,
+      details: [],
+      sections: []
+    }
+  }
+}

--- a/src/lib/intent/tag-delete.ts
+++ b/src/lib/intent/tag-delete.ts
@@ -41,7 +41,7 @@ export default class TagDeleteIntent extends Intent {
 
   toPlanMessage (): PlanMessage {
     return {
-      heading: chalk`Delete Content Type {bold.yellow ${this.getTagId()}}`,
+      heading: chalk`Delete Tag {bold.yellow ${this.getTagId()}}`,
       details: [],
       sections: []
     }

--- a/src/lib/intent/tag-update.ts
+++ b/src/lib/intent/tag-update.ts
@@ -2,6 +2,7 @@ import Intent from './base-intent'
 import { TagUpdateAction } from '../action/tag-update'
 import { PlanMessage } from '../interfaces/plan-message'
 import chalk from 'chalk'
+import { entries } from 'lodash'
 
 export default class TagUpdateIntent extends Intent {
   isTagIntent (): boolean {
@@ -41,8 +42,9 @@ export default class TagUpdateIntent extends Intent {
   }
 
   toPlanMessage (): PlanMessage {
-
-    const details = []
+    const details = entries(this.payload.props).map(([key, value]) => {
+      return chalk`{italic ${key}}: ${JSON.stringify(value)}`
+    })
 
     return {
       heading: chalk`Update Tag {bold.yellow ${this.getTagId()}}`,

--- a/src/lib/interfaces/intent.ts
+++ b/src/lib/interfaces/intent.ts
@@ -36,6 +36,7 @@ interface Intent {
   isTagIntent (): boolean
   isTagCreate (): boolean
   isTagUpdate (): boolean
+  isTagDelete (): boolean
 
   isComposedIntent (): boolean
 

--- a/src/lib/interfaces/intent.ts
+++ b/src/lib/interfaces/intent.ts
@@ -35,6 +35,7 @@ interface Intent {
   isSidebarUpdate (): boolean
   isTagIntent (): boolean
   isTagCreate (): boolean
+  isTagUpdate (): boolean
 
   isComposedIntent (): boolean
 

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -175,6 +175,9 @@ const errorCreators: ErrorCreators = {
     update: {
       TAG_NAME_ALREADY_EXISTS: (name) => {
         return `Tag with name "${name}" already exists.`
+      },
+      TAG_NOT_YET_CREATED: (id) => {
+        return `You cannot set a property on tag "${id}" because it has not yet been created.`
       }
     }
   },

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -171,13 +171,18 @@ const errorCreators: ErrorCreators = {
       TAG_ALREADY_EXISTS: (id) => {
         return `Tag with id "${id}" already exists.`
       }
-    }
+    },
+    update: {
+      TAG_NAME_ALREADY_EXISTS: (name) => {
+        return `Tag with name "${name}" cannot be created more than once.`
+      },
+    },
   },
   generic: {
     DUPLICATE_PROP: (prop, type, id) => {
       return `You are setting the property "${prop}" on ${type} "${id}" more than once. Please set it only once.`
     }
   }
-}
+}  
 
 export default errorCreators

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -174,7 +174,7 @@ const errorCreators: ErrorCreators = {
     },
     update: {
       TAG_NAME_ALREADY_EXISTS: (name) => {
-        return `Tag with name "${name}" cannot be created more than once.`
+        return `Tag with name "${name}" already exists.`
       },
     },
   },

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -179,6 +179,17 @@ const errorCreators: ErrorCreators = {
       TAG_NOT_YET_CREATED: (id) => {
         return `You cannot set a property on tag "${id}" because it has not yet been created.`
       }
+    },
+    delete: {
+      TAG_DOES_NOT_EXIST: (id) => {
+        return `You cannot delete TAG "${id}" because it does not exist.`
+      },
+      TAG_ALREADY_DELETED: (id) => {
+        return `Tag with id "${id}" cannot be deleted more than once.`
+      },
+      EDIT_AFTER_DELETE: (id) => {
+        return `Tag with id "${id}" cannot be edited because it was deleted before.`
+      }
     }
   },
   generic: {

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -173,16 +173,19 @@ const errorCreators: ErrorCreators = {
       }
     },
     update: {
-      TAG_NAME_ALREADY_EXISTS: (name) => {
-        return `Tag with name "${name}" already exists.`
-      },
       TAG_NOT_YET_CREATED: (id) => {
         return `You cannot set a property on tag "${id}" because it has not yet been created.`
+      },
+      TAG_DOES_NOT_EXIST: (id) => {
+        return `You cannot set a property on tag "${id}" because it does not exist.`
+      },
+      TAG_NAME_ALREADY_EXISTS: (name) => {
+        return `Tag with name "${name}" already exists.`
       }
     },
     delete: {
       TAG_DOES_NOT_EXIST: (id) => {
-        return `You cannot delete TAG "${id}" because it does not exist.`
+        return `You cannot delete tag "${id}" because it does not exist.`
       },
       TAG_ALREADY_DELETED: (id) => {
         return `Tag with id "${id}" cannot be deleted more than once.`

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -175,14 +175,14 @@ const errorCreators: ErrorCreators = {
     update: {
       TAG_NAME_ALREADY_EXISTS: (name) => {
         return `Tag with name "${name}" already exists.`
-      },
-    },
+      }
+    }
   },
   generic: {
     DUPLICATE_PROP: (prop, type, id) => {
       return `You are setting the property "${prop}" on ${type} "${id}" more than once. Please set it only once.`
     }
   }
-}  
+}
 
 export default errorCreators

--- a/src/lib/migration-chunks/validation/tag.ts
+++ b/src/lib/migration-chunks/validation/tag.ts
@@ -32,6 +32,98 @@ class DuplicateCreate implements TagValidation {
   }
 }
 
+class EditBeforeCreates implements TagValidation {
+  validate (intent: Intent, context: ValidationContext) {
+    const isRelevant = intent.isTagUpdate()
+
+    if (!isRelevant) {
+      return
+    }
+
+    const checkTagId = (tagId) => {
+      const exists = context.remote.has(tagId) || context.created.has(tagId)
+      const willBeCreated = context.toBeCreated.has(tagId)
+      return { tagId, exists, willBeCreated }
+    }
+
+    const tagId = intent.getTagId()
+    const { exists, willBeCreated } = checkTagId(tagId)
+
+    if (exists || !willBeCreated) {
+      return
+    }
+
+    if (intent.isTagUpdate()) {
+      return tagErrors.update.TAG_NOT_YET_CREATED(tagId)
+    }
+  }
+}
+
+class EditBeforeCreate implements TagValidation {
+  validate (intent: Intent, context: ValidationContext) {
+    const isRelevant = intent.isTagUpdate()
+
+    if (!isRelevant) {
+      return
+    }
+
+    const checkTagId = (tagId) => {
+      const exists = context.remote.has(tagId) || context.created.has(tagId)
+      // TODO Check to be created
+      const willBeCreated = context.toBeCreated.has(tagId)
+
+      return { tagId, exists, willBeCreated }
+    }
+
+    const tagId = intent.getTagId()
+    const { exists, willBeCreated } = checkTagId(tagId)
+
+    if (exists || !willBeCreated) {
+      return
+    }
+
+    if (intent.isTagUpdate()) {
+      return tagErrors.update.TAG_NOT_YET_CREATED(tagId)
+    }
+
+    if (intent.isContentTransform()) {
+      return tagErrors.transformEntries.TRANSFORM_BEFORE_TAG_CREATE(tagId)
+    }
+  }
+}
+
+class NonExistingEdits implements TagValidation {
+  validate (intent: Intent, context: ValidationContext) {
+    const isRelevant = intent.isTagUpdate()
+
+    if (!isRelevant) {
+      return
+    }
+
+    const checkTagId = (tagId) => {
+      const exists = context.remote.has(tagId) || context.created.has(tagId)
+      const willBeCreated = context.toBeCreated.has(tagId)
+
+      return { tagId, exists, willBeCreated }
+    }
+
+    const tagId = intent.getTagId()
+    const { exists, willBeCreated } = checkTagId(tagId)
+
+    if (exists || willBeCreated) {
+      return
+    }
+
+    if (intent.isTagUpdate()) {
+      return tagErrors.update.TAG_DOES_NOT_EXIST(tagId)
+    }
+
+    if (intent.isContentTransform()) {
+      return tagErrors.transformEntries.TAG_DOES_NOT_EXIST(tagId)
+    }
+  }
+}
+
 class AlreadyExistingIdCreates implements TagValidation {
   message = tagErrors.create.TAG_ALREADY_EXISTS
   validate (intent: Intent, context: ValidationContext) {
@@ -66,38 +158,90 @@ class AlreadyExistingNameUpdates implements TagValidation {
   }
 }
 
-class EditBeforeCreates implements TagValidation {
+// TODO: Is all the deleted logic tested?
+
+// TODO
+class NonExistingDeletes implements TagValidation {
   validate (intent: Intent, context: ValidationContext) {
-    const isRelevant = intent.isTagUpdate()
-
-    if (!isRelevant) {
+    if (!intent.isTagDelete()) {
       return
-    }
-
-    const checkTagId = (tagId) => {
-      const exists = context.remote.has(tagId) || context.created.has(tagId)
-      const willBeCreated = context.toBeCreated.has(tagId)
-      return { tagId, exists, willBeCreated }
     }
 
     const tagId = intent.getTagId()
-    const { exists, willBeCreated } = checkTagId(tagId)
 
-    if (exists || !willBeCreated) {
+    if (context.remote.has(tagId) || context.deleted.has(tagId)) {
       return
     }
 
-    if (intent.isTagUpdate()) {
-      return tagErrors.update.TAG_NOT_YET_CREATED(tagId)
-    }
+    return tagErrors.delete.TAG_DOES_NOT_EXIST(tagId)
   }
 }
+
+// // TODO Adjust and test:
+
+// class DuplicateDeletes implements TagValidation {
+//   validate (intent: Intent, context: ValidationContext) {
+//     if (!intent.isTagDelete()) {
+//       return
+//     }
+
+//     const tagId = intent.getTagId()
+
+//     if (!context.deleted.has(tagId)) {
+//       return
+//     }
+
+//     return tagErrors.delete.TAG_ALREADY_DELETED(tagId)
+//   }
+// }
+
+// class EditsAfterDeletes implements TagValidation {
+//   validate (intent: Intent, context: ValidationContext) {
+//     const isRelevant = intent.isFieldUpdate() || intent.isTagUpdate() || intent.isContentTransform() || intent.isEntryDerive()
+
+//     if (!isRelevant) {
+//       return
+//     }
+
+//     const checkTagId = (tagId) => {
+//       const deleted = context.deleted.has(tagId)
+//       return { tagId, deleted }
+//     }
+
+//     if (intent.isEntryDerive()) {
+//       return intent.getRelatedTagIds()
+//         .map(checkTagId)
+//         .filter(({ deleted }) => {
+//           return deleted
+//         })
+//         .map(({ tagId }) => tagErrors.deriveEntries.DERIVE_AFTER_TAG_DELETE(tagId))
+//     }
+
+//     const tagId = intent.getTagId()
+//     const { deleted } = checkTagId(tagId)
+
+//     if (!deleted) {
+//       return
+//     }
+
+//     if (intent.isTagUpdate() || intent.isFieldUpdate()) {
+//       return tagErrors.delete.EDIT_AFTER_DELETE(tagId)
+//     }
+
+//     if (intent.isContentTransform()) {
+//       return Errors.transformEntries.TRANSFORM_AFTER_TAG_DELETE(tagId)
+//     }
+//   }
+// }
 
 const checks: TagValidation[] = [
   new DuplicateCreate(),
   new AlreadyExistingIdCreates(),
   new AlreadyExistingNameUpdates(),
-  new EditBeforeCreates()
+  new EditBeforeCreates(),
+  new NonExistingEdits(),
+  new EditBeforeCreate(),
+  new NonExistingDeletes()
 ]
 
 export default function (intents: Intent[], tags: Tag[]): InvalidActionError[] {
@@ -148,6 +292,11 @@ export default function (intents: Intent[], tags: Tag[]): InvalidActionError[] {
       context.deleted.delete(tagId)
     }
 
+    if (intent.isTagDelete()) {
+      context.deleted.add(tagId)
+      context.remote.delete(tagId)
+      context.created.delete(tagId)
+    }
   }
 
   return errors

--- a/src/lib/migration-chunks/validation/tag.ts
+++ b/src/lib/migration-chunks/validation/tag.ts
@@ -125,9 +125,6 @@ class AlreadyExistingNameUpdates implements TagValidation {
   }
 }
 
-// TODO: Is all the deleted logic tested?
-
-// TODO
 class NonExistingDeletes implements TagValidation {
   validate (intent: Intent, context: ValidationContext) {
     if (!intent.isTagDelete()) {
@@ -143,8 +140,6 @@ class NonExistingDeletes implements TagValidation {
     return tagErrors.delete.TAG_DOES_NOT_EXIST(tagId)
   }
 }
-
-// // TODO Adjust and test:
 
 class DuplicateDeletes implements TagValidation {
   validate (intent: Intent, context: ValidationContext) {

--- a/src/lib/migration-chunks/validation/tag.ts
+++ b/src/lib/migration-chunks/validation/tag.ts
@@ -49,9 +49,27 @@ class AlreadyExistingCreates implements TagValidation {
   }
 }
 
+class AlreadyExistingNameUpdates implements TagValidation {
+  message = tagErrors.update.TAG_NAME_ALREADY_EXISTS
+  validate (intent: Intent, context: ValidationContext) {
+    if (!intent.isTagUpdate()) {
+      return
+    }
+
+    const tagName = intent.toRaw().payload.props.name
+
+    if (!context.remoteTags.find(tag => tag.name === tagName)) {
+      return
+    }
+
+    return tagErrors.update.TAG_NAME_ALREADY_EXISTS(tagName)
+  }
+}
+
 const checks: TagValidation[] = [
   new DuplicateCreate(),
-  new AlreadyExistingCreates()
+  new AlreadyExistingCreates(),
+  new AlreadyExistingNameUpdates()
 ]
 
 export default function (intents: Intent[], tags: Tag[]): InvalidActionError[] {

--- a/src/lib/migration-chunks/validation/tag.ts
+++ b/src/lib/migration-chunks/validation/tag.ts
@@ -93,7 +93,6 @@ class EditBeforeCreates implements TagValidation {
   }
 }
 
-
 const checks: TagValidation[] = [
   new DuplicateCreate(),
   new AlreadyExistingIdCreates(),

--- a/src/lib/migration-steps/action-creators.ts
+++ b/src/lib/migration-steps/action-creators.ts
@@ -357,6 +357,19 @@ const actionCreators = {
           }
         }
       })
+    },
+    delete: (id, instanceId, callsite): Intents.TagDelete => {
+      return new Intents.TagDelete({
+        type: 'tag/delete',
+        meta: {
+          tagInstanceId: `tag/${id}/${instanceId}`,
+          callsite: {
+            file: callsite.getFileName(),
+            line: callsite.getLineNumber()
+          }
+        },
+        payload: { tagId: id }
+      })
     }
   }
 }

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -363,18 +363,15 @@ export async function migration (migrationCreator: Function, makeRequest: Functi
 
     editTag: function (id, changes) {
       const instanceId = instanceIdManager.getNew(id)
-
       const ct = new Tag(id, instanceId, changes, dispatch)
-
       return ct
-    }
+    },
 
-    // TODO
-    // deleteTag: function (id) {
-    //   const callsite = getFirstExternalCaller()
-    //   const instanceId = instanceIdManager.getNew(id)
-    //   // dispatch(actionCreators.contentType.delete(id, instanceId, callsite))
-    // }
+    deleteTag: function (id) {
+      const callsite = getFirstExternalCaller()
+      const instanceId = instanceIdManager.getNew(id)
+      dispatch(actionCreators.tag.delete(id, instanceId, callsite))
+    }
   }
 
   // Create the migration

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -367,7 +367,7 @@ export async function migration (migrationCreator: Function, makeRequest: Functi
       const ct = new Tag(id, instanceId, changes, dispatch)
 
       return ct
-    },
+    }
 
     // TODO
     // deleteTag: function (id) {

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -359,8 +359,22 @@ export async function migration (migrationCreator: Function, makeRequest: Functi
       dispatch(actionCreators.tag.create(id, instanceId, callsite))
 
       return new Tag(id, instanceId, init, dispatch)
-    }
+    },
 
+    editTag: function (id, changes) {
+      const instanceId = instanceIdManager.getNew(id)
+
+      const ct = new Tag(id, instanceId, changes, dispatch)
+
+      return ct
+    },
+
+    // TODO
+    // deleteTag: function (id) {
+    //   const callsite = getFirstExternalCaller()
+    //   const instanceId = instanceIdManager.getNew(id)
+    //   // dispatch(actionCreators.contentType.delete(id, instanceId, callsite))
+    // }
   }
 
   // Create the migration

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -35,8 +35,7 @@ export enum ApiHook {
   PublishContentType = 'PUBLISH_CONTENT_TYPE',
   UnpublishContentType = 'UNPUBLISH_CONTENT_TYPE',
   DeleteContentType = 'DELETE_CONTENT_TYPE',
-  SaveTag = 'SAVE_TAG',
-  DeleteTag = 'DELETE_TAG'
+  SaveTag = 'SAVE_TAG'
 }
 
 const saveContentTypeRequest = function (ct: ContentType): Request {
@@ -153,8 +152,7 @@ const deleteTagRequest = function (tag: Tag): Request {
     url: `/tags/${tag.id}`,
     headers: {
       'X-Contentful-Version': tag.version
-    },
-    data: tag.toApiTag()
+    }
   }
 }
 
@@ -338,7 +336,7 @@ class OfflineAPI {
     await this.publishedContentTypes.delete(id)
     await this.savedContentTypes.delete(id)
 
-    // TODO: Where is the DeleteContentType hook actually being implemented?
+    // TODO: Is the DeleteContentType hook actually being implemented?
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.DeleteContentType)) {
         const errors = validator.validate(ct, this.savedContentTypes.get(id), this.publishedContentTypes.get(id))
@@ -587,20 +585,10 @@ class OfflineAPI {
     this.assertRecording()
 
     const tag = await this.getTag(id)
-    // Store clone as a request
     this.currentRequestsRecorded.push(deleteTagRequest(tag.clone()))
 
     this.modifiedTags.delete(id)
     this.savedTags.delete(id)
-
-    // TODO Do we need this in the case of tags? What does it validate
-    // that has not been validated before and were does the DeleteTag hook actually need to be implemented?
-    for (const validator of this.tagValidators) {
-      if (validator.hooks.includes(ApiHook.DeleteTag)) {
-        const errors = validator.validate(tag)
-        this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
-      }
-    }
   }
 
   async hasTag (id: string): Promise<boolean> {

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -35,7 +35,8 @@ export enum ApiHook {
   PublishContentType = 'PUBLISH_CONTENT_TYPE',
   UnpublishContentType = 'UNPUBLISH_CONTENT_TYPE',
   DeleteContentType = 'DELETE_CONTENT_TYPE',
-  SaveTag = 'SAVE_TAG'
+  SaveTag = 'SAVE_TAG',
+  DeleteTag = 'DELETE_TAG'
 }
 
 const saveContentTypeRequest = function (ct: ContentType): Request {
@@ -337,6 +338,7 @@ class OfflineAPI {
     await this.publishedContentTypes.delete(id)
     await this.savedContentTypes.delete(id)
 
+    // TODO: Where is the DeleteContentType hook actually being implemented?
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.DeleteContentType)) {
         const errors = validator.validate(ct, this.savedContentTypes.get(id), this.publishedContentTypes.get(id))
@@ -591,12 +593,14 @@ class OfflineAPI {
     this.modifiedTags.delete(id)
     this.savedTags.delete(id)
 
-    // for (const validator of this.tagValidators) {
-    //   if (validator.hooks.includes(ApiHook.DeleteTag)) {
-    //     const errors = validator.validate(tag, this.savedTags.get(id), this.publishedContentTypes.get(id))
-    //     this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
-    //   }
-    // }
+    // TODO Do we need this in the case of tags? What does it validate
+    // that has not been validated before and were does the DeleteTag hook actually need to be implemented?
+    for (const validator of this.tagValidators) {
+      if (validator.hooks.includes(ApiHook.DeleteTag)) {
+        const errors = validator.validate(tag)
+        this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
+      }
+    }
   }
 
   async hasTag (id: string): Promise<boolean> {

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -581,7 +581,6 @@ class OfflineAPI {
     return tag
   }
 
-
   async deleteTag (id: string) {
     this.assertRecording()
 

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -146,6 +146,17 @@ const saveTagRequest = function (tag: Tag): Request {
   }
 }
 
+const deleteTagRequest = function (tag: Tag): Request {
+  return {
+    method: 'DELETE',
+    url: `/tags/${tag.id}`,
+    headers: {
+      'X-Contentful-Version': tag.version
+    },
+    data: tag.toApiTag()
+  }
+}
+
 class OfflineAPI {
   private modifiedContentTypes: Map<String, ContentType> = null
   private savedContentTypes: Map<String, ContentType> = null
@@ -568,6 +579,25 @@ class OfflineAPI {
     }
 
     return tag
+  }
+
+
+  async deleteTag (id: string) {
+    this.assertRecording()
+
+    const tag = await this.getTag(id)
+    // Store clone as a request
+    this.currentRequestsRecorded.push(deleteTagRequest(tag.clone()))
+
+    this.modifiedTags.delete(id)
+    this.savedTags.delete(id)
+
+    // for (const validator of this.tagValidators) {
+    //   if (validator.hooks.includes(ApiHook.DeleteTag)) {
+    //     const errors = validator.validate(tag, this.savedTags.get(id), this.publishedContentTypes.get(id))
+    //     this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
+    //   }
+    // }
   }
 
   async hasTag (id: string): Promise<boolean> {

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -54,7 +54,6 @@ const validateContentType = function (contentType: ContentType): PayloadValidati
   })
 }
 
-// Should this function live here?
 const validateTag = function (tag: Tag): PayloadValidationError[] {
   const { error } = Joi.validate(_.omit(tag.toApiTag(), ['sys']), tagSchema, {
     abortEarly: false

--- a/test/end-to-end/assertions.js
+++ b/test/end-to-end/assertions.js
@@ -220,6 +220,41 @@ module.exports = {
         const withoutAnsiCodes = stripAnsi(result.stdout);
         expect(withoutAnsiCodes).to.include(`Derive entries from ${id}`);
       };
+    },
+    tag: {
+      create: function (id, params) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Create Tag ${id}`);
+          if (params != null) {
+            Object.keys(params).forEach((param) => {
+              expect(withoutAnsiCodes).to.include(`- ${param}: ${JSON.stringify(params[param])}`);
+            });
+          }
+        };
+      },
+      update: function (id, params) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Update Tag ${id}`);
+          if (params != null) {
+            return Object.keys(params).forEach((param) => {
+              expect(withoutAnsiCodes).to.include(`- ${param}: ${JSON.stringify(params[param])}`);
+            });
+          }
+        };
+      },
+      delete: function (id) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Delete Tag ${id}`);
+        };
+      }
     }
   },
   help: {

--- a/test/end-to-end/content-type.spec.js
+++ b/test/end-to-end/content-type.spec.js
@@ -6,7 +6,7 @@ const co = Bluebird.coroutine;
 const { expect } = require('chai');
 const assert = require('./assertions');
 const cli = require('./cli');
-const { createDevEnvironment, deleteDevEnvironment, getDevContentType } = require('../helpers/client');
+const { createDevEnvironment, deleteDevEnvironment, getDevContentType, getDevTag } = require('../helpers/client');
 
 const uuid = require('uuid');
 const ENVIRONMENT_ID = uuid.v4();
@@ -98,10 +98,12 @@ describe('apply content-type migration examples', function () {
       .expect(assert.plans.field.create('pet', { type: 'Link', name: 'Their pet', linkType: 'Entry', required: false }))
       .expect(assert.plans.contentType.update('animal'))
       .expect(assert.plans.field.create('name', { type: 'Symbol', name: 'The name of the animal', required: true, localized: true }))
+      .expect(assert.plans.tag.create('longexampletag', { name: 'long example marketing' }))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const contentTypePerson = yield getDevContentType(SOURCE_TEST_SPACE, environmentId, 'person');
         const contentTypeAnimal = yield getDevContentType(SOURCE_TEST_SPACE, environmentId, 'animal');
+        const tag = yield getDevTag(SOURCE_TEST_SPACE, environmentId, 'longexampletag');
 
         expect(contentTypePerson.name).to.eql('Person');
         expect(contentTypePerson.description).to.eql('A content type for a person');
@@ -109,6 +111,7 @@ describe('apply content-type migration examples', function () {
         expect(contentTypeAnimal.name).to.eql('Animal');
         expect(contentTypeAnimal.description).to.eql('An animal');
         expect(contentTypeAnimal.fields.length).to.eql(3);
+        expect(tag.name).to.eql('long example marketing');
         done();
       }));
   });

--- a/test/end-to-end/tag.spec.js
+++ b/test/end-to-end/tag.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// WIP !!!
+
+const Bluebird = require('bluebird');
+const co = Bluebird.coroutine;
+
+const { expect } = require('chai');
+const assert = require('./assertions');
+const cli = require('./cli');
+const { createDevEnvironment, deleteDevEnvironment, getDevContentType } = require('../helpers/client');
+
+const uuid = require('uuid');
+const ENVIRONMENT_ID = uuid.v4();
+
+const SOURCE_TEST_SPACE = process.env.CONTENTFUL_INTEGRATION_SOURCE_SPACE;
+
+
+describe('apply tag migration examples', function () {
+  this.timeout(30000);
+  let environmentId;
+
+  before(co(function * () {
+    this.timeout(30000);
+    environmentId = yield createDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
+  }));
+
+  after(co(function * () {
+    yield deleteDevEnvironment(SOURCE_TEST_SPACE, environmentId);
+  }));
+
+  it('aborts 28-create-tag-migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/28-create-tag.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.tag.create('sampletag', { name: 'marketing' }))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  // TODO Add more end to end tests similar to the ones in content-type.spec
+});

--- a/test/end-to-end/tag.spec.js
+++ b/test/end-to-end/tag.spec.js
@@ -1,35 +1,29 @@
 'use strict';
 
-// WIP !!!
-
-const Bluebird = require('bluebird');
-const co = Bluebird.coroutine;
-
 const { expect } = require('chai');
 const assert = require('./assertions');
 const cli = require('./cli');
-const { createDevEnvironment, deleteDevEnvironment, getDevContentType } = require('../helpers/client');
+const { createDevEnvironment, deleteDevEnvironment, getDevTag } = require('../helpers/client');
 
 const uuid = require('uuid');
 const ENVIRONMENT_ID = uuid.v4();
 
 const SOURCE_TEST_SPACE = process.env.CONTENTFUL_INTEGRATION_SOURCE_SPACE;
 
-
 describe('apply tag migration examples', function () {
   this.timeout(30000);
   let environmentId;
 
-  before(co(function * () {
+  before(async function () {
     this.timeout(30000);
-    environmentId = yield createDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
-  }));
+    environmentId = await createDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
+  });
 
-  after(co(function * () {
-    yield deleteDevEnvironment(SOURCE_TEST_SPACE, environmentId);
-  }));
+  after(async function () {
+    await deleteDevEnvironment(SOURCE_TEST_SPACE, environmentId);
+  });
 
-  it('aborts 28-create-tag-migration', function (done) {
+  it('aborts 28-create-tag migration', function (done) {
     cli()
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/28-create-tag.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
@@ -37,5 +31,57 @@ describe('apply tag migration examples', function () {
       .expect(assert.plans.actions.abort())
       .end(done);
   });
-  // TODO Add more end to end tests similar to the ones in content-type.spec
+
+  it('applies 28-create-tag migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/28-create-tag.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.tag.create('sampletag', { name: 'marketing' }))
+      .expect(assert.plans.actions.apply())
+      .end(async function () {
+        const tag = await getDevTag(SOURCE_TEST_SPACE, environmentId, 'sampletag');
+        expect(tag.name).to.eql('marketing');
+        done();
+      });
+  });
+
+  it('aborts 29-modify-tag migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/29-modify-tag.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.tag.update('sampletag'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+
+  it('applies 29-modify-tag migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/29-modify-tag.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('Y\n')
+      .expect(assert.plans.tag.update('sampletag', { name: 'better marketing' }))
+      .expect(assert.plans.actions.apply())
+      .end(async function () {
+        const tag = await getDevTag(SOURCE_TEST_SPACE, environmentId, 'sampletag');
+        expect(tag.name).to.eql('better marketing');
+        done();
+      });
+  });
+
+  it('applies delete-tag migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/30-delete-tag.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('Y\n')
+      .expect(assert.plans.tag.delete('sampletag'))
+      .expect(assert.plans.actions.apply())
+      .end(async function () {
+        let result;
+        try {
+          result = await getDevTag(SOURCE_TEST_SPACE, environmentId, 'sampletag');
+        } catch (err) {
+          expect(err.name).to.eql('NotFound');
+        }
+        expect(result).to.be.undefined();
+        done();
+      });
+  });
 });

--- a/test/fixtures/contentful-migration-integration.js
+++ b/test/fixtures/contentful-migration-integration.js
@@ -58,7 +58,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:31 GMT',
+  'Wed, 15 Jul 2020 11:19:27 GMT',
   'etag',
   'W/"9f8886bb475af980f12a1a32fbc74d55"',
   'referrer-policy',
@@ -80,7 +80,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd6435e071f7e6f2be3206d9d85e95823',
+  '9057a4e24052f7c3f48338535c7c2127',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -92,11 +92,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BW4VHShsTrOLVOtQIeS/dWPWDV8AAAAAQUIPAAAAAACApH2+h6v/NIRTynQmA0IF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=OtjZD+wfQNC+wQaNbQQIFj/mDl8AAAAAQUIPAAAAAAALda/NuDQPd3SPub1Ff9rZ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=X1LbFWSoqRtUgI4kKsJtVwAAAADD2AKyPU9IHQ01M1+ZJe3h; path=/; Domain=.contentful.com',
+  'nlbi_673446=Pc1ZQsDu9DLwr0RLKsJtVwAAAAAkiHAGCrbGQuepjm2WWS5J; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=wJ6dIDWAbxxxtflMOoVtA2PWDV8AAAAA4Jl2krP+lLLEGiic5pujYg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=h1SFLXXJ+F6S8A5OOoVtAz/mDl8AAAAAO3G0uysaUF/JUznRo34BMQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -104,12 +104,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-5255586-5255587 NNYN CT(90 90 0) RT(1594742370761 41) q(0 0 1 -1) r(3 3) U5'
+  '13-35990224-35990249 NNYN CT(91 87 0) RT(1594811966954 36) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration', {"name":"env-integration"})
-  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-14T15:59:32Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-14T15:59:32Z"}}, [
+  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-15T11:19:28Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T11:19:28Z"}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -131,9 +131,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:32 GMT',
+  'Wed, 15 Jul 2020 11:19:28 GMT',
   'etag',
-  'W/"4f05bbd781578a262c5dfe3e24b0ce22"',
+  'W/"181d13d6b5da34be69e3b92f3f801712"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -145,15 +145,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'dea219f2244834711e05121a1a79f22c',
+  'be027272b2a90c1bf60d123910621e90',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -167,15 +167,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=wutDcZboRgWJnel0gjhEUWTWDV8AAAAAQUIPAAAAAAA/aPftnwhIcRuE+o70SdhY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3JwtreFiS8CK3kjx7BbNd0DmDl8AAAAAQUIPAAAAAAAkz/7SCe5E5hN8FWySgI74; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8hqEcq/wRxAymsiqKsJtVwAAAABCrGkRQbfgqn6+frly1SRt; path=/; Domain=.contentful.com',
+  'nlbi_673446=2wXVQyNungozxc0VKsJtVwAAAABJdJrydttwznNQtoQsYlVZ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=bmXuSz6OO2qYtvlMOoVtA2TWDV8AAAAAc5I8vgPIReO8JAWC7XFDBg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3alZBf3nCwRi8w5OOoVtA0DmDl8AAAAA3Nx+rw94v+EwNafOb+Vi8Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-5255625-5255627 NNNN CT(88 88 0) RT(1594742371337 30) q(0 0 2 -1) r(11 11) U5'
+  '11-24180819-24180829 NNNN CT(86 94 0) RT(1594811967461 35) q(0 0 2 -1) r(11 11) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -207,7 +207,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt":"2020-07-14T15:59:32Z",
+    "createdAt":"2020-07-15T11:19:28Z",
     "updatedBy":{
       "sys":{
         "type":"Link",
@@ -215,7 +215,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "updatedAt":"2020-07-14T15:59:33Z"
+    "updatedAt":"2020-07-15T11:19:29Z"
   }
 }
 
@@ -243,9 +243,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:33 GMT',
+  'Wed, 15 Jul 2020 11:19:29 GMT',
   'etag',
-  'W/"13e0007531e699aec6e7033be00b9b51"',
+  'W/"07a13e6af80e3bada83a5dc19a517648"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -265,7 +265,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bd4cae807cd58264b4df716fa62963f9',
+  '52cae5876809dd6d1a4acc4b3ece494b',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -277,11 +277,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=AUHdWSwXQbqVRRB/Lk2qeWXWDV8AAAAAQUIPAAAAAABgCWp3GEXL7Avlm2whN0iW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BJdowjuKQxOQban9jOtXb0HmDl8AAAAAQUIPAAAAAABWEW9OVmxJvkAeJpWInMfq; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LgogV+yfhmVvvG/BKsJtVwAAAABpRsGcy4rFr3xJxm+qP1+/; path=/; Domain=.contentful.com',
+  'nlbi_673446=m94XIMJPXidJ3YYRKsJtVwAAAAD0ufYdzgbHO5DKDNmaenYw; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=sDKXFS0k5RqAt/lMOoVtA2XWDV8AAAAAODr+KeBnpMAYIvXuUuE3cg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=CBJUNvw19iRG9Q5OOoVtA0HmDl8AAAAAwHA/Y3Bulik48aN7kQ2bhQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -289,7 +289,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20307479-20307503 NNYN CT(96 100 0) RT(1594742372649 38) q(0 0 2 -1) r(9 9) U5'
+  '5-23224440-23224449 NNYN CT(93 93 0) RT(1594811968691 28) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -326,7 +326,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:34 GMT',
+  'Wed, 15 Jul 2020 11:19:30 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -346,15 +346,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '1218f2bb40d8f8b4af2e412919ba51d3',
+  '09ef8eec121221461e1c1c317d7616ad',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Z2A1VxiLQiSIGCIrBXwDbGbWDV8AAAAAQUIPAAAAAACDqKOsxTCeJnX9wdX5yKUG; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mFyovW2/QOeUIGApLimCGELmDl8AAAAAQUIPAAAAAACpI28uuE/5GUqWar9ZHQ89; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=aU3PPLPbZ1ipsK+VKsJtVwAAAAB9vpdsAX6qBzQxrw6PPQBt; path=/; Domain=.contentful.com',
+  'nlbi_673446=pUWmJFYzwDZepMlBKsJtVwAAAAAgs4bPFpX+PDN6KW9ViUYy; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=fEWSGk1BYlpHuPlMOoVtA2bWDV8AAAAAtit6BtYKRYghqbgx4p/RUg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=lZYcdw7BTy6c9g5OOoVtA0LmDl8AAAAA76ZqTIMBsgtJT7eZwkoljA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -362,7 +362,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20307723-20307738 NNYN CT(87 87 0) RT(1594742373651 34) q(0 0 2 -1) r(7 7) U5'
+  '12-30361925-30361931 NNYN CT(89 88 0) RT(1594811969744 28) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -403,8 +403,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -434,9 +434,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:35 GMT',
+  'Wed, 15 Jul 2020 11:19:31 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -456,7 +456,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '7c8aa55353358ef7668ce95b19775036',
+  '60eb35385f67a6f06e21884f176c39ff',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -468,11 +468,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=oUofq5vLQ1idHx8tget/vmfWDV8AAAAAQUIPAAAAAAA7zSn6dVQz4m78c6Xgieyp; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lVAxBuPcRqSspV1DqWU5PkPmDl8AAAAAQUIPAAAAAACCcvrd76UkGSzpx0vJRRT/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=dlsTf5FfGn5tyvnrKsJtVwAAAACpEQxxMOQ/v0RgwjSpOX2E; path=/; Domain=.contentful.com',
+  'nlbi_673446=75J+UqnJJgKZWcGTKsJtVwAAAAA9kAiVulnatkS4lJzpXZZv; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=3srvUFE5R3o2uflMOoVtA2fWDV8AAAAA3bCQAw2tPM5o5DsJ4LAiJQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TUXhE4zieVcJ+Q5OOoVtA0PmDl8AAAAAlKzlnb5fBsgfhux/wSdYYw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -480,12 +480,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-17393592-17393601 NNYN CT(93 95 0) RT(1594742374483 47) q(0 0 2 -1) r(8 8) U5'
+  '14-47471192-47471217 NNYN CT(94 86 0) RT(1594811970522 34) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog', {"name":"angry dog","fields":[{"id":"woofs","name":"woof woof","type":"Number","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-14T15:59:36.539Z","updatedAt":"2020-07-14T15:59:36.539Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-15T11:19:32.579Z","updatedAt":"2020-07-15T11:19:32.579Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -507,9 +507,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:36 GMT',
+  'Wed, 15 Jul 2020 11:19:32 GMT',
   'etag',
-  '"8051465262240085603"',
+  '"12660136450868038466"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -527,21 +527,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'be1fc046553b3b419999029db1343090',
+  '7b5e05aefc0f42e5b4d7a55959090b09',
   'Content-Length',
   '1051',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=xt2bD6SCS2K+PQm41Awxl2jWDV8AAAAAQUIPAAAAAABzyi8ePgNd2JOWwU56O/ip; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qdp3WBYvSU6ynMJan2e5yUTmDl8AAAAAQUIPAAAAAAAWbmiwUCJS/75/KLKZEQCl; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=y3OjZMifsTj3bQPCKsJtVwAAAAB3cstwOFwYeJelVP1ak5Xl; path=/; Domain=.contentful.com',
+  'nlbi_673446=B9FTOWtZfXToTFPuKsJtVwAAAABCqpM7g0yNcD07cEf3mE6a; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=mO7pORgmrGUbuvlMOoVtA2jWDV8AAAAA7xgG5414nmqPhHqTcSRn5Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=f3tWFqQ2zEkZ+w5OOoVtA0TmDl8AAAAAXXuxcyN4LB3YRemgbBt+RA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26987702-26987714 NNNN CT(93 93 0) RT(1594742375529 36) q(0 0 2 -1) r(10 10) U5'
+  '5-23224843-23224849 NNNN CT(88 88 0) RT(1594811971545 35) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -557,8 +557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:37.439Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:33.294Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -582,8 +582,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
-    "publishedAt": "2020-07-14T15:59:37.439Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T11:19:33.294Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -633,9 +633,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:37 GMT',
+  'Wed, 15 Jul 2020 11:19:33 GMT',
   'etag',
-  'W/"7761196522538835660"',
+  'W/"14340618065612228904"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -653,21 +653,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '3f3396b1354164ef2d4c3aeb13e62055',
+  'e811bb86af4ad72b27579909b08a2bc0',
   'Content-Length',
-  '441',
+  '442',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=M60Gv1RiQ3uXwmhpfdr6gmnWDV8AAAAAQUIPAAAAAADTc+ecL/HUb/m1l3Xs6PQB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mgM+ebC+TLeLQKnFVzm7lUXmDl8AAAAAQUIPAAAAAADsGz0HzdBjlfCYaJM3G+Mn; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hG9CC9nLO3Tx9FIrKsJtVwAAAAAT/3OkWshYLAU3u0NekiuX; path=/; Domain=.contentful.com',
+  'nlbi_673446=f41DItStEUUjsImkKsJtVwAAAADR/AiN9nQXDAoiR1RJvbA5; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=SCG+NlAo7R/yuvlMOoVtA2nWDV8AAAAA/oxLfQXACS3Z/TaTjiFYMQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=uaqpVOCORQBa/Q5OOoVtA0XmDl8AAAAAOTdztRoSRsxpeksnIHBNWg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17394102-17394114 NNNN CT(93 93 0) RT(1594742376737 32) q(0 0 2 -1) r(8 8) U5'
+  '12-30362632-30362654 NNNN CT(93 93 0) RT(1594811972443 34) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -683,8 +683,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:37.439Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:33.294Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -693,8 +693,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T15:59:37.439Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:33.294Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -759,9 +759,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:38 GMT',
+  'Wed, 15 Jul 2020 11:19:33 GMT',
   'etag',
-  'W/"6448194171137651990"',
+  'W/"6893380049824259986"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -771,29 +771,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '38f1f736a9467dd6dea2ffd5d6707dba',
+  '3ae26c480394dfaf0606691c31b23533',
   'Content-Length',
-  '442',
+  '443',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=RQb12jjUSmyzy+h5HNF01GrWDV8AAAAAQUIPAAAAAABEs9yPl8ALtVi69ZZLq0fr; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=68PPcDAnRAOxxA8h/d2S9UXmDl8AAAAAQUIPAAAAAAAxg6yh/Vk59v+v8uLX/Qs+; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gOPgNthJpx38X0IoKsJtVwAAAACjLq9A+l65VWHkuBunh7sQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=XYOCfI3CuATEE1snKsJtVwAAAACguCv4gf7gaYyBotSHPDFP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0oanIKDgdEVzu/lMOoVtA2rWDV8AAAAAGiz+fuy6f3e/kFexe6DcDA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=uhrwXJQlihmS/g5OOoVtA0XmDl8AAAAAvsKIbi5AJ0aU4IAsvJ77hQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26988438-26988449 NNNN CT(93 93 0) RT(1594742377640 35) q(0 0 2 -1) r(4 4) U5'
+  '11-24182207-24182216 NNNN CT(86 87 0) RT(1594811973186 32) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -818,8 +818,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-14T15:59:36.539Z",
-        "updatedAt": "2020-07-14T15:59:37.439Z",
+        "createdAt": "2020-07-15T11:19:32.579Z",
+        "updatedAt": "2020-07-15T11:19:33.294Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -828,8 +828,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-14T15:59:37.439Z",
-        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+        "publishedAt": "2020-07-15T11:19:33.294Z",
+        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -896,9 +896,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:43 GMT',
+  'Wed, 15 Jul 2020 11:19:39 GMT',
   'etag',
-  'W/"13692349416730014677"',
+  'W/"13189261227178789964"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -916,21 +916,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '2c25490411a2f5274c0b587295fad6c3',
+  'e20f3a3f6f43f5877c1cc0a9fda36d57',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=8pgkA6JNSJSNwmbyvWuebW/WDV8AAAAAQUIPAAAAAAC141GqaA9Z0mwL4tje+hV/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=e4tPep2kQSio2GdvkOp8ukvmDl8AAAAAQUIPAAAAAAAxrp1oC124gh/lUjPawakK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8Xy/QysRmUpj75hjKsJtVwAAAAAvRozKcRNlCBqID4EDUE49; path=/; Domain=.contentful.com',
+  'nlbi_673446=8zCdRsp0nF7gRzpRKsJtVwAAAACS+efxRctrBAakwfqTU96u; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=nXqtGpkzcz/GwflMOoVtA2/WDV8AAAAAwvSciVT3bAHHfT2VIimEow==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=PqDUYarmQkgWCw9OOoVtA0vmDl8AAAAAI2VEfxesUf8XJl4YSAIUfQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13770450-13770453 NNNN CT(91 91 0) RT(1594742383161 33) q(0 0 2 -1) r(4 4) U5'
+  '10-14419177-14419183 NNNN CT(93 94 0) RT(1594811978896 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -971,8 +971,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -1002,9 +1002,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:45 GMT',
+  'Wed, 15 Jul 2020 11:19:40 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -1024,7 +1024,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '397be94a0c89e7cd868c0d4309403b35',
+  '49983f168ae40e728708090e274c98dd',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -1036,11 +1036,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=WvetzpFrTyyJoEF8iX4J5HHWDV8AAAAAQUIPAAAAAACcBqF5wTFRp4v9nkDd/yQs; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=E3Gf1qzuS3ann0j1SvLhA0zmDl8AAAAAQUIPAAAAAAD/CMH1Rf1jMQOeatvemmsz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=B8DEOLkjsBWHyMOiKsJtVwAAAACy00VjC+uwoLurtAEfCdlh; path=/; Domain=.contentful.com',
+  'nlbi_673446=KazSVsj6xFrpYEnfKsJtVwAAAABog+DeMsZysQo56FwGrm8i; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=7F5qEpUj43iaxPlMOoVtA3HWDV8AAAAA3zXCqzDhzLc0Jo9cADwNmQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1WnEG7r+KEy/DQ9OOoVtA0zmDl8AAAAAJRG7hRxkpFMhCYO74P2e2w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1048,7 +1048,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-26990724-26990733 NNYN CT(88 87 0) RT(1594742384689 34) q(0 0 1 -1) r(8 8) U5'
+  '12-30364540-30364554 NNYN CT(86 89 0) RT(1594811979531 43) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1064,8 +1064,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:46.518Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:41.491Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1074,8 +1074,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T15:59:37.439Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:33.294Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1140,9 +1140,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:46 GMT',
+  'Wed, 15 Jul 2020 11:19:41 GMT',
   'etag',
-  'W/"17009879483529396695"',
+  'W/"18145230863164173062"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1160,21 +1160,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '41b955b2e0c9409aabe01cd293841ecd',
+  '555f148d9f2db6e96dacef1bdbe402b9',
   'Content-Length',
-  '446',
+  '448',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3ERSb8OpTvG9RANrWps2pHLWDV8AAAAAQUIPAAAAAADtKcJakwPDwp+AbPyNmwNS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=H4OCIwYPSSmUD9ufXQxjXU3mDl8AAAAAQUIPAAAAAABqQ34TpzQFsJdYLxi15dZQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ypG+B6/uw3F24DXBKsJtVwAAAADuD0bzF74TeNJ2NgS9q6RN; path=/; Domain=.contentful.com',
+  'nlbi_673446=m1f9VEriRRFGLtjwKsJtVwAAAACJ3y6if6S9YRvylBlxaa8k; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=KQD1aMYM7C1DxflMOoVtA3LWDV8AAAAApcxeN7NjwiTzGDXptdmGWQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=whwlTZgOkGuYDw9OOoVtA03mDl8AAAAAC0rXRpXY2+od9k6+jwHuCQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-7154761-7154763 NNNN CT(86 88 0) RT(1594742385781 31) q(0 0 1 -1) r(4 4) U5'
+  '14-47474787-47474799 NNNN CT(94 87 0) RT(1594811980548 30) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1190,8 +1190,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:47.040Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:42.055Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1200,8 +1200,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T15:59:47.040Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:42.055Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1266,9 +1266,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:47 GMT',
+  'Wed, 15 Jul 2020 11:19:42 GMT',
   'etag',
-  'W/"13834337006343995036"',
+  'W/"3079181608759559087"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1278,29 +1278,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'a9853d2f0afa74d2a3c6c2ddfa97b676',
-  'transfer-encoding',
-  'chunked',
+  '0e5d993397227d0d240acdf8307bee17',
+  'Content-Length',
+  '453',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lpXKQe4HR+6BhvfZZ8891XLWDV8AAAAAQUIPAAAAAADig+8DhVUepIlLWCP/x05I; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=EAWtRyPpS1mNC2Wfdkxb903mDl8AAAAAQUIPAAAAAADAG472drdTMC65LNmvRfh/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ORSaXiJNon9rKlofKsJtVwAAAAA3BaGgb87KcTLCTbLHArPp; path=/; Domain=.contentful.com',
+  'nlbi_673446=nr9vFnXb7Ryiow/fKsJtVwAAAAD5zrbVd2HTA80brUcoRRsM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=H6R3e03VBwzExflMOoVtA3LWDV8AAAAAq7Aita1oM5u5K4qFGoL//Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1cLUWxat+y9JEQ9OOoVtA03mDl8AAAAAhE/faKHZySXIERUj+EFO5g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26991273-26991283 NNNN CT(92 94 0) RT(1594742386357 35) q(0 0 2 -1) r(5 5) U5'
+  '12-30365071-30365090 NNNN CT(103 95 0) RT(1594811981382 37) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1316,8 +1316,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:47.823Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:42.710Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1326,8 +1326,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T15:59:47.040Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:42.055Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1381,239 +1381,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:47 GMT',
+  'Wed, 15 Jul 2020 11:19:42 GMT',
   'etag',
-  'W/"2112654971627075758"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'f8155733774fa2a8b49688cff150c7ea',
-  'Content-Length',
-  '374',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=YPDr0YzNTCaAmaiN+4tREnPWDV8AAAAAQUIPAAAAAACQN0uszW2afzKu8fXLFoId; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=zHrrM8f6ZEmHEhBOKsJtVwAAAACD+KuvT8ZU36S2dw6bQjey; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=ok2/dF+ZDHBVxvlMOoVtA3PWDV8AAAAARVP4UhTp6Q1eQKs2uiS+8Q==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '3-6341568-6341570 NNNN CT(87 88 0) RT(1594742386962 58) q(0 0 1 -1) r(5 5) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:48.344Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 5,
-    "publishedAt": "2020-07-14T15:59:48.344Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 3,
-    "version": 6,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "angry dog",
-  "description": "super angry",
-  "fields": []
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 15:59:48 GMT',
-  'etag',
-  'W/"11539890348999363549"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'd8c3b23bc8db1af197a68f26a74d9369',
-  'Content-Length',
-  '370',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=L6D0y1thSaOEI3HiH3WHUXTWDV8AAAAAQUIPAAAAAABTR1HjLF53HPmpJDhf+9FM; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=clEEX3X2ahRuCAh1KsJtVwAAAAASiHXfoRJSAIDaWWGrLBK7; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=4zyaQHLis0D2xvlMOoVtA3TWDV8AAAAAG0GbbeNX5857/PMGekRokw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '5-13522032-13522037 NNNN CT(86 89 0) RT(1594742387685 33) q(0 0 1 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:48.344Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 5,
-    "publishedAt": "2020-07-14T15:59:48.344Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 3,
-    "version": 6,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "angry dog",
-  "description": "super angry",
-  "fields": []
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 15:59:48 GMT',
-  'etag',
-  'W/"11539890348999363549"',
+  'W/"3062650862090098999"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1631,21 +1401,251 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '06eee3f8cca4c0f2724eb1267e3a7224',
+  '6e93d289f3636b3993b122cb6af21b27',
+  'Content-Length',
+  '374',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=N5ca1hscRsmna5D2yTxI907mDl8AAAAAQUIPAAAAAAALzZTy3taZ4qZcD2YQEjTD; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=Du+OOCaVEn7O8IC7KsJtVwAAAADdVC3X9uvRkmb/267oUtON; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=Xm9MQLC3vEO6Eg9OOoVtA07mDl8AAAAAYvoA62vLfHVlTf/xwDR/Fg==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '4-15461784-15461789 NNNN CT(88 89 0) RT(1594811982012 26) q(0 0 2 -1) r(5 5) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:43.470Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 5,
+    "publishedAt": "2020-07-15T11:19:43.470Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 3,
+    "version": 6,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "angry dog",
+  "description": "super angry",
+  "fields": []
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:19:43 GMT',
+  'etag',
+  'W/"16647505954805289641"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'e5ae6a72603ee6075be76b43b4ff09f0',
+  'Content-Length',
+  '370',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=Ib8r5hCjQ6alpxWvhYx6aU/mDl8AAAAAQUIPAAAAAABpR8WenXhihyARMVYSO8DY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=UKUyYvJZkUEfU79iKsJtVwAAAADgNVMOK6603V/bGXUNRuMc; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=AMekXeMhu1xgFA9OOoVtA0/mDl8AAAAAgJxC86wo2FGsbYS0TeP7xg==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '10-14419770-14419781 NNNN CT(88 88 0) RT(1594811982814 28) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:43.470Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 5,
+    "publishedAt": "2020-07-15T11:19:43.470Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 3,
+    "version": 6,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "angry dog",
+  "description": "super angry",
+  "fields": []
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:19:44 GMT',
+  'etag',
+  'W/"16647505954805289641"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '241c707dc195654eb76b83a0cf30e1d8',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=RfQT7OpWQCqJjS3RQGXZDnTWDV8AAAAAQUIPAAAAAAAj2cAy6Pr0xu6nvvDXmnhT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=TPbXu+HvTOWqmArYRXnjLk/mDl8AAAAAQUIPAAAAAADwoXBDlX463SFkPRUIEgWv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=einhHP9sCyWkAv+yKsJtVwAAAADckfOrH4npyWnL++0kJDin; path=/; Domain=.contentful.com',
+  'nlbi_673446=c+Y3fg5DkX7LW1vFKsJtVwAAAAD81s9kUHLtiq9HeLC4CYD+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=LwAfIAXfRThUx/lMOoVtA3TWDV8AAAAABGSIDti7bpy5AHY3/+THKg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=SeSrKBzbvVfnFQ9OOoVtA0/mDl8AAAAAPJmCD6oBIhUk2anxghQ34A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20311444-20311449 NNNN CT(93 95 0) RT(1594742388231 30) q(0 0 2 -1) r(4 4) U5'
+  '13-35995428-35995439 NNNN CT(88 91 0) RT(1594811983439 31) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1670,8 +1670,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-14T15:59:36.539Z",
-        "updatedAt": "2020-07-14T15:59:48.344Z",
+        "createdAt": "2020-07-15T11:19:32.579Z",
+        "updatedAt": "2020-07-15T11:19:43.470Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -1680,8 +1680,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 5,
-        "publishedAt": "2020-07-14T15:59:48.344Z",
-        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+        "publishedAt": "2020-07-15T11:19:43.470Z",
+        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -1737,9 +1737,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:49 GMT',
+  'Wed, 15 Jul 2020 11:19:45 GMT',
   'etag',
-  'W/"18429099488360793111"',
+  'W/"3508040354696139078"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1757,21 +1757,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bbfe6999bef951562523222dac723811',
+  '3a3471d93430a0ef0d749cc9cff878e7',
   'Content-Length',
-  '435',
+  '436',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=auzuvkEMRxSIo/wRTjdqCXXWDV8AAAAAQUIPAAAAAACSlLeu6USKSgd/AevFofX6; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MPQPDgkDRxm54vUPwSoL4FHmDl8AAAAAQUIPAAAAAABGURNsMMSYfSBykAPUfFq4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ewLBaU5rnTrositlKsJtVwAAAAB/9aEhhVsdyZCo0psas50t; path=/; Domain=.contentful.com',
+  'nlbi_673446=QTDsW1ujdGSglcdmKsJtVwAAAAD20iCAyiYJ9kHlMRMY2mJp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=vZ0HaVDSMCLNx/lMOoVtA3XWDV8AAAAAHOdwsgvl56r92Wql83wqsQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=pW/DcSa4EUPeGA9OOoVtA1HmDl8AAAAAyjyVzYQysAex9LxK+2WdEw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13771248-13771253 NNNN CT(92 91 0) RT(1594742388763 32) q(0 0 2 -1) r(4 4) U5'
+  '8-4528566-4528567 NNNN CT(85 86 0) RT(1594811984832 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1812,8 +1812,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -1843,9 +1843,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:49 GMT',
+  'Wed, 15 Jul 2020 11:19:45 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -1865,7 +1865,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '0eb6e6c3b63f1364a29b0c8c58108c51',
+  '044443985adf123173a17d71b3bc6204',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -1877,11 +1877,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=rNbJHEqRTICUxqYsMyNRG3XWDV8AAAAAQUIPAAAAAADuBfgyz3/31kt2KsxjY+1r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=+RetEnrYTEu3TGIO741dMlHmDl8AAAAAQUIPAAAAAAD5Avf3X0H8UVRAzqkkAMMU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=nHE6fw01SG1BO2o7KsJtVwAAAABHdgwWhFfWvWGKG+gUMpjG; path=/; Domain=.contentful.com',
+  'nlbi_673446=7Qk8bJ9UumTB8P0DKsJtVwAAAAChwyJ2EGe8DTjvSJ992CdB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=5SnncTPNYH49yPlMOoVtA3XWDV8AAAAALL9qxm+5qygmSOTzciVidA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=l3w6ML1uWy7PGQ9OOoVtA1HmDl8AAAAA7zFaeNkdLaendgKXG/NIjg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1889,7 +1889,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-6341732-6341735 NNYN CT(92 92 0) RT(1594742389219 34) q(0 0 2 -1) r(3 3) U5'
+  '3-10880458-10880460 NNYN CT(88 88 0) RT(1594811985383 27) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1905,8 +1905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:50.328Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:46.629Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1915,8 +1915,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-14T15:59:48.344Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:43.470Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1981,9 +1981,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:50 GMT',
+  'Wed, 15 Jul 2020 11:19:46 GMT',
   'etag',
-  'W/"7991568740491863076"',
+  'W/"13317033406405494459"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2001,21 +2001,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a980d805eee771b0a8ddc43126a16820',
+  '4ffa9010bfa38eb324fbc632ddcbd534',
   'Content-Length',
-  '496',
+  '497',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NUFd+Il5RTG2qVcFcpBWrnbWDV8AAAAAQUIPAAAAAADoHmWv2BNV5WJQPzi5MQVF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rMtnpIkxQDanScwvExSLYFLmDl8AAAAAQUIPAAAAAABgYJPcUGD6dmppVLv1IBpQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=VMo5AF5IChMOpZSfKsJtVwAAAAByoQX3G6jHXL1V6bFTm2ep; path=/; Domain=.contentful.com',
+  'nlbi_673446=STBZD2a3nFX/Lk38KsJtVwAAAABkPw+D6egM05z7gWooi6Cs; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Elf7ZP9ueU7FyPlMOoVtA3bWDV8AAAAAa804YrQyvlmnJBGhrZlBpw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ZPpIWqjK9hpaGw9OOoVtA1LmDl8AAAAAESiyJItWczHKD0sfXEwIUw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-6341754-6341759 NNNN CT(94 102 0) RT(1594742389636 33) q(0 0 2 -1) r(4 4) U5'
+  '13-35996223-35996229 NNNN CT(87 87 0) RT(1594811985882 28) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2031,8 +2031,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:50.905Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:47.155Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2041,8 +2041,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-14T15:59:50.905Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:47.155Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2107,9 +2107,135 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:51 GMT',
+  'Wed, 15 Jul 2020 11:19:47 GMT',
   'etag',
-  'W/"7028925680526682898"',
+  'W/"5694865152655047241"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'fa21bc62211d764c28340f5502a3ce09',
+  'Content-Length',
+  '493',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=MYqTGyg2SsKuciSsow2K+FLmDl8AAAAAQUIPAAAAAADgZSdWMHj1rylnhOfozead; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=we9TaEkHPHOWYUWWKsJtVwAAAAALdmwWp0qbnstMtdH8D9lT; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=m04NAyV4AC6XHA9OOoVtA1LmDl8AAAAAYY0hUfWnSVDagUEXnnAzig==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '14-47476791-47476803 NNNN CT(88 89 0) RT(1594811986504 36) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:47.155Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 7,
+    "publishedAt": "2020-07-15T11:19:47.155Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 4,
+    "version": 8,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "goodboys",
+      "name": "number of times he has been called a good boy",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:19:47 GMT',
+  'etag',
+  'W/"5694865152655047241"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2127,147 +2253,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '746bd488b2df027216de0b1e7572ce03',
+  'b0186c7903d6a23c117372476837efdf',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=WblmqFUuSE2tOttOUb4ZcHbWDV8AAAAAQUIPAAAAAABENUh2TnyVkfkucf5SLjDA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=UQ0rKlGdRguvf4in3jDSm1PmDl8AAAAAQUIPAAAAAAAHmI87WFJG4XfqyJh8Uxa1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=YCsnHt8pykLUCgUAKsJtVwAAAAAZCJWbojGNw3ZLcGWl04qE; path=/; Domain=.contentful.com',
+  'nlbi_673446=TZ80W0f1gzUzcq1qKsJtVwAAAAC9IqfnK/dvMwyKxuJNwvtz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=NEFEKfe93R5syflMOoVtA3bWDV8AAAAAZA1h/l+31hWyJnR9KBTiWQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=qKuCfh8hzxH+HQ9OOoVtA1PmDl8AAAAAjsjtJN9HtKLkPJqNe+MAXQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26992502-26992513 NNNN CT(87 94 0) RT(1594742390251 32) q(0 0 2 -1) r(5 5) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:50.905Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 7,
-    "publishedAt": "2020-07-14T15:59:50.905Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 4,
-    "version": 8,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "goodboys",
-      "name": "number of times he has been called a good boy",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 15:59:51 GMT',
-  'etag',
-  'W/"7028925680526682898"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '7bb76a067437bd26a399ef7057239821',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=LaRCNvVGQnKioux+gWUUJ3fWDV8AAAAAQUIPAAAAAADKaggsNQn4XnApWoDAKwXg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=60n7J5R6b091w7I0KsJtVwAAAAAcsz6hrJCdiChshRXZZMnb; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=FgeFQKqnOkfCyflMOoVtA3fWDV8AAAAAxvIwZ10NeOsB8JY4lMSWnw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '4-9009661-9009667 NNNN CT(93 94 0) RT(1594742390787 31) q(0 0 2 -1) r(3 3) U5'
+  '14-47476997-47477013 NNNN CT(88 89 0) RT(1594811987116 34) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2292,8 +2292,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-14T15:59:36.539Z",
-        "updatedAt": "2020-07-14T15:59:50.905Z",
+        "createdAt": "2020-07-15T11:19:32.579Z",
+        "updatedAt": "2020-07-15T11:19:47.155Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -2302,8 +2302,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 7,
-        "publishedAt": "2020-07-14T15:59:50.905Z",
-        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+        "publishedAt": "2020-07-15T11:19:47.155Z",
+        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -2370,9 +2370,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:51 GMT',
+  'Wed, 15 Jul 2020 11:19:48 GMT',
   'etag',
-  'W/"9386130412272337565"',
+  'W/"5186700402868981456"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2382,29 +2382,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '262a9f8a928cc0e6be573b443edc4cfa',
+  '1965f19bfea04faf8e6b481b74affee1',
   'Content-Length',
-  '554',
+  '556',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=pLbLjKtpT3ab6WiZJJlqInfWDV8AAAAAQUIPAAAAAADG4WmZu2j7d6mJa/1xrSOe; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YSA/xQeETX637hvFpovUelTmDl8AAAAAQUIPAAAAAAB/bfO2zgCG42E7MmtLUjHd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=uIhrRWdD6l+rUeB8KsJtVwAAAACbllGV8+3dHzi1YakHnp/i; path=/; Domain=.contentful.com',
+  'nlbi_673446=Gth4X7bJbh3IfoIiKsJtVwAAAACsbEXe8kquqNkBd5zsHJuO; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0xCxKEO2szwmyvlMOoVtA3fWDV8AAAAAwAPcF1qSUMiqOa2CklRAcA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=qx34REYQ6CcQHw9OOoVtA1TmDl8AAAAAQxhnZU+3RS/bUlYq4wXotQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26992803-26992809 NNNN CT(89 90 0) RT(1594742391249 29) q(0 0 2 -1) r(4 4) U5'
+  '4-15462394-15462401 NNNN CT(93 94 0) RT(1594811987737 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2421,7 +2421,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-14T15:59:37.648Z",
+    "createdAt": "2020-07-15T11:19:33.362Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2429,7 +2429,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T15:59:50.994Z",
+    "updatedAt": "2020-07-15T11:19:47.228Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2480,9 +2480,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:52 GMT',
+  'Wed, 15 Jul 2020 11:19:48 GMT',
   'etag',
-  '"15450428136113776622"',
+  '"16677162563861590957"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2492,23 +2492,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'dbf9419de9d6d7a2c18c902a2534b8a1',
+  '4c45a8edc9fda5135e4f8c170c009c5e',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=cZWbMZXWQdi6dFkA9nQTynjWDV8AAAAAQUIPAAAAAABhDl46ZJtXwXVXVtjlQGwx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=LkhyOekuSw2+Jilp+h8zV1TmDl8AAAAAQUIPAAAAAAATG71HNnb3NH3U72VqNbuj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JHzffeAaeDw0Q8jXKsJtVwAAAABNHvAkhgMK0SZgUqnKi0E4; path=/; Domain=.contentful.com',
+  'nlbi_673446=IBSAFo5Rs2ZcemLcKsJtVwAAAAAU14mtfyDs5qnMAM6IEErK; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=4kUbTuNI5W/zyvlMOoVtA3jWDV8AAAAALEvSTg9AxioBIVRgIIWjqA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=PTZKG1NV9EByIA9OOoVtA1TmDl8AAAAAUltNp2gcOpaxIPwP//VXEQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2516,7 +2516,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-6341882-6341886 NNYN CT(85 88 0) RT(1594742391883 34) q(0 0 1 -1) r(6 6) U5'
+  '11-24185972-24185980 NNYN CT(87 87 0) RT(1594811988340 35) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2557,8 +2557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -2588,9 +2588,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:53 GMT',
+  'Wed, 15 Jul 2020 11:19:50 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -2610,7 +2610,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a2a9ccdbb76bc98d5eb2419ffaba1671',
+  'e797fc36c7ea4e7481b1de3d6e9e77a1',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -2622,11 +2622,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=9KK7gnHJTHu4VAAyqP8O5HnWDV8AAAAAQUIPAAAAAACxDPRZ7RIgoxzIQevBtOc2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=G+5HSBGzQb68yLUxtrRwblXmDl8AAAAAQUIPAAAAAADNNnci4t2bKquS+2MKjSwx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RK8xQa0wql2FlS+nKsJtVwAAAADGHGkS0FA9sEx+5vsS96xS; path=/; Domain=.contentful.com',
+  'nlbi_673446=iSPZM1Py2ASfkZe0KsJtVwAAAAD+TAOCGMAwEoXUo4hBKZ9p; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=fVvyHS/b8Fhky/lMOoVtA3nWDV8AAAAATPPNg/VfYzgdty23GMy1IA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=YH0tGq5g3yxzIw9OOoVtA1XmDl8AAAAADcfOtbd1ph14mw15WMXByQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2634,7 +2634,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-26993287-26993296 NNYN CT(87 87 0) RT(1594742392713 33) q(0 0 2 -1) r(3 3) U5'
+  '11-24186108-24186116 NNYN CT(92 88 0) RT(1594811988954 30) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2650,8 +2650,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:53.832Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:50.723Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2660,8 +2660,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-14T15:59:50.905Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:47.155Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2726,9 +2726,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:53 GMT',
+  'Wed, 15 Jul 2020 11:19:50 GMT',
   'etag',
-  'W/"15185963368281600899"',
+  'W/"14338444956490695869"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2738,29 +2738,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'c1d23ed915eb9fb089984b9ab4b645da',
+  '030b8908d327e83ca76537443e5a5dc7',
   'Content-Length',
-  '501',
+  '503',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=wmPzWPcCRKC8MyCVTZbYRHnWDV8AAAAAQUIPAAAAAABCEPz6+BOV9bIrzl8g28lf; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qmougX3rRYKVBk9CuBGhxFbmDl8AAAAAQUIPAAAAAADYMiu/Cm7fB111yJ0qLVFx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GYm1d87YTHCRJf+CKsJtVwAAAAB3WC0BgeWDBiYk/uMUUG91; path=/; Domain=.contentful.com',
+  'nlbi_673446=OOGUd5C1aBBw2rnFKsJtVwAAAABZnE0M610qeY1sPSD5pe3W; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=9aWgXfRnJnXsy/lMOoVtA3nWDV8AAAAANmrmWOh1/wsSVRHA4i9TqQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=LEKHQh0gryZkJQ9OOoVtA1bmDl8AAAAAdsAS7Fwso7tQgekuxH/MFw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26993392-26993400 NNNN CT(87 88 0) RT(1594742393149 32) q(0 0 2 -1) r(4 4) U5'
+  '14-47478056-47478083 NNNN CT(93 94 0) RT(1594811990022 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2776,8 +2776,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:54.396Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:51.257Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2786,8 +2786,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-14T15:59:54.396Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:51.257Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2852,9 +2852,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:54 GMT',
+  'Wed, 15 Jul 2020 11:19:51 GMT',
   'etag',
-  'W/"842318945658093321"',
+  'W/"6552828642614742331"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2872,26 +2872,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e82def8b65f9bd38a6288c8f6b3bcd63',
+  'f3b8c3e1a99f64a650b048306d62ae5b',
   'Content-Length',
-  '497',
+  '498',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=IPjUYtalR2yRQbTEquKDDnrWDV8AAAAAQUIPAAAAAABPdMlG+JQd7m2Ro+F9A94Z; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=0UNxNr2sQvOyu0JJ9bcj9lfmDl8AAAAAQUIPAAAAAABB7uvr7t8/U0v05Km8+2DE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CJIwBUR5uRFNQJhqKsJtVwAAAAC3FDFQ2d+94tq6vwKhPhXJ; path=/; Domain=.contentful.com',
+  'nlbi_673446=FJLJc+GS6mAuLG8UKsJtVwAAAABWyy0l2z9Mf4YY/ara98tH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ro3tXk1MIQN1zPlMOoVtA3rWDV8AAAAAB1Qa0kIsw9zPLip1RjxLLA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=8J9zNZfRVS6qJg9OOoVtA1fmDl8AAAAAcaGlcKFg/hVgtKSSPENpXQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26993562-26993574 NNNN CT(92 92 0) RT(1594742393737 32) q(0 0 2 -1) r(5 5) U5'
+  '12-30367754-30367763 NNNN CT(89 88 0) RT(1594811990594 39) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/editor_interface', {"controls":[{"fieldId":"aDifferentId"}]})
-  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-14T15:59:37.648Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-14T15:59:55.024Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-15T11:19:33.362Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T11:19:51.897Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -2913,9 +2913,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:55 GMT',
+  'Wed, 15 Jul 2020 11:19:51 GMT',
   'etag',
-  '"15999300434070215171"',
+  '"829332846074526072"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2933,21 +2933,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'cd9a472c99d7a23a083beb45ae36454e',
+  '01767358811fc1acf7b4ebda36c2dccc',
   'Content-Length',
   '922',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BpL5xxg8Sv6LoBV2Zlyz5nrWDV8AAAAAQUIPAAAAAADgevRrfHs8UeiJePYQq0vA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3e9V+xvKQ2q9JTOrF34YalfmDl8AAAAAQUIPAAAAAADLrcPaO8ceXIap+wtMKutB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=M7n+GhRN0jnsD2gJKsJtVwAAAABM26uZzYYevZL6sVQurZor; path=/; Domain=.contentful.com',
+  'nlbi_673446=dvHQNkv+mzSI6jH/KsJtVwAAAACF/RBx6Y8GrRQU9Mgzghno; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=4gD2NW2a+XEAzflMOoVtA3rWDV8AAAAAiWNwa5kTMtjXxsw2Wu61hg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=P6T1Cw4ZgThFKA9OOoVtA1fmDl8AAAAAhphwZZddQCCq2WwOUUKQJg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20312908-20312918 NNNN CT(94 102 0) RT(1594742394334 28) q(0 0 2 -1) r(4 4) U5'
+  '12-30367969-30367982 NNNN CT(93 93 0) RT(1594811991208 44) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2963,8 +2963,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:55.496Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:52.506Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2973,8 +2973,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-14T15:59:54.396Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:51.257Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3039,9 +3039,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:55 GMT',
+  'Wed, 15 Jul 2020 11:19:52 GMT',
   'etag',
-  'W/"8017555108429248175"',
+  'W/"15178747109335340619"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3059,21 +3059,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '701abbe551cb748aa335ec02e2c23fb8',
+  '8d6cc2a9d315b2aa022fb62954f14fff',
   'Content-Length',
-  '493',
+  '494',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MgRhAcsyQxWxqnDOxFXWWXvWDV8AAAAAQUIPAAAAAADd0J5RfrGnObOZWIxSvdBA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=2CMKjJ1cTyagE64g4x8XNVjmDl8AAAAAQUIPAAAAAACfIzwHM2d61/ageGynigy1; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=89lKGunVH3/9vKSCKsJtVwAAAAC8wLMmtpGE0VcTIXU95YRy; path=/; Domain=.contentful.com',
+  'nlbi_673446=38y2Hy5vwB8lcglxKsJtVwAAAABzHRxJ0YRS7vZk219kJ6vS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=LS3IGQbk62ZtzflMOoVtA3vWDV8AAAAA+y9PYCkY1PhA7g33DujqaQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7KkLCKJuqjCmKQ9OOoVtA1jmDl8AAAAAlSLYgjhRnYRmKDmSd96L2w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-4138283-4138288 NNNN CT(86 88 0) RT(1594742394805 29) q(0 0 2 -1) r(4 4) U5'
+  '5-23228233-23228237 NNNN CT(93 94 0) RT(1594811991823 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3089,8 +3089,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:56.033Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:53.100Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3099,8 +3099,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 11,
-    "publishedAt": "2020-07-14T15:59:56.033Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-15T11:19:53.100Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3165,9 +3165,135 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:56 GMT',
+  'Wed, 15 Jul 2020 11:19:53 GMT',
   'etag',
-  'W/"3439410942897877923"',
+  'W/"15879163713603625765"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '90f6c5aa373dbc7f66f0ffa0334cdce2',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=nq8eiwOvRqO0gXJk7U7hrFjmDl8AAAAAQUIPAAAAAAC/Pm8BNe68FJ0aZVCHXSeV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=27AwZxOX6Rr1cUkPKsJtVwAAAACajjdp5bShsUw9cJ91+lbG; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=0h6NVC+GDRIeKw9OOoVtA1jmDl8AAAAASNKVX0KPO1ZEj+lVHwVvqw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '10-14421253-14421267 NNNN CT(85 88 0) RT(1594811992440 31) q(0 0 2 -1) r(5 5) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:53.100Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 11,
+    "publishedAt": "2020-07-15T11:19:53.100Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 6,
+    "version": 12,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "aDifferentId",
+      "name": "ID switching is fun!",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:19:53 GMT',
+  'etag',
+  'W/"15879163713603625765"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3185,147 +3311,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'a4dae81709efd7f5aa6a741c6c58916b',
+  '889c500f6f4fc82535b9373e262726bf',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=EEIjoBdOTvWWkz7f9w2TGnvWDV8AAAAAQUIPAAAAAADNnpjY+CdyZa/h5LA4o76/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=GRqkfJMpT52b7VSWPFprW1nmDl8AAAAAQUIPAAAAAAArAsYcLRBmWfUjne1NnFF2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=jeriRwxUeB6Qrm1bKsJtVwAAAACEt01HsMwiCxoeS6K2cjHe; path=/; Domain=.contentful.com',
+  'nlbi_673446=HNMac/3rDHiPkD+GKsJtVwAAAAChaZCxvZUaS7h47VUApmq8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=pdQaOFAZRBnxzflMOoVtA3vWDV8AAAAAsb1P8d4QHbj7lkZru9NOfQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=i17GegisXRZcLA9OOoVtA1nmDl8AAAAAoOUGoKVCUiKWFJCU58yZLw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13772113-13772118 NNNN CT(92 92 0) RT(1594742395369 35) q(0 0 1 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:56.033Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 11,
-    "publishedAt": "2020-07-14T15:59:56.033Z",
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 6,
-    "version": 12,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "aDifferentId",
-      "name": "ID switching is fun!",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 15:59:56 GMT',
-  'etag',
-  'W/"3439410942897877923"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '49b82039f6ad20656b651e8e84fbf6c1',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=IUFOpOcVTxWdPWt4uy08enzWDV8AAAAAQUIPAAAAAAC5TwgT2cHCOPZciXXy4uNg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=SXc5Dp+qjiWE3rSSKsJtVwAAAAD8gO0r/Gjuhh1aUK+Ivbin; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=06LmLfLFriNVzvlMOoVtA3zWDV8AAAAAGDV3RU8IWpVHVXbs3bhtOw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '14-26993985-26993999 NNNN CT(92 93 0) RT(1594742395985 34) q(0 0 2 -1) r(3 3) U5'
+  '12-30368466-30368486 NNNN CT(95 94 0) RT(1594811993058 44) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3350,8 +3350,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-14T15:59:36.539Z",
-        "updatedAt": "2020-07-14T15:59:56.033Z",
+        "createdAt": "2020-07-15T11:19:32.579Z",
+        "updatedAt": "2020-07-15T11:19:53.100Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -3360,8 +3360,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 11,
-        "publishedAt": "2020-07-14T15:59:56.033Z",
-        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+        "publishedAt": "2020-07-15T11:19:53.100Z",
+        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -3428,9 +3428,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:57 GMT',
+  'Wed, 15 Jul 2020 11:19:54 GMT',
   'etag',
-  'W/"8887087949937762504"',
+  'W/"10008067805799834274"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3448,21 +3448,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '003fca335606a3442a12b33a769de32d',
+  'f12d60916b5d15d76ab2304d1d9fee0a',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=QhRs+4/sRZyf94zshQDrLX3WDV8AAAAAQUIPAAAAAADTbk79E8unF/qoFKyY+9s1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AANKsGnTQ/29RtpcqBxDslnmDl8AAAAAQUIPAAAAAACSWQQGPrGI1S0LgFyk2mDh; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=sp7dWrIEVTrLhWOQKsJtVwAAAACR6iZuekECsii71TSVQ6Gv; path=/; Domain=.contentful.com',
+  'nlbi_673446=9MtrG1pdx0IQTfpvKsJtVwAAAABJ80WMRoAPihJayV8caEf6; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=dCIQGCxh9hDtzvlMOoVtA33WDV8AAAAA+Jysg08/uR8qo5gqVb/5HA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=PZlXRTzJKnlSLQ9OOoVtA1nmDl8AAAAAn9VL+DTjXa3qTYvu7F+ISw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26994187-26994197 NNNN CT(89 89 0) RT(1594742396597 33) q(0 0 2 -1) r(4 4) U5'
+  '14-47479349-47479372 NNNN CT(94 88 0) RT(1594811993524 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3499,7 +3499,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:58 GMT',
+  'Wed, 15 Jul 2020 11:19:54 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -3511,23 +3511,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'fe026f330bf11ffc85d25817ea16edb8',
+  '3812548edd546535b6484177b3bac5c1',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=tDEUiu1aTca4umAn4cU6in7WDV8AAAAAQUIPAAAAAADMh0WrAaDwrzZruIJsOtN4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qdC3zeq/SLWXYfugd5wd9FrmDl8AAAAAQUIPAAAAAAAwzGchDvw0SjTtjjRgB+ic; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=+TvIadbkLzpbjWTRKsJtVwAAAAAiylykoapWoQ2iJblQfQJW; path=/; Domain=.contentful.com',
+  'nlbi_673446=ZjAyZZpGMyv6R2m0KsJtVwAAAADVa4Uf57KXyprtNpf+rdrX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Y/+Cc/RJAnj+z/lMOoVtA37WDV8AAAAAUf1EyBlajdwHRDtcAgYbyw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+7GwAsFgtypXLg9OOoVtA1rmDl8AAAAA/2qk7VRO/XWacgD+9iwJtg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3535,7 +3535,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-6342343-6342346 NNYN CT(93 92 0) RT(1594742397999 33) q(0 0 2 -1) r(4 4) U5'
+  '11-24187364-24187374 NNYN CT(88 88 0) RT(1594811993990 35) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3576,8 +3576,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -3607,9 +3607,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:59 GMT',
+  'Wed, 15 Jul 2020 11:19:55 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -3629,7 +3629,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '58e984e0646233224b931f6459a33d5f',
+  'd16fdf3361ceaec7ca77aa4f8b8d538e',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -3641,11 +3641,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=AWTr5EwjTXW0mJousuQUR37WDV8AAAAAQUIPAAAAAABblnV8G8amFvwF81mot5w1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=l2KwCgn+S2S4W4BmbmsEhVrmDl8AAAAAQUIPAAAAAABqbrisBKK9OJe54g6XKpfv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=U5UVSNzcMDEYlgDqKsJtVwAAAAAgK93uPh+3/d2Xir5+RpxP; path=/; Domain=.contentful.com',
+  'nlbi_673446=yMa9Uo5c+w6LhBCCKsJtVwAAAABsBrcRilbXoAILC9k4lXpz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=y3PzQOJSJy2G0PlMOoVtA37WDV8AAAAAsKnBpzD+M07K5j4z6yzu9g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/KWrRH/sCyM1Lw9OOoVtA1rmDl8AAAAAeAQ0ilgnao4Hdeqc+uIr8A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3653,7 +3653,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-26994692-26994698 NNYN CT(91 94 0) RT(1594742398665 33) q(0 0 2 -1) r(3 3) U5'
+  '10-14421653-14421655 NNYN CT(86 87 0) RT(1594811994488 30) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3669,8 +3669,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-14T15:59:36.539Z",
-    "updatedAt": "2020-07-14T15:59:59.855Z",
+    "createdAt": "2020-07-15T11:19:32.579Z",
+    "updatedAt": "2020-07-15T11:19:55.548Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3678,7 +3678,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "Environment"
       }
     },
-    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3736,9 +3736,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 15:59:59 GMT',
+  'Wed, 15 Jul 2020 11:19:55 GMT',
   'etag',
-  'W/"66922666318594733"',
+  'W/"2193406852284124990"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3756,21 +3756,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'b8cfd56f6b59904bb00fa656b80af780',
-  'Content-Length',
-  '464',
+  'e348689c045e80d6331df799ff237bdb',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kr3ZSEDBT/+l2465hCEOGn/WDV8AAAAAQUIPAAAAAAAvS/Ew3URZMuF88X+sOXMa; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=i9wCp46jSG6Gein6EQKWwFvmDl8AAAAAQUIPAAAAAACtHiG9eCF3+T9BW5pvt70q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=pKKIB3S5tVXdYbR5KsJtVwAAAAB2oEtAiyuu1E+4GJVYdt/D; path=/; Domain=.contentful.com',
+  'nlbi_673446=vC1zXi4ipyKK1e3mKsJtVwAAAAC9DLsaE+QuTvgzVxFz1Tyz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=QfpvEcnvnDQr0flMOoVtA3/WDV8AAAAAymuvfkaZIJLBWGWVJsiMUw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=g/Q/T8xShiAxMQ9OOoVtA1vmDl8AAAAA5mFgKwnRUYUBrN9/7SlRZQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20314000-20314008 NNNN CT(95 94 0) RT(1594742399157 35) q(0 0 2 -1) r(5 5) U5'
+  '3-10881120-10881130 NNNN CT(87 86 0) RT(1594811994894 30) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3797,7 +3797,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:00 GMT',
+  'Wed, 15 Jul 2020 11:19:56 GMT',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3807,27 +3807,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '7',
   'X-Contentful-Request-Id',
-  'a9ae1b2ceee0d7d1a9b9f3829f3eaadf',
+  '1edd33e81038e1e1d554a0de2595f178',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vfxlVFFER82m1tgwReV9P4DWDV8AAAAAQUIPAAAAAAAOvJezPnjkv4nrR0WE6s47; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=oMygffbQRkCXHCKjm1KkB1vmDl8AAAAAQUIPAAAAAACU5Jlm/j+z3BIl74scSCUL; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8mUIVLTGTiFS37KAKsJtVwAAAADddc5CLyaoPKyXomU00czQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=zRYDP2EzsGwXHnAbKsJtVwAAAAAEuH00Pu9pnucE/fBuQvRx; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=AcrNf+laxAvf0flMOoVtA4DWDV8AAAAAaolQU+F2PupOeXbi5KB9DQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=54OQYI3igVFlMg9OOoVtA1vmDl8AAAAApem/nUqNz/YFZSpxygtVBw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-8159648-8159651 NNNN CT(86 89 0) RT(1594742399883 28) q(0 0 1 -1) r(3 3) U5'
+  '13-35999355-35999361 NNNN CT(92 90 0) RT(1594811995379 31) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3844,7 +3844,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "5a99d8971677027743d159b16ebe2dce"
+  "requestId": "9c8f124a358d227817812198b3171c8f"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -3868,9 +3868,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:01 GMT',
+  'Wed, 15 Jul 2020 11:19:56 GMT',
   'etag',
-  '"11653283982414078269"',
+  '"3514449655326400314"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3880,23 +3880,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '5a99d8971677027743d159b16ebe2dce',
+  '9c8f124a358d227817812198b3171c8f',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Cp8otIDRQIK684BgrX3TCoHWDV8AAAAAQUIPAAAAAACcZoxveZOKIO6gE8HKSe3S; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=bFWFxXEfQ5q6ppMLq4Ad0FzmDl8AAAAAQUIPAAAAAACsmGzwrUs2oKiHcHB4lBwu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GpenVaAI109Cb3+QKsJtVwAAAABtkpG/t5Kg1WXWIbAjz+6r; path=/; Domain=.contentful.com',
+  'nlbi_673446=GLyXMKOv3xVMfd4oKsJtVwAAAADhkgQ9GMloBcDIBoSKqRzx; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=20u2GNf7ETe/0vlMOoVtA4HWDV8AAAAA1QeyymRCgn4VSYIce2Mo+Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=FlF6FI7QWG2XMw9OOoVtA1zmDl8AAAAAY3QJWu0tJaq3hsKM9CnpnQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3904,7 +3904,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-26995266-26995275 NNYN CT(95 114 0) RT(1594742400355 32) q(0 0 2 -1) r(8 8) U5'
+  '11-24187809-24187826 NNYN CT(87 87 0) RT(1594811995916 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3941,7 +3941,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:02 GMT',
+  'Wed, 15 Jul 2020 11:19:57 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -3961,15 +3961,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'becf84e251588beefdb8b326714ab917',
+  'c5610c0be6a3b7ee0d31776867fb90f5',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=a2w6rRupTbK2RBq2YQIa74HWDV8AAAAAQUIPAAAAAACDfLNxLbfZA6D5iRjwXaeT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=GfOsCsVOQXmiM+NWxlmE8VzmDl8AAAAAQUIPAAAAAADfYXq8EvMY2qJmHiA3gL7r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=l2ktGyBKITz8BNLRKsJtVwAAAABDzRw3aIFOg8rLhReyPPrV; path=/; Domain=.contentful.com',
+  'nlbi_673446=RuofXCSx6yAT5WL5KsJtVwAAAACd066WBV6S+0Njz312aoEB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=T3TMFgLlwBF80/lMOoVtA4HWDV8AAAAAcjM1xWTQ3fl5jsAQgr95GQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=MIInblqRukkxNQ9OOoVtA1zmDl8AAAAAiXODT+DTiPb1Ywo/Wcp83g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3977,7 +3977,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-5257053-5257059 NNYN CT(89 98 0) RT(1594742401299 32) q(0 0 2 -1) r(4 4) U5'
+  '11-24187977-24187986 NNYN CT(89 85 0) RT(1594811996590 34) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4018,8 +4018,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -4049,9 +4049,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:02 GMT',
+  'Wed, 15 Jul 2020 11:19:58 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -4071,7 +4071,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '230767b423139ffe7ad6cd1b8c46ac33',
+  '35faccc692e5f7e5dbf60629a93dfac1',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -4083,11 +4083,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kOObGLkIQK2AZ0adYZ8PYYLWDV8AAAAAQUIPAAAAAACtGNokjhvrJlI3KBx8+RZf; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=KIHhgoFVTdmlxjzquKTTc17mDl8AAAAAQUIPAAAAAAC31M8Q08mFiN2swx1tMOZo; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=IA2aX1vV4gXzputJKsJtVwAAAABDV6X/y1jI8AcjnW1HWsFl; path=/; Domain=.contentful.com',
+  'nlbi_673446=JQUYHPJ3Vgp7BVtVKsJtVwAAAAAnkD+3WlkZZMFyxwhsgux/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=I3trKVwJT1GF1PlMOoVtA4LWDV8AAAAA7Xt54Wds0QO020oJ0luWOQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=HWgHIhQ+ol4COQ9OOoVtA17mDl8AAAAA9lOJUC6bh2emyNEX3JhBvw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4095,12 +4095,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-8159833-8159834 NNYN CT(96 191 0) RT(1594742401948 43) q(0 0 3 -1) r(5 5) U5'
+  '10-14422365-14422369 NNYN CT(93 94 0) RT(1594811998151 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dieatary-food', {"name":"Dieatary Food","fields":[{"id":"name","type":"Symbol","name":"name of the food","validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}]},{"id":"calories","type":"Link","linkType":"Asset","name":"amount of calories the food contains","validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}]}],"description":"Food with up to 500 calories"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-14T16:00:03.504Z","updatedAt":"2020-07-14T16:00:03.504Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-15T11:19:59.308Z","updatedAt":"2020-07-15T11:19:59.308Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4122,9 +4122,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:03 GMT',
+  'Wed, 15 Jul 2020 11:19:59 GMT',
   'etag',
-  '"15413338736341783902"',
+  '"18322066142834842159"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4142,21 +4142,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '0b97b16ec3277d4f1a0fa048e6b0be2c',
+  'b3e8c2ad7b4008dc0474e5ea0136a147',
   'Content-Length',
   '1783',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ADyB8FhITRyP8qmSwvP8/4PWDV8AAAAAQUIPAAAAAADhCIAlSsAJVLbDGmKArqRu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lzcw/6K6TDS5I49SdLSUNV/mDl8AAAAAQUIPAAAAAACImbv64oJJtDvp/8PYcojE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=6o6XO6xNvGzC+UwMKsJtVwAAAAAYwuWwrdUdXVEU1yR8Q9P0; path=/; Domain=.contentful.com',
+  'nlbi_673446=0KXYcMRg2xyZUS8XKsJtVwAAAADzUEXMCz0psCTkefeKIYBf; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=j/qcJntJlW1z1flMOoVtA4PWDV8AAAAASKgtjZERqImYFDcGSL3V5g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=mURmSM8ScxtbOg9OOoVtA1/mDl8AAAAAvPAJP8AoAb3HPq4dco7RNw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-2535089-2535091 NNNN CT(93 93 0) RT(1594742402528 34) q(0 0 2 -1) r(7 7) U5'
+  '8-4529385-4529387 NNNN CT(93 99 0) RT(1594811998600 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4172,8 +4172,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:03.504Z",
-    "updatedAt": "2020-07-14T16:00:04.219Z",
+    "createdAt": "2020-07-15T11:19:59.308Z",
+    "updatedAt": "2020-07-15T11:19:59.940Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4197,8 +4197,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:04.219Z",
-    "publishedAt": "2020-07-14T16:00:04.219Z",
+    "firstPublishedAt": "2020-07-15T11:19:59.940Z",
+    "publishedAt": "2020-07-15T11:19:59.940Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4282,9 +4282,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:04 GMT',
+  'Wed, 15 Jul 2020 11:20:00 GMT',
   'etag',
-  'W/"4656321227028868333"',
+  'W/"950984746461574053"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4294,29 +4294,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'df68e3150365081b05877238f5c20d75',
-  'transfer-encoding',
-  'chunked',
+  '856f24f7a4a8b9bf39f652b9aae34aca',
+  'Content-Length',
+  '651',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Ht6TNMdrQ7qyqjrYCAkViITWDV8AAAAAQUIPAAAAAAD9y1xEfB66m0dZS1GFMDWf; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=v+CoxdTMSo+3nqEg81Q1G1/mDl8AAAAAQUIPAAAAAACAJwDIexMJjI1+WnwzW8To; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qrMcS+D7+DpGGsvYKsJtVwAAAAAWB4Azx+960RAb8F94un45; path=/; Domain=.contentful.com',
+  'nlbi_673446=298ZG7Qc8F4MBW4nKsJtVwAAAADLXVr4wMO9m0duy5oGG7QT; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=oXkCcl5e2VU41vlMOoVtA4TWDV8AAAAAQ8ACF4F5ae8Jb3oblfl7xg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=r2KpL1BQvVS8Ow9OOoVtA1/mDl8AAAAAhgFWZnns/U9X9Pp3SAr05A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26996189-26996199 NNNN CT(85 89 0) RT(1594742403567 37) q(0 0 1 -1) r(4 4) U5'
+  '10-14422595-14422597 NNNN CT(86 87 0) RT(1594811999190 20) q(0 0 1 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4332,8 +4332,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:03.504Z",
-    "updatedAt": "2020-07-14T16:00:04.219Z",
+    "createdAt": "2020-07-15T11:19:59.308Z",
+    "updatedAt": "2020-07-15T11:19:59.940Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4342,8 +4342,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T16:00:04.219Z",
-    "firstPublishedAt": "2020-07-14T16:00:04.219Z",
+    "publishedAt": "2020-07-15T11:19:59.940Z",
+    "firstPublishedAt": "2020-07-15T11:19:59.940Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -4442,9 +4442,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:04 GMT',
+  'Wed, 15 Jul 2020 11:20:00 GMT',
   'etag',
-  'W/"16093084401735594068"',
+  'W/"17841477265352863197"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4454,29 +4454,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '8012195717abd244f9a240d4d99f2596',
-  'transfer-encoding',
-  'chunked',
+  'cc633d0b62ea0a83f7d1f6ec1c26c055',
+  'Content-Length',
+  '651',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ivAfQPC+RjWrGHcZljI5BoTWDV8AAAAAQUIPAAAAAAB2q1DCiEl9GeHwoKQmgqno; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=S81HIokiTzW1JclghukhzWDmDl8AAAAAQUIPAAAAAABesAkOCT4rp/uxZi0pyk77; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JQLxA2LikS+K8UUrKsJtVwAAAADJuMhH2dSYim0jBHwADrPH; path=/; Domain=.contentful.com',
+  'nlbi_673446=g0FcKCIbX2yBQ8edKsJtVwAAAABFTdTHHtOFwXqfk71GvBoJ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=D7BRIZix6XPM1vlMOoVtA4TWDV8AAAAA2CP3FRDuOIpkA+977hGeoQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/B5gBkIFc2sKPg9OOoVtA2DmDl8AAAAANZbsSPAu3z3trYrM+hdlNQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13524477-13524480 NNNN CT(93 94 0) RT(1594742404175 29) q(0 0 1 -1) r(3 3) U5'
+  '10-14422758-14422766 NNNN CT(88 89 0) RT(1594812000014 31) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4513,7 +4513,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:05 GMT',
+  'Wed, 15 Jul 2020 11:20:01 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -4533,15 +4533,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a563163d440e1209d748070a5b1e2e05',
+  'c9f4199cc29d0ba576d18b6bff93cbcd',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=7WCgrfj5TuSYTq3biJ0KF4XWDV8AAAAAQUIPAAAAAACbJi28u9sFs2ESX6nLaWr8; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=iQd0usnJQ/qNHzTFFM6apGHmDl8AAAAAQUIPAAAAAAAXiQNGZ80Y7Ga9y0dAgO23; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XozpKkFt02BK3e/hKsJtVwAAAABk+eRDy0e2E3LiVVO8j1KJ; path=/; Domain=.contentful.com',
+  'nlbi_673446=TlM/GgjHHU0wU7lPKsJtVwAAAAAQCtlGKtCI/BxbjAsl6lZf; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=hBeMCy4AzTyT1/lMOoVtA4XWDV8AAAAATsdnMh2+V7bVFf+v/N3DZA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=xM53azQMO1jSPw9OOoVtA2HmDl8AAAAAvfbGHmBhQRcicFOVYeCLyg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4549,7 +4549,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-26996563-26996576 NNYN CT(94 95 0) RT(1594742404777 33) q(0 0 2 -1) r(3 3) U5'
+  '14-47481922-47481934 NNYN CT(94 100 0) RT(1594812000836 36) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4590,8 +4590,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -4621,9 +4621,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:05 GMT',
+  'Wed, 15 Jul 2020 11:20:02 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -4635,15 +4635,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '8d8b1facc92aae56f5907e0d2eb6a6c3',
+  'bdbd5ee90e9382c6e54491bc37603ce2',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -4655,11 +4655,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kL7/myIoQl+ryqlCr9R3YoXWDV8AAAAAQUIPAAAAAABHlYFqUrmp8Ihc8PZ+Nkyn; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=zPwcr1CYQH2Zm0GG5PNxS2HmDl8AAAAAQUIPAAAAAAC9XEFSUtgq7QmGINyBVnCP; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=N8rXDewtdH+7Ysf1KsJtVwAAAAAUnMbDvRMdn8hAVAq2DpMI; path=/; Domain=.contentful.com',
+  'nlbi_673446=TZlGE9KCZx9E88ncKsJtVwAAAACIFmETn16uksnOkpKE8zJ1; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=vdDndbIhhRHv1/lMOoVtA4XWDV8AAAAAwzjL8gKzCtQNZujA1vCFRQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=5/LeNkkDqxoHQQ9OOoVtA2HmDl8AAAAAhE18HuJtxYGT4wPI40u8qg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4667,12 +4667,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-5257277-5257278 NNYN CT(93 94 0) RT(1594742405255 32) q(0 0 2 -1) r(3 3) U5'
+  '9-9345138-9345147 NNYN CT(86 88 0) RT(1594812001648 52) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food', {"name":"foooood","displayField":"taste","fields":[{"id":"taste","type":"Symbol","name":"what it tastes like"}],"description":" well, food"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-14T16:00:06.759Z","updatedAt":"2020-07-14T16:00:06.759Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-15T11:20:02.872Z","updatedAt":"2020-07-15T11:20:02.872Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4694,9 +4694,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:07 GMT',
+  'Wed, 15 Jul 2020 11:20:02 GMT',
   'etag',
-  '"15268465080734638946"',
+  '"3717530732025275517"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4706,29 +4706,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '30ef18e9d880dd5b959bd6ae8d50f749',
+  '93f8de08212e80ed1291c81d01f852b5',
   'Content-Length',
   '1064',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=JKPWlgyVSsu8ZEuqlL1Ki4bWDV8AAAAAQUIPAAAAAACpXBeLRhM9Adt9D8CvMKCe; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ZvOwWPyrSqWuZBu2afTlHGLmDl8AAAAAQUIPAAAAAABasTFJ9lphoDFqtm+xsOpN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WPfqTgIe3luQwUbAKsJtVwAAAACNx3bD5vax9JW5Y+TqXoD2; path=/; Domain=.contentful.com',
+  'nlbi_673446=LxMQH/XRQkQmFQPRKsJtVwAAAADaTgN2ht3LSWsW1bjv6Fnl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=VA+obCIayiwD2flMOoVtA4bWDV8AAAAAWOQ20itC2nwJ9ABbBkb6Mg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0my/SWtp4yKvQg9OOoVtA2LmDl8AAAAApkosZzl4WXuHptVO+61iFw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-8160343-8160345 NNNN CT(100 101 0) RT(1594742405817 36) q(0 0 2 -1) r(9 9) U5'
+  '8-4529620-4529625 NNNN CT(87 87 0) RT(1594812002068 29) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4744,8 +4744,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:06.759Z",
-    "updatedAt": "2020-07-14T16:00:07.633Z",
+    "createdAt": "2020-07-15T11:20:02.872Z",
+    "updatedAt": "2020-07-15T11:20:03.568Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4769,8 +4769,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
-    "publishedAt": "2020-07-14T16:00:07.633Z",
+    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
+    "publishedAt": "2020-07-15T11:20:03.568Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4820,9 +4820,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:07 GMT',
+  'Wed, 15 Jul 2020 11:20:03 GMT',
   'etag',
-  'W/"16233065968810141319"',
+  'W/"7569917411828058782"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4840,21 +4840,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fd3730b89ee7485dfc4df3f6f86c1788',
+  '3f71d70163f05abb506168172e19c747',
   'Content-Length',
-  '447',
+  '452',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=06xmQA4FRLSjHjYk0LhA1YfWDV8AAAAAQUIPAAAAAABiS7r7st3EQ0SWX4oMhwFl; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=0YCbm1KySwy2Ix5EbE/GpWPmDl8AAAAAQUIPAAAAAABd+bpAze7XnKtgoKXex+Dt; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=aETrZGv9GSt9GcPrKsJtVwAAAAAHP7woNzqxTxlyZCNzNKSC; path=/; Domain=.contentful.com',
+  'nlbi_673446=LuUhdVxh6k8YLbmTKsJtVwAAAACutnF9UaZPqVCcaarzLWKn; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=LybBUEUbT0Ip2vlMOoVtA4fWDV8AAAAArQjoHkjS5og/fJI2ib6eMw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=T9gBFSm8DACrRQ9OOoVtA2PmDl8AAAAAJi3DxS/cOTcVkyegBpIF3A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-7156655-7156659 NNNN CT(93 94 0) RT(1594742406825 27) q(0 0 2 -1) r(7 7) U5'
+  '11-24189588-24189592 NNNN CT(90 89 0) RT(1594812002724 29) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4879,8 +4879,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "food",
         "type": "ContentType",
-        "createdAt": "2020-07-14T16:00:06.759Z",
-        "updatedAt": "2020-07-14T16:00:07.633Z",
+        "createdAt": "2020-07-15T11:20:02.872Z",
+        "updatedAt": "2020-07-15T11:20:03.568Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -4889,8 +4889,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-14T16:00:07.633Z",
-        "firstPublishedAt": "2020-07-14T16:00:07.633Z",
+        "publishedAt": "2020-07-15T11:20:03.568Z",
+        "firstPublishedAt": "2020-07-15T11:20:03.567Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -4957,9 +4957,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:08 GMT',
+  'Wed, 15 Jul 2020 11:20:04 GMT',
   'etag',
-  'W/"7080602346270485044"',
+  'W/"5213400854561507595"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4977,21 +4977,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '96e4d0ba759ca5ea968d45207cafa9f8',
-  'transfer-encoding',
-  'chunked',
+  'dde78d337bad7e8e202e37392f4f61eb',
+  'Content-Length',
+  '517',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=1dxme0LlQwOdzFjnTX4RaIjWDV8AAAAAQUIPAAAAAAACRjHDtnM8W7HNtgm+sG+7; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=nGjmRLRwSHO0Ks5QUOUX9WTmDl8AAAAAQUIPAAAAAADb2CPYtuM1h1++ygbOmc/m; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Wi7/MFFTmUUOv8PGKsJtVwAAAAAtXXvGZ2SddrCe7XlFBQLE; path=/; Domain=.contentful.com',
+  'nlbi_673446=26yAV29g1COg/1//KsJtVwAAAABpVs0HhrVHN6RTuYtA/xmq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=NwwXNgILCWXT2vlMOoVtA4jWDV8AAAAAWm+MfFz0unPSOb2IJS/wsA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=QNEjCyjiqRHpRg9OOoVtA2TmDl8AAAAAFMBN7dA1xc16HyLEoilngQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13525235-13525239 NNNN CT(87 87 0) RT(1594742407657 28) q(0 0 2 -1) r(5 5) U5'
+  '11-24189887-24189893 NNNN CT(86 90 0) RT(1594812003697 36) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5032,8 +5032,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -5063,9 +5063,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:08 GMT',
+  'Wed, 15 Jul 2020 11:20:04 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -5085,7 +5085,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '2e5c3d430b56c87773777ab44bcd2e6e',
+  '9bf62bc8c5906db41c66f415b2b4d1fa',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -5097,11 +5097,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=a3sUPWjtQyexnkRrTiMBrojWDV8AAAAAQUIPAAAAAAAuOK/0FOOSuy3N7IRCYK+t; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vWOdDKauQhirMbAOpDah0GTmDl8AAAAAQUIPAAAAAABmZU9Mq1OoIS3LF3UzRjyR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=u/LuHsFLLy0iVFiIKsJtVwAAAACI84jHJdhUQMFgTVMfL2Uq; path=/; Domain=.contentful.com',
+  'nlbi_673446=LBznDkj0aSsYn4VTKsJtVwAAAAC2Yr1qy9sW3bvEdRuR0rji; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0HZCT6Gx3HRp2/lMOoVtA4jWDV8AAAAAPcj3yxYnkcd3WMpWTjbmVg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7N9BIchP23AqSA9OOoVtA2TmDl8AAAAAj3cbfVu6O+S165odFKT/Gw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5109,7 +5109,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '6-4139267-4139269 NNYN CT(94 94 0) RT(1594742408293 34) q(0 0 2 -1) r(3 3) U5'
+  '8-4529773-4529777 NNYN CT(86 86 0) RT(1594812004320 31) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5125,8 +5125,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:06.759Z",
-    "updatedAt": "2020-07-14T16:00:09.600Z",
+    "createdAt": "2020-07-15T11:20:02.872Z",
+    "updatedAt": "2020-07-15T11:20:05.426Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5135,8 +5135,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T16:00:07.633Z",
-    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
+    "publishedAt": "2020-07-15T11:20:03.568Z",
+    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5251,9 +5251,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:09 GMT',
+  'Wed, 15 Jul 2020 11:20:05 GMT',
   'etag',
-  'W/"9911136001177961075"',
+  'W/"15705685296220394012"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5271,21 +5271,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '38d6b0fd12646a626f3fc42bd442a7c7',
+  'fc23fee1428480887c6bf9bcb96d746b',
   'Content-Length',
-  '592',
+  '595',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=LXPHq1caQ3iSPvK70XZAhonWDV8AAAAAQUIPAAAAAADBSphDazpGxai2EKUVmGYc; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=jOH9V5VrRHihh+8WaeOGFWXmDl8AAAAAQUIPAAAAAADWLhVR+GtmrISeSQUxNPYT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PSAhE4IgQF9AqkRRKsJtVwAAAADtlaVVUxF2o3VUr0MmfoSv; path=/; Domain=.contentful.com',
+  'nlbi_673446=73GOH7rEOhOI92/CKsJtVwAAAAD8pJrQBT+KHOkgoeWv6I0y; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=i+nHUfGZnFMU3PlMOoVtA4nWDV8AAAAA2eSlWFksXrSire7aorQEtg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ERnRWrMU/GtJSQ9OOoVtA2XmDl8AAAAA4/oq1wxLQyElSTz2Ruw/yg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '2-3148398-3148400 NNNN CT(91 92 0) RT(1594742408883 34) q(0 0 2 -1) r(4 4) U5'
+  '10-14423761-14423763 NNNN CT(94 94 0) RT(1594812004736 40) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5301,8 +5301,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:06.759Z",
-    "updatedAt": "2020-07-14T16:00:10.150Z",
+    "createdAt": "2020-07-15T11:20:02.872Z",
+    "updatedAt": "2020-07-15T11:20:06.032Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5311,8 +5311,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:10.150Z",
-    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
+    "publishedAt": "2020-07-15T11:20:06.032Z",
+    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5427,185 +5427,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:10 GMT',
+  'Wed, 15 Jul 2020 11:20:06 GMT',
   'etag',
-  'W/"12096556430046982097"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'e9beb2f7392adb01e33090e566807fc8',
-  'Content-Length',
-  '598',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=497Aur0kT2SLI7+BRKu4i4nWDV8AAAAAQUIPAAAAAADPOD/QeXUtCSzuSSRRFWLL; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=t3acSRz55xnPeXGeKsJtVwAAAAA+GQZBVoc3JsaeAOkZMHTo; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=Ho2MXUq51TGm3PlMOoVtA4nWDV8AAAAAK03vMW6e+xIuBeVDgxGyxQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '13-20316599-20316603 NNNN CT(87 90 0) RT(1594742409499 32) q(0 0 2 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/food')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "food",
-    "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:06.759Z",
-    "updatedAt": "2020-07-14T16:00:10.150Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:10.150Z",
-    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 2,
-    "version": 4,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": "taste",
-  "name": "foooood",
-  "description": " well, food",
-  "fields": [
-    {
-      "id": "calories",
-      "name": "How many calories does it have?",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "taste",
-      "name": "what it tastes like",
-      "type": "Symbol",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "producer",
-      "name": "Food producer",
-      "type": "Symbol",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "vegan",
-      "name": "Vegan friendly",
-      "type": "Boolean",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "gmo",
-      "name": "Genetically modified food",
-      "type": "Boolean",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "sugar",
-      "name": "Amount of sugar",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 16:00:10 GMT',
-  'etag',
-  'W/"12096556430046982097"',
+  'W/"2154243301793315147"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5623,21 +5447,197 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'd5ccddd28526754a9ca5207ddbbd87a1',
-  'transfer-encoding',
-  'chunked',
+  '59c25fa14197a1a8697211340d1e0a58',
+  'Content-Length',
+  '596',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=WIqLlSzwTIeYLyrtkzxqEYrWDV8AAAAAQUIPAAAAAABax6W89IulkYAqvvIlbwRw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=1uPHdRyBT5a9AjMiwmIyY2XmDl8AAAAAQUIPAAAAAAAuupnBq+Vcx3rbvw5WZ8nX; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zMeWeTXBNypk2eXNKsJtVwAAAAA1YKEXRqQT8g3UJ+LNZbpL; path=/; Domain=.contentful.com',
+  'nlbi_673446=z7ViIyCtyjDNssbMKsJtVwAAAACYDd2SThekNiqAYLPHcbgM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=hlBkW/JGGwwa3flMOoVtA4rWDV8AAAAAzJNEiDzNU0POE8jfYgJiWw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=zRcEfL6LxVWiSg9OOoVtA2XmDl8AAAAAApheIBn8HZWArn6HQgjZhA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17400737-17400746 NNNN CT(86 87 0) RT(1594742410119 29) q(0 0 2 -1) r(3 3) U5'
+  '10-14423865-14423870 NNNN CT(93 94 0) RT(1594812005334 34) q(0 0 2 -1) r(5 5) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/food')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "food",
+    "type": "ContentType",
+    "createdAt": "2020-07-15T11:20:02.872Z",
+    "updatedAt": "2020-07-15T11:20:06.032Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 3,
+    "publishedAt": "2020-07-15T11:20:06.032Z",
+    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 2,
+    "version": 4,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": "taste",
+  "name": "foooood",
+  "description": " well, food",
+  "fields": [
+    {
+      "id": "calories",
+      "name": "How many calories does it have?",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "taste",
+      "name": "what it tastes like",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "producer",
+      "name": "Food producer",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "vegan",
+      "name": "Vegan friendly",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "gmo",
+      "name": "Genetically modified food",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "sugar",
+      "name": "Amount of sugar",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:20:06 GMT',
+  'etag',
+  'W/"2154243301793315147"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '78fe2090b89b31123fbde199d9cfec33',
+  'Content-Length',
+  '596',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=IE4/CF1sT76E4ChFxbodJWbmDl8AAAAAQUIPAAAAAAAFsNlijCZp11G+InMZ5aQc; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=YG8aCRwKnnGDv9UoKsJtVwAAAADkMsSEuLCTtKDTLkJzngFN; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=d0WZWE0Z0B3WSw9OOoVtA2bmDl8AAAAAVZtrLGXGID3CgEOwocda7Q==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '5-23230472-23230476 NNNN CT(93 93 0) RT(1594812005952 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5674,7 +5674,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:11 GMT',
+  'Wed, 15 Jul 2020 11:20:07 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -5694,15 +5694,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f1605e9f522a2546c91b245389e4e5a9',
+  '5e8fefa2abb18f9202cb60de0bdd089c',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3/tEWI+eR7iIqaSdkJe42YrWDV8AAAAAQUIPAAAAAAAfPLh7Rc0ef26m0IF84rx7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=uXjtw/P6S9OLQxmhNm8C8GbmDl8AAAAAQUIPAAAAAAAYKHU49gq9gNZPLYWFCB3E; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=lRj7N2P7WAlXZTatKsJtVwAAAADB+X1vzVCfumlcfYwTHCVW; path=/; Domain=.contentful.com',
+  'nlbi_673446=RTkmfCpNlBoiw+1VKsJtVwAAAABHrPJMiB58CGxko1TDLVr+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=p1eMc07YpjiI3flMOoVtA4rWDV8AAAAAQdaZbqraYsYtrdbmZbuniA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=iz7XbJL4TC2RTQ9OOoVtA2bmDl8AAAAAEkq2YId3Cv/V6XhYHzNP3A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5710,7 +5710,78 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-8160816-8160824 NNYN CT(86 86 0) RT(1594742410556 34) q(0 0 2 -1) r(4 4) U5'
+  '11-24190640-24190657 NNYN CT(88 87 0) RT(1594812006572 32) q(0 0 1 -1) r(3 3) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/tags')
+  .query({"limit":"100","order":"sys.createdAt","skip":"0"})
+  .reply(200, {
+  "sys": {
+    "type": "Array"
+  },
+  "total": 0,
+  "items": []
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:20:07 GMT',
+  'etag',
+  '"9177491833369070274"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  '8481905d96125310ff33ac510a8784be',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=LrlEWdjARxibCU7fq2uQt2fmDl8AAAAAQUIPAAAAAAAuqCwNgV8Z99cPITVIzvQa; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=AMWqQ6sgjW0KLIMaKsJtVwAAAACvdtxOXGvMr57LiNWWhUe0; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=nzgRGXN9YEwCTw9OOoVtA2fmDl8AAAAAf7d+bOZcUj4tU6UgsqHaiQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '11-24190879-24190884 NNYN CT(93 94 0) RT(1594812007182 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5751,8 +5822,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -5782,9 +5853,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:12 GMT',
+  'Wed, 15 Jul 2020 11:20:08 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -5796,15 +5867,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '76f3c68a18346ad72cd1752273ab6ade',
+  '3901bb0ba8f7a2dc183f157f10ce923e',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -5816,11 +5887,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=HPt8k8MeTbG8EFD/C1edWozWDV8AAAAAQUIPAAAAAACC2MJe+hRCyFv/iXiWwWWv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=11i//yMtT5mFqFM284qdmGjmDl8AAAAAQUIPAAAAAABadF/8r2RWuRkroeSZUBdU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4LIMS21oXWk7lTs+KsJtVwAAAAB4csAv/cy3MrVpS6hSVR/4; path=/; Domain=.contentful.com',
+  'nlbi_673446=uAG1R9qMVSVen8wYKsJtVwAAAADvz7s5OBgVkHmf1Flw8nSn; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=AtebUKSRyFaH3vlMOoVtA4zWDV8AAAAAq5HfNUgbGZAo1h4cMkLVPA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=r0EvC1wLvl4pUA9OOoVtA2jmDl8AAAAA9FXqMJckT75tfbrQxnrW2g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5828,12 +5899,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-17400958-17400971 NNYN CT(93 94 0) RT(1594742411129 35) q(0 0 2 -1) r(9 9) U5'
+  '4-15464546-15464550 NNYN CT(93 98 0) RT(1594812007798 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/person', {"name":"Person","fields":[{"id":"age","name":"Age","type":"Number","required":true},{"id":"fullName","name":"Full name","type":"Symbol","required":true,"localized":true}],"description":"A content type for a person"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-14T16:00:12.848Z","updatedAt":"2020-07-14T16:00:12.848Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-15T11:20:08.929Z","updatedAt":"2020-07-15T11:20:08.929Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -5855,9 +5926,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:12 GMT',
+  'Wed, 15 Jul 2020 11:20:09 GMT',
   'etag',
-  '"16330242251810075220"',
+  '"5959611084888124152"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5867,29 +5938,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '707cf28120102d166b5fb7633bf265c6',
+  '0adfb9eaa09f1642df0833a56c15749b',
   'Content-Length',
   '1269',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=xcMrXgt8Rz6FUQN/chubs4zWDV8AAAAAQUIPAAAAAABj+k4ow0Q38XG09/yIRpxD; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=OGX9Y0uZQrKU111bQCV42GjmDl8AAAAAQUIPAAAAAADMqEw/hehgDSIQ+Rl16S9F; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=UgpJYo+sZzxM+MbsKsJtVwAAAACKPbCoeVjk6jWn3fto0Gjq; path=/; Domain=.contentful.com',
+  'nlbi_673446=qvsLEpwVpgY9/ULaKsJtVwAAAADb+icqYSTi4LKyPGoPtUsh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=uQA8YASQIw463/lMOoVtA4zWDV8AAAAAkIeGWsgs5nApWRDnYWeJvA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=LoI9dCf1AxOGUQ9OOoVtA2jmDl8AAAAAL39rpb5UX2TatSu1BIz44w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26998752-26998757 NNNN CT(89 89 0) RT(1594742412175 26) q(0 0 1 -1) r(4 4) U5'
+  '13-36002750-36002761 NNNN CT(86 87 0) RT(1594812008224 29) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5905,8 +5976,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:12.848Z",
-    "updatedAt": "2020-07-14T16:00:13.465Z",
+    "createdAt": "2020-07-15T11:20:08.929Z",
+    "updatedAt": "2020-07-15T11:20:09.464Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5930,8 +6001,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
-    "publishedAt": "2020-07-14T16:00:13.465Z",
+    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
+    "publishedAt": "2020-07-15T11:20:09.464Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -5991,9 +6062,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:13 GMT',
+  'Wed, 15 Jul 2020 11:20:09 GMT',
   'etag',
-  'W/"14016083358203130093"',
+  'W/"291918392709008713"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6011,26 +6082,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '90268f4e860104b16199403a8e06799f',
+  '32ec926b13ca4ce9b6cd09fdd187085b',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ns2KsNr/R6Wi9K6TGaK0W43WDV8AAAAAQUIPAAAAAADmoVzykeeOxcgSPDUt97y5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mRE5CgFdSoqsffyGDGo/yWnmDl8AAAAAQUIPAAAAAADmN5KdPf7slSPejdbbew7m; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Z3ACWAONkFHdn8kuKsJtVwAAAACBzbC7rDdshXN3T8rdziea; path=/; Domain=.contentful.com',
+  'nlbi_673446=AbHhc0tJEnl5gBEoKsJtVwAAAACbjO86QoB/zasEDls91h4m; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=yFo3NlT9ymL13/lMOoVtA43WDV8AAAAA6spzvyi+iCwX9IDwe+0PrQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+JRzKzzi4gW4Ug9OOoVtA2nmDl8AAAAArCz4oCYNOta4Xh7BtV6+iQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-26998913-26998924 NNNN CT(93 94 0) RT(1594742412771 31) q(0 0 1 -1) r(4 4) U5'
+  '4-15464655-15464660 NNNN CT(87 86 0) RT(1594812008826 27) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/animal', {"name":"Animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","required":true},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","required":false}],"description":"An animal"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-14T16:00:14.117Z","updatedAt":"2020-07-14T16:00:14.117Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-15T11:20:10.043Z","updatedAt":"2020-07-15T11:20:10.043Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -6052,9 +6123,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:14 GMT',
+  'Wed, 15 Jul 2020 11:20:10 GMT',
   'etag',
-  '"14484180835877969120"',
+  '"9570763304851875678"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6072,21 +6143,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '50f3e549b4854cc05a6800508180a741',
+  '8dfd1bedd0ae81bed2dc35490b46bc64',
   'Content-Length',
   '1292',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kg74E1ARROOp5VIim20Oo43WDV8AAAAAQUIPAAAAAADLBnizTyimLap9PCPmUwdz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=JPjJAcDATDSwP6vlNJ6StWnmDl8AAAAAQUIPAAAAAADxassKqLZnUYftbJ7MyW2P; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=KlWQRrtYNzG8Sx9sKsJtVwAAAACoGFsFV3Vq4xNFz8qnApi9; path=/; Domain=.contentful.com',
+  'nlbi_673446=EXmgSGtm3TpdBCQpKsJtVwAAAACH2Pv7DeCE3FAa8QIMk0TW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=yRhgQAMBZk7I4PlMOoVtA43WDV8AAAAAw3n31VGGUyNvgSScrj2wwg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=q3IKbixCm0YVVA9OOoVtA2nmDl8AAAAARW1IpPsNcS/nzhB7d9Houg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17401368-17401373 NNNN CT(86 88 0) RT(1594742413395 34) q(0 0 2 -1) r(5 5) U5'
+  '4-15464710-15464714 NNNN CT(93 94 0) RT(1594812009328 36) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6102,8 +6173,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:14.117Z",
-    "updatedAt": "2020-07-14T16:00:14.874Z",
+    "createdAt": "2020-07-15T11:20:10.043Z",
+    "updatedAt": "2020-07-15T11:20:10.719Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6127,8 +6198,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
-    "publishedAt": "2020-07-14T16:00:14.874Z",
+    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
+    "publishedAt": "2020-07-15T11:20:10.719Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -6188,9 +6259,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:14 GMT',
+  'Wed, 15 Jul 2020 11:20:10 GMT',
   'etag',
-  'W/"12875455613032629404"',
+  'W/"7527256497393373562"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6208,21 +6279,82 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '2abdc21340d407c8243487cab8489834',
-  'Content-Length',
-  '484',
+  '3e0655fed0c4480847edc6c818c397c8',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=TgH49ixFRUqH4JZQy1gnLY7WDV8AAAAAQUIPAAAAAADXCaENFQXeiEQbI/incNW8; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=HZOwP3cpQQWpcTi0Ie8LwGrmDl8AAAAAQUIPAAAAAABHRMOIVuOEBXgAx1hSPP+z; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=kfrUclZMFkp4OMnxKsJtVwAAAAAeEDHIvRMgOsQUD1i7yha/; path=/; Domain=.contentful.com',
+  'nlbi_673446=X0zjWd8NnE9E/lHHKsJtVwAAAADhykgUiQWyBsg5wxg4NVul; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=5r23HhlUMgwz4vlMOoVtA47WDV8AAAAAwk9G8ChJJJSoh5gco4iahg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=OddTWEXyIUKpVQ9OOoVtA2rmDl8AAAAAVtTnvFiFfnMXxnQl87eO4w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13775311-13775316 NNNN CT(87 87 0) RT(1594742414212 34) q(0 0 2 -1) r(4 4) U5'
+  '12-30374249-30374254 NNNN CT(93 87 0) RT(1594812010064 38) q(0 0 1 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/tags/longexampletag', {"sys":{"id":"longexampletag","version":0},"name":"long example marketing"})
+  .reply(201, {"sys":{"id":"longexampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-15T11:20:11.344Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T11:20:11.344Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"long example marketing"}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:20:11 GMT',
+  'etag',
+  '"18067423180685085321"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'ba7b0be5ce629b582c35ad02793ba3a0',
+  'Content-Length',
+  '758',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=75oWYn1bRpSdjbYYGCuPrWvmDl8AAAAAQUIPAAAAAAAf2XNFWdQs3J1UrwABtnhY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=VfypXGMeVD+9q6zXKsJtVwAAAACzHBodeEm2KL/W12pY6G3C; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=lbQKYQe3SSPZVg9OOoVtA2vmDl8AAAAAcDlOFx1WXAHv3iX6MKrZ3Q==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '12-30374454-30374464 NNNN CT(93 93 0) RT(1594812010664 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6238,8 +6370,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:12.848Z",
-    "updatedAt": "2020-07-14T16:00:15.536Z",
+    "createdAt": "2020-07-15T11:20:08.929Z",
+    "updatedAt": "2020-07-15T11:20:11.978Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6248,8 +6380,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T16:00:13.465Z",
-    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
+    "publishedAt": "2020-07-15T11:20:09.464Z",
+    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6335,9 +6467,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:15 GMT',
+  'Wed, 15 Jul 2020 11:20:12 GMT',
   'etag',
-  'W/"10179108162775744838"',
+  'W/"16198056543532702191"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6347,29 +6479,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '16465dc163700b20f806e5b33655ce25',
+  '102d77551bcb6e9a6e655d434bdc9f87',
   'Content-Length',
-  '519',
+  '520',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=b8gchYpfSmKy3gW34rzV84/WDV8AAAAAQUIPAAAAAABGmg4Xcwl4WNIYoWvE3XJG; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=4E4y8oBMSs+wAf/UHmF3UGvmDl8AAAAAQUIPAAAAAADVYjyC2pvIYzhSc9ti+L8J; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Sjt0ZLd1J0mqzYfPKsJtVwAAAADCHqhNqadw97Cut32sW7ss; path=/; Domain=.contentful.com',
+  'nlbi_673446=HTtzZD9Z61EnsOA+KsJtVwAAAAB0uUxcChVvj7k0/+DtyAO6; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=dGMeJ9GN6R7+4vlMOoVtA4/WDV8AAAAAkhC4iPPwgxntlGEW1KEviw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=glw7c6Nkb1Q0WA9OOoVtA2vmDl8AAAAA56TZ06TOHTKqLLNv1D3kDQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17401776-17401784 NNNN CT(86 88 0) RT(1594742414823 31) q(0 0 2 -1) r(4 4) U5'
+  '14-47485449-47485475 NNNN CT(90 89 0) RT(1594812011280 32) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6385,8 +6517,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:12.848Z",
-    "updatedAt": "2020-07-14T16:00:16.138Z",
+    "createdAt": "2020-07-15T11:20:08.929Z",
+    "updatedAt": "2020-07-15T11:20:12.491Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6395,8 +6527,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:16.138Z",
-    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
+    "publishedAt": "2020-07-15T11:20:12.491Z",
+    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6482,9 +6614,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:16 GMT',
+  'Wed, 15 Jul 2020 11:20:12 GMT',
   'etag',
-  'W/"7048743671037706340"',
+  'W/"11806803488069972852"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6502,21 +6634,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '812345aae0553a6336c09b99727ac57a',
-  'transfer-encoding',
-  'chunked',
+  '573f1b24880e52a41d4750c29c70a442',
+  'Content-Length',
+  '526',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=u/O1/pm+Sz6ZaGnlc8cM/o/WDV8AAAAAQUIPAAAAAADwj4TbtmKJo2ubm/Hc8dDa; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=21A1cuewT5eSxM3ug4kft2zmDl8AAAAAQUIPAAAAAACl3ndmNxU65EKOlH5vYOZC; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=3FlwRBOFYQeFNKR0KsJtVwAAAAClRVqElxvmxJ4CVXlLQ+AV; path=/; Domain=.contentful.com',
+  'nlbi_673446=GTViWLBs/XEjB+7jKsJtVwAAAACha3Efdz6ltOYkvRXcJpqL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=3wXNR8dSjUZW5PlMOoVtA4/WDV8AAAAAUndMH/ImwCSgcU3QyxoRPA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=t1V+Ys5jvmFfWQ9OOoVtA2zmDl8AAAAAfymfKoyjoYIIrDs0N7gCkA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13775587-13775595 NNNN CT(100 98 0) RT(1594742415437 47) q(0 0 2 -1) r(5 5) U5'
+  '1-2861662-2861663 NNNN CT(93 94 0) RT(1594812011833 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6532,8 +6664,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:14.117Z",
-    "updatedAt": "2020-07-14T16:00:16.856Z",
+    "createdAt": "2020-07-15T11:20:10.043Z",
+    "updatedAt": "2020-07-15T11:20:13.213Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6542,8 +6674,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T16:00:14.874Z",
-    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
+    "publishedAt": "2020-07-15T11:20:10.719Z",
+    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6628,9 +6760,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:16 GMT',
+  'Wed, 15 Jul 2020 11:20:13 GMT',
   'etag',
-  'W/"4762994068728274015"',
+  'W/"15004543883460504939"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6640,29 +6772,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'ea7a26c65fa4151ee7f04bfa09dd5b35',
+  '45554341ca56d79c37cb295fe1d9ee60',
   'Content-Length',
-  '510',
+  '508',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=46vK9mjhR7GSshgBeX3gIpDWDV8AAAAAQUIPAAAAAADgUf49qaZicPKQcSxYJ72d; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=9gJFt9tgTISmJ+gQH+9UVGzmDl8AAAAAQUIPAAAAAAAfbM2DUgbdL4jzPsnIpoqg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=S7S8LvHztA4xkxjsKsJtVwAAAADcy5x/tuN2uFAV16rPAyKE; path=/; Domain=.contentful.com',
+  'nlbi_673446=qkFcBhhcLER8JuGWKsJtVwAAAAC+KBxeBN0y57I5+Od55dN7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=6k/LJg3fAzXq5PlMOoVtA5DWDV8AAAAAdKJKVXnnYIwAVMAjL20KCw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=SzduGMz44UQnWw9OOoVtA2zmDl8AAAAAjZ4M9E9Ret2xssv5lplhNQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13526433-13526437 NNNN CT(92 92 0) RT(1594742416139 32) q(0 0 2 -1) r(5 5) U5'
+  '14-47485947-47485961 NNNN CT(97 89 0) RT(1594812012502 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6678,8 +6810,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:14.117Z",
-    "updatedAt": "2020-07-14T16:00:17.562Z",
+    "createdAt": "2020-07-15T11:20:10.043Z",
+    "updatedAt": "2020-07-15T11:20:13.796Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6688,8 +6820,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:17.562Z",
-    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
+    "publishedAt": "2020-07-15T11:20:13.796Z",
+    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6774,9 +6906,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:17 GMT',
+  'Wed, 15 Jul 2020 11:20:13 GMT',
   'etag',
-  'W/"14583803251784325129"',
+  'W/"17502525284640369912"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6786,29 +6918,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '912142cc064cd46080e078a78c4e1507',
+  '50a27dfa638d427ae1ea08efaa46d047',
   'Content-Length',
   '516',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=AdHiHH0rTcOeaZA7j18HUJHWDV8AAAAAQUIPAAAAAAC+8rgieflXfyFd8x6xXbuo; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=7rTJJkL9Tm69rc54Pjw+B23mDl8AAAAAQUIPAAAAAAD8DRgQhv/Yn0RQgxTD9d3l; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hxuVGngSnXfHLcbpKsJtVwAAAADLkzlZZoPJaxAu3sezZLda; path=/; Domain=.contentful.com',
+  'nlbi_673446=hfzdBSWq+WEToxUVKsJtVwAAAABxxzlxbA3mFKCvEIgweZ8I; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ejTILsyxy0V25flMOoVtA5HWDV8AAAAAY5TXX/oA1En2DxfZVlUepg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=esyHCFv6LSuEXA9OOoVtA23mDl8AAAAAHWP1OwPdtzVxbss1hcD2yQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27000130-27000142 NNNN CT(92 93 0) RT(1594742416872 33) q(0 0 1 -1) r(4 4) U5'
+  '13-36004235-36004244 NNNN CT(88 91 0) RT(1594812013128 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6824,8 +6956,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:12.848Z",
-    "updatedAt": "2020-07-14T16:00:16.138Z",
+    "createdAt": "2020-07-15T11:20:08.929Z",
+    "updatedAt": "2020-07-15T11:20:12.491Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6834,8 +6966,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:16.138Z",
-    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
+    "publishedAt": "2020-07-15T11:20:12.491Z",
+    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6921,9 +7053,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:18 GMT',
+  'Wed, 15 Jul 2020 11:20:14 GMT',
   'etag',
-  'W/"7048743671037706340"',
+  'W/"11806803488069972852"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6941,21 +7073,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '9c4bbd3ea52bb4652f3d827405211039',
-  'Content-Length',
-  '524',
+  '62c4f3537ad50bf4da9f3816278abd23',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=IoGlsfAVRhSgiv9KKBn0+5HWDV8AAAAAQUIPAAAAAADtoFYMzy3TYtM0Qo6dkDQU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ATIElFNqRb+gur9rRVG1oW7mDl8AAAAAQUIPAAAAAAAtDu7xxDz0rcPbgO9dJWq8; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Z0O1UlYJRmZNMpqqKsJtVwAAAADcFZUnaYPsrXe1KLcoO69i; path=/; Domain=.contentful.com',
+  'nlbi_673446=Jcj7DFlaVUIJ7dzAKsJtVwAAAAAFz7JeylLziAngdG3vHEr6; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=S5v1Bp9ecQAK5vlMOoVtA5HWDV8AAAAAZn04Wnmmvu+Yxp6AeiTctQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Ak5fYlOMWHquXQ9OOoVtA27mDl8AAAAAIYuhcVXshCuER4+hDlz7Ew==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20318797-20318803 NNNN CT(94 93 0) RT(1594742417481 30) q(0 0 1 -1) r(4 4) U5'
+  '9-9347233-9347237 NNNN CT(86 87 0) RT(1594812013738 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6971,8 +7103,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:14.117Z",
-    "updatedAt": "2020-07-14T16:00:17.562Z",
+    "createdAt": "2020-07-15T11:20:10.043Z",
+    "updatedAt": "2020-07-15T11:20:13.796Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6981,8 +7113,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:17.562Z",
-    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
+    "publishedAt": "2020-07-15T11:20:13.796Z",
+    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -7067,9 +7199,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:18 GMT',
+  'Wed, 15 Jul 2020 11:20:15 GMT',
   'etag',
-  'W/"14583803251784325129"',
+  'W/"17502525284640369912"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7087,21 +7219,122 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'b2ffa317593bcad6a2c0beac001a3e6a',
+  '6ac6c554e41d2a29dc9b849b50b50223',
   'Content-Length',
   '516',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=tbfa9gVIR92nF53Az6o42pLWDV8AAAAAQUIPAAAAAACkox6V+boqwZSnQhERNDJH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Kz1WBE5NQM+k9VSvAPDn6G7mDl8AAAAAQUIPAAAAAADBYiz0uQdbTfvv+TL5IEty; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=krubaZJD4WfFgXOmKsJtVwAAAAB3s8JVRSbTBDkjR/wO7wan; path=/; Domain=.contentful.com',
+  'nlbi_673446=n0NretSQyg1SNrfOKsJtVwAAAAAabj0kQojzUMKGxtMEfMSR; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=et11Zac2KSGX5vlMOoVtA5LWDV8AAAAAgsMa/jDTFQT+IlZSfcvIpw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ZFX4FKlWBm5WXw9OOoVtA27mDl8AAAAAowPcQQsIj0XComwNyEVltQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27000433-27000443 NNNN CT(93 93 0) RT(1594742418093 37) q(0 0 2 -1) r(4 4) U5'
+  '9-9347322-9347330 NNNN CT(93 94 0) RT(1594812014350 28) q(0 0 2 -1) r(5 5) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/tags/longexampletag')
+  .reply(200, {
+  "sys": {
+    "type": "Tag",
+    "id": "longexampletag",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "createdAt": "2020-07-15T11:20:11.344Z",
+    "updatedAt": "2020-07-15T11:20:11.344Z",
+    "version": 1
+  },
+  "name": "long example marketing"
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:20:15 GMT',
+  'etag',
+  '"11042076232677178575"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '67982c1076afb344d2f89ce909c37826',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=zUX0YMHMTu2T1T3HZDQI52/mDl8AAAAAQUIPAAAAAAADintyrkLxLXhMkMBvkr/G; expires=Wed, 14 Jul 2021 14:42:28 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=IplIXOY5ahBFra7OKsJtVwAAAADXe3DZqPXmRluTdRy9SeTB; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=3t9xWorniXuQYA9OOoVtA2/mDl8AAAAAcAiVYkGlGRJc1j8EiOeQqg==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '0-1831915-1831916 NNYN CT(93 94 0) RT(1594812014972 30) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7126,8 +7359,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "person",
         "type": "ContentType",
-        "createdAt": "2020-07-14T16:00:12.848Z",
-        "updatedAt": "2020-07-14T16:00:16.138Z",
+        "createdAt": "2020-07-15T11:20:08.929Z",
+        "updatedAt": "2020-07-15T11:20:12.491Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7136,8 +7369,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-14T16:00:16.138Z",
-        "firstPublishedAt": "2020-07-14T16:00:13.465Z",
+        "publishedAt": "2020-07-15T11:20:12.491Z",
+        "firstPublishedAt": "2020-07-15T11:20:09.464Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7225,9 +7458,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:19 GMT',
+  'Wed, 15 Jul 2020 11:20:16 GMT',
   'etag',
-  'W/"3162401999013364753"',
+  'W/"13870320801103358832"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7245,26 +7478,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'c865830763402fd810e4943326864000',
-  'transfer-encoding',
-  'chunked',
+  'ffff1d76f5bf1cca5db5eba52560f9b2',
+  'Content-Length',
+  '589',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=cmT/QXc8SPSXeMDmI+O/5JPWDV8AAAAAQUIPAAAAAAD91tdhjq8CRM0+WHT/XOuj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=dOAveraBTau7aDwtk11/p2/mDl8AAAAAQUIPAAAAAABu05tSXJJDPTSRnDuR5ONN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xoWZGmt2s23To4n9KsJtVwAAAADTCveOD1SZDUTaZQQaakIm; path=/; Domain=.contentful.com',
+  'nlbi_673446=mX50XbIuZmbMKxjuKsJtVwAAAACluQudndUM77JDSz/6Ygcq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=27jcUX0eoRs95/lMOoVtA5PWDV8AAAAAeDocZ1OV+QYvyMEbO1n0RQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=LSKEQmvgIk0hYg9OOoVtA2/mDl8AAAAASxMH13GkSrT/XcKmmBmk3w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27000579-27000592 NNNN CT(93 93 0) RT(1594742418728 34) q(0 0 2 -1) r(4 4) U5'
+  '14-47487004-47487015 NNNN CT(88 110 0) RT(1594812015577 38) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogpost', {"name":"blog post","fields":[{"name":"title","id":"title","type":"Symbol"},{"name":"category","id":"category","type":"Symbol"}]})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-14T16:00:20.040Z","updatedAt":"2020-07-14T16:00:20.040Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-15T11:20:16.967Z","updatedAt":"2020-07-15T11:20:16.967Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -7286,9 +7519,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:20 GMT',
+  'Wed, 15 Jul 2020 11:20:17 GMT',
   'etag',
-  '"8259321137694976203"',
+  '"2075389067367576010"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7306,21 +7539,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '29e5b60fc76930e61af4405eb7ed82e2',
+  'ccd988b45d1e6178cb2ce0ac0b43ccc2',
   'Content-Length',
   '1255',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=9Yo1ytbWSa2zyPsATu/gG5PWDV8AAAAAQUIPAAAAAACGFcorESTbPXz541JbVDNN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=UwE+gf6mTzCvBQ217HJITnDmDl8AAAAAQUIPAAAAAABndGN6B0wamNJF9oFKYgVF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SWRrSQHVCBSh5jMEKsJtVwAAAADhVHNMyfkWAwTHQRbrbvE5; path=/; Domain=.contentful.com',
+  'nlbi_673446=h1eeVmh8xli6XYevKsJtVwAAAAAn2mZ/zfqSOAHrt1QATkK4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=R66mIo6TiXjm5/lMOoVtA5PWDV8AAAAAosASahfamJnAO5mpj3lXwA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=VSiKcHM8z3rLYw9OOoVtA3DmDl8AAAAAXmCTLBCGYUEVgW8qjBSTlw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27000723-27000730 NNNN CT(90 97 0) RT(1594742419229 33) q(0 0 2 -1) r(6 6) U5'
+  '12-30375942-30375952 NNNN CT(94 115 0) RT(1594812016207 43) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7336,8 +7569,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogpost",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:20.040Z",
-    "updatedAt": "2020-07-14T16:00:20.617Z",
+    "createdAt": "2020-07-15T11:20:16.967Z",
+    "updatedAt": "2020-07-15T11:20:17.577Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7361,8 +7594,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:20.617Z",
-    "publishedAt": "2020-07-14T16:00:20.617Z",
+    "firstPublishedAt": "2020-07-15T11:20:17.577Z",
+    "publishedAt": "2020-07-15T11:20:17.577Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -7422,9 +7655,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:20 GMT',
+  'Wed, 15 Jul 2020 11:20:17 GMT',
   'etag',
-  'W/"10082589985409053526"',
+  'W/"1280240300566591262"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7442,21 +7675,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '507ecd1e6e07df3b1db4bb1b7b0295ad',
+  '5800d66aa431dac3348635cd5c0359a1',
   'Content-Length',
-  '442',
+  '445',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/vi8cm9oRgKrVG7sCMV3npTWDV8AAAAAQUIPAAAAAACX/J8R6JClwqpoPx5hpBkv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qHqTU7L6TM+ZmyCaIn/UrnHmDl8AAAAAQUIPAAAAAADIXKhpOU31hiXjw21kigAC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Ld7qcXhqCBOM4ccOKsJtVwAAAABGpNJa9j3ThfGtDZgNeza3; path=/; Domain=.contentful.com',
+  'nlbi_673446=+hs+E2hwel7fRtuQKsJtVwAAAACZ1ovNQYjkCsNLgtWMzXzh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=EOIlI2fqJxmn6PlMOoVtA5TWDV8AAAAAUSgHYye+OBk8nBV22hbVeg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=fdZoK8WgFVEaZQ9OOoVtA3HmDl8AAAAAgtVles9A4fW9SKzicS3u9Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20319435-20319443 NNNN CT(98 93 0) RT(1594742419951 29) q(0 0 2 -1) r(4 4) U5'
+  '13-36005389-36005403 NNNN CT(93 88 0) RT(1594812016916 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7473,10 +7706,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "2qjlQ6dEAo5bEW5SI1PAKv",
+    "id": "5ACaSqp8quE2VUdm4ti00Z",
     "type": "Entry",
-    "createdAt": "2020-07-14T16:00:21.438Z",
-    "updatedAt": "2020-07-14T16:00:21.438Z",
+    "createdAt": "2020-07-15T11:20:18.319Z",
+    "updatedAt": "2020-07-15T11:20:18.320Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7536,9 +7769,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:21 GMT',
+  'Wed, 15 Jul 2020 11:20:18 GMT',
   'etag',
-  '"12179876388851723368"',
+  '"17304987540903161622"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7556,15 +7789,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '8608cf34d658268a20f1edb9abe2ff5e',
+  'a4ad3085edc92b48c90c2135b5cec4ef',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=hFKfw897Q22NPI8hXGNlvJXWDV8AAAAAQUIPAAAAAACuwMsOPesuTA7dPLfvv5ZB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=tjKFWfIhRNWD2j368U6o+XLmDl8AAAAAQUIPAAAAAACl9fma1B9KilJq54prme1q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PKg8eJZnul1922IFKsJtVwAAAADuoocFNlgHjEZFLPmFGl9f; path=/; Domain=.contentful.com',
+  'nlbi_673446=0XazKKbIzhp9VpSJKsJtVwAAAADv+UWAyUcSBvySZJ9zyi7b; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=iwzeXZ0Kug2A6flMOoVtA5XWDV8AAAAACoKP3Uyx1cxp6Z2XkH9/qQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=46jDYfu2VDiqZg9OOoVtA3LmDl8AAAAAycOOLXpx6AzgjlsoLZONjQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7572,7 +7805,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20319608-20319615 NNYN CT(86 87 0) RT(1594742420559 41) q(0 1 2 -1) r(8 8) U5'
+  '13-36005567-36005573 NNYN CT(86 92 0) RT(1594812017520 33) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7589,10 +7822,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "4FiuEf8CqgsbY1ZI4wBg0X",
+    "id": "551boZKK9dmBDwpfWaQmd5",
     "type": "Entry",
-    "createdAt": "2020-07-14T16:00:22.276Z",
-    "updatedAt": "2020-07-14T16:00:22.276Z",
+    "createdAt": "2020-07-15T11:20:19.041Z",
+    "updatedAt": "2020-07-15T11:20:19.041Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7652,9 +7885,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:22 GMT',
+  'Wed, 15 Jul 2020 11:20:19 GMT',
   'etag',
-  '"11652420770846934910"',
+  '"1435225799643613627"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7664,23 +7897,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '99ac7c3d2ef272d8201ff37376a17788',
+  'e5c84dae3c60b4603df124273c8f500a',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=l/TSLR9oR7WORW/jJ6afOpbWDV8AAAAAQUIPAAAAAAAfBXqDcMkKaZXWR0AWwGIC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Etvsb6O8Q1e5AixlGsa8OXLmDl8AAAAAQUIPAAAAAABoN0xvtFMO6t7hiiI0KYqx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ZfEKD3vtZ0hkiOpiKsJtVwAAAAA0x1e/NDzZ5H+xTNMEmElV; path=/; Domain=.contentful.com',
+  'nlbi_673446=SntZO2fdOW7vwwbOKsJtVwAAAADS3xamOVzwVR2S7PNU3oEQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=7tyaa7uPmAkj6vlMOoVtA5bWDV8AAAAAKFJ6DiUhgHqVeoPbv6W3kg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=h+TKVh2T+VZGaA9OOoVtA3LmDl8AAAAAq8+mh5bA7MOtf6xU09s9+w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7688,7 +7921,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-27001504-27001510 NNYN CT(95 93 0) RT(1594742421585 32) q(0 0 2 -1) r(4 4) U5'
+  '13-36005780-36005790 NNYN CT(86 87 0) RT(1594812018350 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7713,8 +7946,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogpost",
         "type": "ContentType",
-        "createdAt": "2020-07-14T16:00:20.040Z",
-        "updatedAt": "2020-07-14T16:00:20.617Z",
+        "createdAt": "2020-07-15T11:20:16.967Z",
+        "updatedAt": "2020-07-15T11:20:17.577Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7723,8 +7956,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-14T16:00:20.617Z",
-        "firstPublishedAt": "2020-07-14T16:00:20.617Z",
+        "publishedAt": "2020-07-15T11:20:17.577Z",
+        "firstPublishedAt": "2020-07-15T11:20:17.577Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7801,9 +8034,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:22 GMT',
+  'Wed, 15 Jul 2020 11:20:19 GMT',
   'etag',
-  'W/"16271660349285021501"',
+  'W/"10960682778969613798"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7813,29 +8046,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '4e0f1768b91321ffe436665c9b1c5dd8',
+  '72d21e47b46d95fc091e4d0c6f5c8836',
   'Content-Length',
-  '513',
+  '516',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=EGmNxaXjRtCir90iMqUp35bWDV8AAAAAQUIPAAAAAACGMCNYn8i7cVp2VCuzJH7Q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=iKGOrSNHR3uTL0aHc7mML3PmDl8AAAAAQUIPAAAAAABy1hrkmpWIt15W7FgsEst1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=2i05LQ+zuAMVym1XKsJtVwAAAAA68YVWqud0EwOz0g2iUsLc; path=/; Domain=.contentful.com',
+  'nlbi_673446=DmrPYOboUHfayJkQKsJtVwAAAAAPPYNo0HIlARZaRzjrLLzp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=djRbN8jZ3xCl6vlMOoVtA5bWDV8AAAAAzzNbfy1jV0JrCTfRitx/tQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=AuNGPywGNENcaQ9OOoVtA3PmDl8AAAAAwl4Csllt/tpqwbU1kK1IIA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20319989-20320008 NNNN CT(96 97 0) RT(1594742422200 32) q(0 0 2 -1) r(3 3) U5'
+  '14-47488189-47488195 NNNN CT(87 87 0) RT(1594812018972 37) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7861,10 +8094,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "2qjlQ6dEAo5bEW5SI1PAKv",
+        "id": "5ACaSqp8quE2VUdm4ti00Z",
         "type": "Entry",
-        "createdAt": "2020-07-14T16:00:21.438Z",
-        "updatedAt": "2020-07-14T16:00:21.438Z",
+        "createdAt": "2020-07-15T11:20:18.319Z",
+        "updatedAt": "2020-07-15T11:20:18.320Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7914,10 +8147,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "4FiuEf8CqgsbY1ZI4wBg0X",
+        "id": "551boZKK9dmBDwpfWaQmd5",
         "type": "Entry",
-        "createdAt": "2020-07-14T16:00:22.276Z",
-        "updatedAt": "2020-07-14T16:00:22.276Z",
+        "createdAt": "2020-07-15T11:20:19.041Z",
+        "updatedAt": "2020-07-15T11:20:19.041Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7981,9 +8214,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:23 GMT',
+  'Wed, 15 Jul 2020 11:20:20 GMT',
   'etag',
-  'W/"15682920442187095777"',
+  'W/"14800598204800972611"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8001,21 +8234,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '9bd30e17cd926e6c97c87915bbbcb821',
+  'd831905786fba24895bb28bc3b1ab084',
   'Content-Length',
   '480',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=1zv9t5FQTn+Q4nDivGs23JfWDV8AAAAAQUIPAAAAAADNv1RND3igPJNiLAih4U/D; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=+cZB+uUZQWOrHod1/D2ZnXPmDl8AAAAAQUIPAAAAAABbijqZzAD5Yu0NJcj+UCJP; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=MbQDSAC8EG4gxxDiKsJtVwAAAAA7l5K6SNGIFhC+civsUIje; path=/; Domain=.contentful.com',
+  'nlbi_673446=h6IrY5YviwsEPLyzKsJtVwAAAABJxdmvqxPB5n2lGZX5IVSJ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=2UzSR98WWQ8L6/lMOoVtA5fWDV8AAAAArISDhwAqwKr3umMCuxo+Gw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=d6lveGYcUE68ag9OOoVtA3PmDl8AAAAAbLuoTqdH025A3sHLO470QQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17403377-17403384 NNNN CT(91 91 0) RT(1594742422802 28) q(0 0 2 -1) r(3 3) U5'
+  '13-36006147-36006164 NNNN CT(88 89 0) RT(1594812019469 35) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8056,8 +8289,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -8087,9 +8320,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:23 GMT',
+  'Wed, 15 Jul 2020 11:20:20 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -8109,7 +8342,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '87497f5eae995c7049637bc6915000b5',
+  'd9e7ddea77c386e2ebd9a79172c77bae',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -8121,11 +8354,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=XbhF9m3KQKG5V+PEie9tKpfWDV8AAAAAQUIPAAAAAADxJEvg+c7EIo2PiiR/yeWA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Co8GGFhpQoKdXpbbPKPS/HTmDl8AAAAAQUIPAAAAAAC4jwSiWl0BIh6fsv4Cs5e9; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=+BjiHLVBIiv2T16wKsJtVwAAAADK30NbV+VH81bZrbmLIfHw; path=/; Domain=.contentful.com',
+  'nlbi_673446=Ww5peaHnoyQpvEt3KsJtVwAAAAAanOdenLBysAu5w38nsFIO; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Kf3fJj0kkxJi6/lMOoVtA5fWDV8AAAAAys3SuUL9RIyrbqYgvNX7Gw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=quQjSPWKuSbJaw9OOoVtA3TmDl8AAAAAtgUWQz/1TQc1q13AGlKcQw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8133,11 +8366,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20320282-20320292 NNYN CT(92 93 0) RT(1594742423323 27) q(0 0 2 -1) r(3 3) U5'
+  '11-24193980-24193991 NNYN CT(86 86 0) RT(1594812020186 35) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/2qjlQ6dEAo5bEW5SI1PAKv', {"sys":{"id":"2qjlQ6dEAo5bEW5SI1PAKv","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/5ACaSqp8quE2VUdm4ti00Z', {"sys":{"id":"5ACaSqp8quE2VUdm4ti00Z","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8150,10 +8383,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "2qjlQ6dEAo5bEW5SI1PAKv",
+    "id": "5ACaSqp8quE2VUdm4ti00Z",
     "type": "Entry",
-    "createdAt": "2020-07-14T16:00:21.438Z",
-    "updatedAt": "2020-07-14T16:00:25.435Z",
+    "createdAt": "2020-07-15T11:20:18.319Z",
+    "updatedAt": "2020-07-15T11:20:21.235Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8218,9 +8451,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:25 GMT',
+  'Wed, 15 Jul 2020 11:20:21 GMT',
   'etag',
-  'W/"14136653011521110968"',
+  'W/"3045145916106052823"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8238,25 +8471,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '0c80431b6a62b2e865ded6bf7443258e',
+  '6970d621a655fd6d2f86842c6dd22c42',
   'Content-Length',
-  '388',
+  '386',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=oTStHoA8T9i7eOjydXrmYZnWDV8AAAAAQUIPAAAAAACF2VPRy5ifp6/nAtNxd8UL; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FmekybhvRE6a+Mgwuw2PAnTmDl8AAAAAQUIPAAAAAADr/277nLwlXOCc0QZ+oXMv; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8qRsU9I43UxFZDbwKsJtVwAAAAA4Lh5vwVk+ZvqBgzD/ajZN; path=/; Domain=.contentful.com',
+  'nlbi_673446=kPnxbEKQvGWrhnRCKsJtVwAAAACZY1qx6nXzyrk+LPoHUDfF; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Nu80exeLD04G7flMOoVtA5nWDV8AAAAA7dF6UXsr8p3uht6U1BbpWw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=DJh8EgLo0FLUbA9OOoVtA3TmDl8AAAAACWpoqojgf/r9a4P69qsRyw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13527812-13527814 NNNN CT(88 89 0) RT(1594742424725 33) q(0 0 2 -1) r(4 4) U5'
+  '1-2861848-2861850 NNNN CT(88 88 0) RT(1594812020568 27) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/2qjlQ6dEAo5bEW5SI1PAKv/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/5ACaSqp8quE2VUdm4ti00Z/published')
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8269,10 +8502,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "2qjlQ6dEAo5bEW5SI1PAKv",
+    "id": "5ACaSqp8quE2VUdm4ti00Z",
     "type": "Entry",
-    "createdAt": "2020-07-14T16:00:21.438Z",
-    "updatedAt": "2020-07-14T16:00:25.937Z",
+    "createdAt": "2020-07-15T11:20:18.319Z",
+    "updatedAt": "2020-07-15T11:20:21.715Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8281,8 +8514,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-14T16:00:25.937Z",
-    "firstPublishedAt": "2020-07-14T16:00:25.937Z",
+    "publishedAt": "2020-07-15T11:20:21.715Z",
+    "firstPublishedAt": "2020-07-15T11:20:21.715Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8347,9 +8580,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:26 GMT',
+  'Wed, 15 Jul 2020 11:20:21 GMT',
   'etag',
-  'W/"17433361460839943386"',
+  'W/"12097007725014896026"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8367,25 +8600,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'de193f6889634667eb4fbee7910fa2e2',
-  'transfer-encoding',
-  'chunked',
+  '8db7a0766c002953728d459e6dfbca89',
+  'Content-Length',
+  '415',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vWm3EeYnTDOW/L4R9BSB15nWDV8AAAAAQUIPAAAAAAAHPUw/sQobSItBOvWpUQkR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=wSWkvw2EQN62y293Mv4O73XmDl8AAAAAQUIPAAAAAADNXIHOhUbRz7j2C57vHBXw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=BK2yQZsntHqdp8qmKsJtVwAAAADGau+rX/ekoPWN6ejVG6J1; path=/; Domain=.contentful.com',
+  'nlbi_673446=jaq+V/f+xWEamRP+KsJtVwAAAADLAZXoy7p12HYkoxbn8zfS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=uAKqYjoJxHWb7flMOoVtA5nWDV8AAAAA3riaz6+ICDAOUAizUVIJzA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=9phQYmYFdBn8bQ9OOoVtA3XmDl8AAAAAdcNzjzyGxehazDJgUREliw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17403866-17403871 NNNN CT(87 88 0) RT(1594742425275 40) q(0 0 1 -1) r(4 4) U5'
+  '13-36006609-36006616 NNNN CT(89 87 0) RT(1594812021040 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4FiuEf8CqgsbY1ZI4wBg0X', {"sys":{"id":"4FiuEf8CqgsbY1ZI4wBg0X","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/551boZKK9dmBDwpfWaQmd5', {"sys":{"id":"551boZKK9dmBDwpfWaQmd5","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8398,10 +8631,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "4FiuEf8CqgsbY1ZI4wBg0X",
+    "id": "551boZKK9dmBDwpfWaQmd5",
     "type": "Entry",
-    "createdAt": "2020-07-14T16:00:22.276Z",
-    "updatedAt": "2020-07-14T16:00:26.581Z",
+    "createdAt": "2020-07-15T11:20:19.041Z",
+    "updatedAt": "2020-07-15T11:20:22.321Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8466,9 +8699,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:26 GMT',
+  'Wed, 15 Jul 2020 11:20:22 GMT',
   'etag',
-  'W/"18207385812785737405"',
+  'W/"12812563658042893928"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8486,25 +8719,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b646ad90e571e8b1e5b1cbb51b293226',
+  '69f265db5fc5ae0f868b9d8d333c1215',
   'Content-Length',
-  '388',
+  '387',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=LbikgXKqRMecMscsno2dMprWDV8AAAAAQUIPAAAAAABqP1obzHERyQrJt/hqS5Ol; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=uedokmXGQ+CyQ97qQ5xEZ3bmDl8AAAAAQUIPAAAAAABMjpjHpvrH6PNJtkhEJTor; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=atkAViFUkAfG5LAqKsJtVwAAAACPM40uQetAlM6H5SrCOESL; path=/; Domain=.contentful.com',
+  'nlbi_673446=KtPEbr+2L3hdqgqoKsJtVwAAAABARTjbZ8oGi6IVDvDiAtfQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=gg45FpI6CiUs7vlMOoVtA5rWDV8AAAAAHJZQthT6NeH/IlDQZbjMBw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1zWbWseHC0oqbw9OOoVtA3bmDl8AAAAAD8iKhMt+Willd7+r1zhacg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-4140346-4140349 NNNN CT(94 94 0) RT(1594742425886 34) q(0 0 2 -1) r(4 4) U5'
+  '9-9348488-9348492 NNNN CT(88 89 0) RT(1594812021627 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4FiuEf8CqgsbY1ZI4wBg0X/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/551boZKK9dmBDwpfWaQmd5/published')
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8517,10 +8750,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "4FiuEf8CqgsbY1ZI4wBg0X",
+    "id": "551boZKK9dmBDwpfWaQmd5",
     "type": "Entry",
-    "createdAt": "2020-07-14T16:00:22.276Z",
-    "updatedAt": "2020-07-14T16:00:27.168Z",
+    "createdAt": "2020-07-15T11:20:19.041Z",
+    "updatedAt": "2020-07-15T11:20:22.826Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8529,8 +8762,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-14T16:00:27.168Z",
-    "firstPublishedAt": "2020-07-14T16:00:27.168Z",
+    "publishedAt": "2020-07-15T11:20:22.826Z",
+    "firstPublishedAt": "2020-07-15T11:20:22.826Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8595,9 +8828,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:27 GMT',
+  'Wed, 15 Jul 2020 11:20:22 GMT',
   'etag',
-  'W/"16244480329112468108"',
+  'W/"16019902109207386826"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8607,29 +8840,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'b804595fe31d40f3c3fb1d9b160c41f0',
-  'transfer-encoding',
-  'chunked',
+  '9c4bc8561c34c4329fbbd46e87e50143',
+  'Content-Length',
+  '417',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=VHXrfMKGQsWZftSMjTm8jZrWDV8AAAAAQUIPAAAAAABExbX9oUDGgRPkDfY+NVv7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=5i614lhsSX2z3ce+S3cDY3bmDl8AAAAAQUIPAAAAAACsJM7DhQBA/yWasfsYhv2h; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ZyNoDQGnOXCOlK8ZKsJtVwAAAAAa5ZJH2jIeNM7AA4dSDb/Y; path=/; Domain=.contentful.com',
+  'nlbi_673446=ITv0dl1R4nIME+q/KsJtVwAAAAC2UtenwHHrf76U2Ixjd0Qr; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=3RrdDlGY5gTv7vlMOoVtA5rWDV8AAAAA1RzzSIdKl9eYAvzdyaE8Hg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=H/wnVa3wz29NcA9OOoVtA3bmDl8AAAAAcj1XWAL8ZdvQvk6jAQH2KQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-4140409-4140417 NNNN CT(93 94 0) RT(1594742426494 36) q(0 0 2 -1) r(4 4) U5'
+  '5-23233195-23233204 NNNN CT(93 93 0) RT(1594812022140 37) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8655,10 +8888,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "4FiuEf8CqgsbY1ZI4wBg0X",
+        "id": "551boZKK9dmBDwpfWaQmd5",
         "type": "Entry",
-        "createdAt": "2020-07-14T16:00:22.276Z",
-        "updatedAt": "2020-07-14T16:00:27.168Z",
+        "createdAt": "2020-07-15T11:20:19.041Z",
+        "updatedAt": "2020-07-15T11:20:22.826Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8667,8 +8900,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-14T16:00:27.168Z",
-        "firstPublishedAt": "2020-07-14T16:00:27.168Z",
+        "publishedAt": "2020-07-15T11:20:22.826Z",
+        "firstPublishedAt": "2020-07-15T11:20:22.826Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8721,10 +8954,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "2qjlQ6dEAo5bEW5SI1PAKv",
+        "id": "5ACaSqp8quE2VUdm4ti00Z",
         "type": "Entry",
-        "createdAt": "2020-07-14T16:00:21.438Z",
-        "updatedAt": "2020-07-14T16:00:25.937Z",
+        "createdAt": "2020-07-15T11:20:18.319Z",
+        "updatedAt": "2020-07-15T11:20:21.715Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8733,8 +8966,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-14T16:00:25.937Z",
-        "firstPublishedAt": "2020-07-14T16:00:25.937Z",
+        "publishedAt": "2020-07-15T11:20:21.715Z",
+        "firstPublishedAt": "2020-07-15T11:20:21.715Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8801,9 +9034,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:27 GMT',
+  'Wed, 15 Jul 2020 11:20:23 GMT',
   'etag',
-  'W/"12336269207667690128"',
+  'W/"11432752330253039410"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8813,29 +9046,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '16ba8cf930617e25968f8d0a5c780949',
+  'e916782d934246be166f4d7eb14a723c',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=bmye7nzuQdae9KN3UYTec5vWDV8AAAAAQUIPAAAAAADKZuf24gdDkfuJ5+QCb1Fr; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=6n14jWrrQ5eK8gqnBX8jinfmDl8AAAAAQUIPAAAAAABOk2mW1JAuxgoieX5W+xuV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=puwRIeuiRQN3USAFKsJtVwAAAAAfrn3dtstLlEcr/Rl2XBXc; path=/; Domain=.contentful.com',
+  'nlbi_673446=0RC4LGb+1kBDVz7gKsJtVwAAAAAaCzWgnqFTMNCFlGcrgU3m; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=TCprP1SUF21V7/lMOoVtA5vWDV8AAAAAoyWY9HSGQHFjLqsiDR83pA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=jLDVL8U7GHt4cQ9OOoVtA3fmDl8AAAAAPXos60t7+PpRPXv4mk5mAw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '2-3148973-3148974 NNNN CT(93 95 0) RT(1594742427110 30) q(0 0 2 -1) r(3 3) U5'
+  '10-14426992-14427001 NNNN CT(86 89 0) RT(1594812022852 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8872,7 +9105,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:28 GMT',
+  'Wed, 15 Jul 2020 11:20:24 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -8892,15 +9125,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '902cbc61fd10f77cf11d5bf2689e0d5d',
+  'e7fbcd4f8e02cb57497598dce9327af1',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Mfe98czcQl+MJeT1PiuAyJzWDV8AAAAAQUIPAAAAAADrK8GcM1Fasyua5ljJqlUA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MmBgqAO/QfqHoJW93oH8kXfmDl8AAAAAQUIPAAAAAABFlzdRbVU0BnHdfllpvDYM; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=c5P4SQWVNC1s+3WNKsJtVwAAAADDUxDyrQHCBGyqBfIZX6fn; path=/; Domain=.contentful.com',
+  'nlbi_673446=Dm9pCUff6kjLEVKYKsJtVwAAAACXDGwPM0PcyrCYO06ZB2Dj; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=/0NqRRYYwjzB7/lMOoVtA5zWDV8AAAAAcWPVSBTKcETMKlJ/lGv+LA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=O6iUe2XyFz7bcg9OOoVtA3fmDl8AAAAAYLfipk4WooaddBFJbvWDqg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8908,7 +9141,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20321262-20321274 NNYN CT(95 87 0) RT(1594742427631 37) q(0 0 2 -1) r(4 4) U5'
+  '11-24194974-24194981 NNYN CT(86 86 0) RT(1594812023465 35) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8925,7 +9158,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "0050b204b4a09ee50189f93e52f60a67"
+  "requestId": "56295f486fa2dfc63add6576fcc70f6f"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -8949,9 +9182,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:28 GMT',
+  'Wed, 15 Jul 2020 11:20:24 GMT',
   'etag',
-  '"10792275763360566336"',
+  '"4326466516401107974"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8969,15 +9202,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '0050b204b4a09ee50189f93e52f60a67',
+  '56295f486fa2dfc63add6576fcc70f6f',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fGKLT+7HSQ2mv+NljeSWapzWDV8AAAAAQUIPAAAAAACo2Cox9gryCwCddRFLF01U; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=tL1ljN+FSrGykdGqOr/Ca3jmDl8AAAAAQUIPAAAAAABQzzz7fsqPmeo3QaKaBSnc; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=pqg7cFtfmjEUCHxdKsJtVwAAAACm7fCcVOAs7Hk3AduLEqCs; path=/; Domain=.contentful.com',
+  'nlbi_673446=pPIxBpnm2GG5uo4PKsJtVwAAAAAuIdrAS3caiJgI1MrYjV1S; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=AxwWPhzpojQ38PlMOoVtA5zWDV8AAAAAJadFZynPrwyR+quZFZ6Spg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=jbWFdQ+TJi/Ccw9OOoVtA3jmDl8AAAAAghetfT4aGzn3kyACZGX9Cw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8985,7 +9218,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-8162607-8162617 NNYN CT(97 101 0) RT(1594742428131 32) q(0 0 2 -1) r(4 4) U5'
+  '12-30378001-30378015 NNYN CT(88 88 0) RT(1594812023907 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9026,8 +9259,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -9057,9 +9290,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:29 GMT',
+  'Wed, 15 Jul 2020 11:20:25 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -9071,15 +9304,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '7',
   'X-Contentful-Request-Id',
-  '14915318fc930a5866139fb2e7efb138',
+  '18e8146921d6110dee676d4ecd6fe6f3',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -9091,11 +9324,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=xyPnZJpjQxCRwT4tagHZvp3WDV8AAAAAQUIPAAAAAAC3n8HbgGeMlMLlMNoI1udq; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rOZx+kcZS0CTuQYKzbrDi3jmDl8AAAAAQUIPAAAAAAA1EZwwcBjruQB+ZZv82cvG; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=p1A0Nrnpj0+niCPiKsJtVwAAAAAK2RTDgoCvKvX6RlQ/ZICV; path=/; Domain=.contentful.com',
+  'nlbi_673446=oDMSYS7301W5xOdrKsJtVwAAAACnaLzbYmRV1Bg2gZpeMpid; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=7i2fHJ08aVCv8PlMOoVtA53WDV8AAAAAEoEiZpmOd5IdLNVoqjkA+A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=sW4rBR2vsEy6dA9OOoVtA3jmDl8AAAAA+j9ngbD40UmkihYcdX23SQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9103,12 +9336,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-6344394-6344397 NNYN CT(87 88 0) RT(1594742428745 28) q(0 0 2 -1) r(3 3) U5'
+  '7-12574428-12574439 NNYN CT(86 87 0) RT(1594812024410 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost', {"name":"Blog post","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-14T16:00:29.878Z","updatedAt":"2020-07-14T16:00:29.878Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-15T11:20:25.720Z","updatedAt":"2020-07-15T11:20:25.720Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -9130,9 +9363,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:29 GMT',
+  'Wed, 15 Jul 2020 11:20:25 GMT',
   'etag',
-  '"14285541248354921546"',
+  '"9571140362493432271"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9142,29 +9375,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '53e07a8b1e199fc1f84f4731c2809c81',
+  'a24393c564a29b63b07df21e214eb5ac',
   'Content-Length',
   '1054',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=jzc+GF6CRX2lvm1QRNtHu53WDV8AAAAAQUIPAAAAAAD6mdLmdnrunEQslrL/SVeK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=E9wafwnTQfuvnZhR2tFC0HnmDl8AAAAAQUIPAAAAAACrWgcNM9Ba0YNbXPK5nkQH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SOsqIb7X5Rec+BLPKsJtVwAAAACWW92r+c+2tJGlSLLeUSo3; path=/; Domain=.contentful.com',
+  'nlbi_673446=FHHmIQA7lhhZTYuCKsJtVwAAAACXhzOEzqbckHTr+taoMCQH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=+wImL6QERHk78flMOoVtA53WDV8AAAAAdjbHIruGocGLYHySjkUa/Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=O8Y0GqL/C1h5dg9OOoVtA3nmDl8AAAAA0xIHO4sAsruJdjJ35EA1Ow==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-8162789-8162801 NNNN CT(86 87 0) RT(1594742429165 32) q(0 0 2 -1) r(5 5) U5'
+  '13-36008004-36008019 NNNN CT(87 87 0) RT(1594812024914 35) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9180,8 +9413,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:29.878Z",
-    "updatedAt": "2020-07-14T16:00:30.418Z",
+    "createdAt": "2020-07-15T11:20:25.720Z",
+    "updatedAt": "2020-07-15T11:20:26.403Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9205,8 +9438,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
-    "publishedAt": "2020-07-14T16:00:30.418Z",
+    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+    "publishedAt": "2020-07-15T11:20:26.403Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -9256,9 +9489,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:30 GMT',
+  'Wed, 15 Jul 2020 11:20:26 GMT',
   'etag',
-  'W/"6828217408317239309"',
+  'W/"5140207975816893466"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9276,21 +9509,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fd0964184f8587396253deb701dd7e83',
+  'd4ef405593681c819c4460f5677b9430',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=5Rwupq9XSYmANLewNIyfRJ7WDV8AAAAAQUIPAAAAAACV7viHzyyHxXsqbJa8j8dT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sYA+l4CRTvWWJpTrUtrYWnrmDl8AAAAAQUIPAAAAAAD2wL1x/zc3D3290T3ZVaQV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XgTSJOw2KV3a13UHKsJtVwAAAAArPc3QeMOMzGYzSBvuY2J0; path=/; Domain=.contentful.com',
+  'nlbi_673446=aLC9Yb4q2gvriAIWKsJtVwAAAAAd0R0Sfz+QUABCPg2OSh9/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=3fGsGaS8TCvv8flMOoVtA57WDV8AAAAAh/jwcW1EidIiX7N8MlRodQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=xK+hYgJfElzweA9OOoVtA3rmDl8AAAAApj8uwNMH4bg/PFO0ykeuqA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27003733-27003744 NNNN CT(88 88 0) RT(1594742429771 30) q(0 0 1 -1) r(4 4) U5'
+  '7-12574715-12574719 NNNN CT(92 94 0) RT(1594812025724 36) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9317,7 +9550,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9325,7 +9558,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:31.070Z",
+    "updatedAt": "2020-07-15T11:20:27.007Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -9373,9 +9606,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:31 GMT',
+  'Wed, 15 Jul 2020 11:20:27 GMT',
   'etag',
-  'W/"12431943504097401511"',
+  'W/"12054685273160273957"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9393,21 +9626,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '035225c93d25c14f48124b72b0ea6cc1',
+  '15c62fdb544d5b9cb8610b07d23b35e5',
   'Content-Length',
   '383',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ptOdz+bIRpu5Ob6KPLiRaZ7WDV8AAAAAQUIPAAAAAACdZa69o2wpvpZkRUwLeJ8h; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=niPLp4ejTO+7wXnM4Sk5UnrmDl8AAAAAQUIPAAAAAAD7yJV0BWNETumrp1gqp66A; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xzDLZYpdvHUw5JPcKsJtVwAAAABVuhxenlvViAFcJuAq0Q4F; path=/; Domain=.contentful.com',
+  'nlbi_673446=QPYdan+smxjrBBR4KsJtVwAAAABGKvdAvG8zrtenq8AtuK9c; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=tHI+VjxlaVZi8vlMOoVtA57WDV8AAAAAEbn8qSRweacFE0gk1fVzvw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=JixFbLdqmFcFeg9OOoVtA3rmDl8AAAAAt1Yz36GKMnLR4xDaUs+OBg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17404847-17404861 NNNN CT(88 88 0) RT(1594742430391 33) q(0 0 2 -1) r(4 4) U5'
+  '11-24195769-24195775 NNNN CT(93 96 0) RT(1594812026320 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9424,7 +9657,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9432,7 +9665,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:31.070Z",
+    "updatedAt": "2020-07-15T11:20:27.007Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9490,9 +9723,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:31 GMT',
+  'Wed, 15 Jul 2020 11:20:27 GMT',
   'etag',
-  'W/"4178674710576013527"',
+  'W/"10198323548035316952"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9510,21 +9743,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '0acebafaa9789ae827c4419e9d721c83',
-  'transfer-encoding',
-  'chunked',
+  '9b53da1b0ec27daf69e6ac65879d4a88',
+  'Content-Length',
+  '370',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=2wYvZepAQRigtSUz3CiFhZ/WDV8AAAAAQUIPAAAAAACggh9koRylZym4jtwJzgu/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=NdHerjNzSKC2tEiafXWK5nvmDl8AAAAAQUIPAAAAAAD+BMJUIllwKfOtntixIaer; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PqMLa79ukjw2MoJnKsJtVwAAAAAT70apzpx/4IliPy/C2oxk; path=/; Domain=.contentful.com',
+  'nlbi_673446=tddxTlc1IUYv2GreKsJtVwAAAACuFHsYrSAeajxiuFJ58Q6b; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=noFJFYAKB0Tw8vlMOoVtA5/WDV8AAAAAzhs5/Uq84wUBJYmeC3yKBA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=NjafJB87MBYJew9OOoVtA3vmDl8AAAAAaumoRzRhpQPf84h/ulTkzw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20322125-20322141 NNNN CT(92 92 0) RT(1594742430999 34) q(0 0 2 -1) r(3 3) U5'
+  '14-47490592-47490609 NNNN CT(89 89 0) RT(1594812026844 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9549,8 +9782,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-14T16:00:29.878Z",
-        "updatedAt": "2020-07-14T16:00:30.418Z",
+        "createdAt": "2020-07-15T11:20:25.720Z",
+        "updatedAt": "2020-07-15T11:20:26.403Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -9559,8 +9792,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-14T16:00:30.418Z",
-        "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+        "publishedAt": "2020-07-15T11:20:26.403Z",
+        "firstPublishedAt": "2020-07-15T11:20:26.403Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -9627,9 +9860,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:32 GMT',
+  'Wed, 15 Jul 2020 11:20:27 GMT',
   'etag',
-  'W/"15466410452043374031"',
+  'W/"902835408233017923"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9639,29 +9872,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'b9eb039e75a5eab8094d8c8a84f078d1',
+  '437d6a0fc7aa76a711b6cc08742e4a99',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ScSNCA5PTjW0qrmEB+sB/KDWDV8AAAAAQUIPAAAAAAAAv6DDO7k2IGI7Rcwa9pR0; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vQF9fwzhQbGXyByEttKC13vmDl8AAAAAQUIPAAAAAACBNW7NOQ32LwFV17uLo3j3; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=QZ/IQ5pUcQgvJuAGKsJtVwAAAADuIfV712h6eqULWNFL+TR8; path=/; Domain=.contentful.com',
+  'nlbi_673446=fJ5oTalz2Qe4zKGpKsJtVwAAAAD9kf/i8fEzBfu4pAJHCBT1; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=+dMZI7KYeWJ98/lMOoVtA6DWDV8AAAAAC64TzCkLyG9I7Ly9Lo+6fw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7L+pUlL7eTf+ew9OOoVtA3vmDl8AAAAAhXofNuWR7qoLu9ZdaJ2fSQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13528833-13528840 NNNN CT(94 93 0) RT(1594742431645 34) q(0 0 2 -1) r(4 4) U5'
+  '14-47490800-47490813 NNNN CT(96 97 0) RT(1594812027268 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9678,7 +9911,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9686,7 +9919,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:31.070Z",
+    "updatedAt": "2020-07-15T11:20:27.007Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9744,9 +9977,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:32 GMT',
+  'Wed, 15 Jul 2020 11:20:28 GMT',
   'etag',
-  'W/"4178674710576013527"',
+  'W/"10198323548035316952"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9756,29 +9989,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '1f41fa50686c9833c2a0da84cef404ae',
-  'Content-Length',
-  '370',
+  'cbfc66bdd99092e90226fb1aa56fc708',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=rovvk8E1RLG4dhLnRlSa5aDWDV8AAAAAQUIPAAAAAAAcnibvenUaF5BC9cyn6b7G; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3GVasBz8Re24aaAe7l2VAHzmDl8AAAAAQUIPAAAAAABTVBZ//QmrpoWXvmBzHmGr; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=pAW6UGVHvEy5tqpcKsJtVwAAAACXpd7i67D1+TWj7M3nS/CR; path=/; Domain=.contentful.com',
+  'nlbi_673446=8Qlke2i6UkK9uOV1KsJtVwAAAACgWHcHvZK3+nfGPjuqSnfl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=RHlfK1XWczQA9PlMOoVtA6DWDV8AAAAAJvqAg8TpNLM2Tcf+rgX2lA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=FuJDd/D3szf8fA9OOoVtA3zmDl8AAAAA9VJaVVYl/HGJoumyZbtJQw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20322459-20322468 NNNN CT(89 89 0) RT(1594742432237 30) q(0 0 2 -1) r(4 4) U5'
+  '9-9349485-9349496 NNNN CT(93 94 0) RT(1594812027769 35) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9819,8 +10052,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -9850,9 +10083,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:33 GMT',
+  'Wed, 15 Jul 2020 11:20:28 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -9864,15 +10097,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'd944676f0205147ae93b8f0436956683',
+  'a503d9b2d2e83ca4c984c045a912f062',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -9884,11 +10117,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=jlstKOAKQIG4zNVAt5hWyKHWDV8AAAAAQUIPAAAAAACtMxIb/IZ6t3f7GjiNHVf5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=pyjecqE3SAyTi5rCN2heinzmDl8AAAAAQUIPAAAAAACeIIcYmdwJzXlPSCVJVosC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NRERW0/MhGpiWOaqKsJtVwAAAACNlTLkmuPDAFXCznGP4pya; path=/; Domain=.contentful.com',
+  'nlbi_673446=O0SjZ2yyZXB9DXG+KsJtVwAAAADPiTZnAebrgru+XXW0Cf8o; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=/8obA85aGQGR9PlMOoVtA6HWDV8AAAAATxSEHYmMAcNCRZuHRVcCtg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=IhVgDmOVwwsbfg9OOoVtA3zmDl8AAAAA6/J/BqpHQJbNrnL9wwh3Nw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9896,7 +10129,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-8163414-8163420 NNYN CT(99 100 0) RT(1594742432871 26) q(0 0 2 -1) r(4 4) U5'
+  '11-24196247-24196259 NNYN CT(88 89 0) RT(1594812028378 33) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9912,8 +10145,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:29.878Z",
-    "updatedAt": "2020-07-14T16:00:33.981Z",
+    "createdAt": "2020-07-15T11:20:25.720Z",
+    "updatedAt": "2020-07-15T11:20:29.456Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9922,8 +10155,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-14T16:00:30.418Z",
-    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+    "publishedAt": "2020-07-15T11:20:26.403Z",
+    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -9988,9 +10221,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:34 GMT',
+  'Wed, 15 Jul 2020 11:20:29 GMT',
   'etag',
-  'W/"854256650927920123"',
+  'W/"8197350643571311752"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10000,29 +10233,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '2d9236aba9250c0585499eb2f76773af',
+  'f59e9a3000491d38cb7332d2ef43f85f',
   'Content-Length',
-  '454',
+  '452',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mARuKgzRS+yLnuuXl84jC6HWDV8AAAAAQUIPAAAAAABxLi4bCSmkMY8/fUBt/HSY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=D89n9uEuSI+LR/7S/W3nyX3mDl8AAAAAQUIPAAAAAAD/nEog0MIUYYb16bgxUd3/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=afHYT0U4Bx5yaxPaKsJtVwAAAADjUJAHgxoixE4lQIWfFc4K; path=/; Domain=.contentful.com',
+  'nlbi_673446=D15THue6aF19HyzSKsJtVwAAAAAillYLMIAalgOdC3JvIdDr; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=GbocL2HAOi8A9flMOoVtA6HWDV8AAAAAd30TKFsKj9nXstD3vTobeA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=tEUNT1pn63Mtfw9OOoVtA33mDl8AAAAAyTq0TiDzmQZ1OQZhS90Slw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27004736-27004743 NNNN CT(94 97 0) RT(1594742433281 37) q(0 0 2 -1) r(4 4) U5'
+  '10-14428086-14428092 NNNN CT(86 87 0) RT(1594812028788 33) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10038,8 +10271,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:29.878Z",
-    "updatedAt": "2020-07-14T16:00:34.458Z",
+    "createdAt": "2020-07-15T11:20:25.720Z",
+    "updatedAt": "2020-07-15T11:20:30.042Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10048,8 +10281,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:34.458Z",
-    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+    "publishedAt": "2020-07-15T11:20:30.042Z",
+    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10114,131 +10347,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:34 GMT',
+  'Wed, 15 Jul 2020 11:20:30 GMT',
   'etag',
-  'W/"17196034623532127127"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'dc3ede0a328f16a30f5d1480446b14b7',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=zpc3NAcGSLuFvFBUa4gHTKLWDV8AAAAAQUIPAAAAAAD4XhaW0em6p8wxcFVSIehP; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=y05NQCS/DhYTcJhBKsJtVwAAAABWTcAW+K2ncRb1jDZIfXpR; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=3jfbH+2kxkeB9flMOoVtA6LWDV8AAAAAufwNAjmrdgA9S4NXWXUTaQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '12-17405670-17405680 NNNN CT(93 96 0) RT(1594742433793 32) q(0 0 2 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[]})
-  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-14T16:00:30.513Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-14T16:00:35.152Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 16:00:35 GMT',
-  'etag',
-  '"15152394975435498389"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'ce90bc3f77df1c46fedcc972bff09cd0',
-  'Content-Length',
-  '880',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=zxR/xCXhQ7qvrNqiN9LeOKLWDV8AAAAAQUIPAAAAAACzFxgCqfjkDsjR9h2CmFq4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=/MSNMuKKSTdEG7S1KsJtVwAAAACAiR7PZ2OCJ17Y2KG2xqIS; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=XDBTPx5yUDws9vlMOoVtA6LWDV8AAAAAg3rP7z0tuUoCHhmNT8rf3Q==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '4-9014074-9014079 NNNN CT(88 88 0) RT(1594742434484 35) q(0 0 1 -1) r(3 3) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}]})
-  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-14T16:00:30.513Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-14T16:00:35.801Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Tue, 14 Jul 2020 16:00:35 GMT',
-  'etag',
-  '"1836674219385494909"',
+  'W/"6126344861331558714"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10256,21 +10367,143 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '27d61c3e66984a0f9eca111bc9cbccc4',
+  '52d10b478bc9b8522b1f07fe902e4b8d',
+  'Content-Length',
+  '461',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=v6eHWDhvTpW7b7NFymJw4X3mDl8AAAAAQUIPAAAAAADdPb6G9qRLdeEWVlKE8wJg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=6G2GRnQPaCqlroURKsJtVwAAAAAcD4P+iK6dJcFLDSthZBeE; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=T5TNawHdDk56gA9OOoVtA33mDl8AAAAAbzf0apGg2N01Z5scioGwow==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '7-12575224-12575227 NNNN CT(86 87 0) RT(1594812029398 33) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[]})
+  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-15T11:20:26.475Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T11:20:30.671Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:20:30 GMT',
+  'etag',
+  '"5202440968502403685"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'efaddacd8fd3749aae3bab36d5c9bfee',
+  'Content-Length',
+  '880',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=uvJYEpWPTBWnbbtyaVpOUn7mDl8AAAAAQUIPAAAAAACcx9mEMgdN5ruulCOsdIf7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=GzleK9S5fSPppvFLKsJtVwAAAABnG6qFAWXebGQ9WrGjCuoz; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=HbFrNwZhzQGXgQ9OOoVtA37mDl8AAAAAk/hZhwgQZKdM8Hilyg39Ow==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '3-10883465-10883472 NNNN CT(87 87 0) RT(1594812030022 26) q(0 0 2 -1) r(3 3) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}]})
+  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-15T11:20:26.475Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T11:20:31.279Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 11:20:31 GMT',
+  'etag',
+  '"6959354504976781302"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '0894ec5d438667ac9d589744c24166ca',
   'Content-Length',
   '987',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YwRD8gtqQI6J2VKehjYasaPWDV8AAAAAQUIPAAAAAAB59WVtTHKjp01CKM8jPaxW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fBiSDsAHRraL39Aet6bvfX7mDl8AAAAAQUIPAAAAAACh0NZ6v3CDHQQLdkHvlJ97; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=HESsL5fGPG4b2PKpKsJtVwAAAABcN913ue9LicqIc6TzD/Sa; path=/; Domain=.contentful.com',
+  'nlbi_673446=Ytm3TWql+AFXZB2lKsJtVwAAAADTuQY6x99C8GUvwBAqZP3/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=cF06Wd4z2W4V9/lMOoVtA6PWDV8AAAAAO2cW4xTQzoDqVF7QNCarRg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=4xdZC/pIskXLgg9OOoVtA37mDl8AAAAAt2FBOnmMDiJebB2QfTu6qQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27005258-27005266 NNNN CT(91 89 0) RT(1594742435098 34) q(0 0 2 -1) r(4 4) U5'
+  '4-15466771-15466775 NNNN CT(87 87 0) RT(1594812030638 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10287,7 +10520,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10295,7 +10528,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:35.801Z",
+    "updatedAt": "2020-07-15T11:20:31.279Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10348,9 +10581,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:36 GMT',
+  'Wed, 15 Jul 2020 11:20:31 GMT',
   'etag',
-  '"15837268598995971550"',
+  '"17156288789629272913"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10360,23 +10593,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '2902406d9f48ed75a4852be5bd046277',
+  '18271ad07c5ddc115f10b1c3b3580c95',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=GWUwtFVORuurx0ud4B7uhKPWDV8AAAAAQUIPAAAAAADJuB/28ppbxq6iiFvwpF9A; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Gg6K+TpqQimbp+LZLxLOY3/mDl8AAAAAQUIPAAAAAAAqaXendJEeZIkJIsYkRdfd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=L75pe12yUAFqLJyGKsJtVwAAAADwU5/Z9UoJ7yFb6bPPqGfy; path=/; Domain=.contentful.com',
+  'nlbi_673446=O+IqI+AKx1mrwVJSKsJtVwAAAABwOTJ9Ksdg2Abkug5tvg+y; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=A7qeEIYdT0+L9/lMOoVtA6PWDV8AAAAALIVwtyahFABiGRBcW4OFpw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Lb5hfB3+Fi0mhA9OOoVtA3/mDl8AAAAAkN0vtHcsveBCpxdBBluBug==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10384,7 +10617,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-27005410-27005414 NNYN CT(95 98 0) RT(1594742435617 33) q(0 0 2 -1) r(3 3) U5'
+  '13-36009994-36010011 NNYN CT(86 88 0) RT(1594812031250 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10409,8 +10642,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-14T16:00:29.878Z",
-        "updatedAt": "2020-07-14T16:00:34.458Z",
+        "createdAt": "2020-07-15T11:20:25.720Z",
+        "updatedAt": "2020-07-15T11:20:30.042Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -10419,8 +10652,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-14T16:00:34.458Z",
-        "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+        "publishedAt": "2020-07-15T11:20:30.042Z",
+        "firstPublishedAt": "2020-07-15T11:20:26.403Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -10487,9 +10720,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:36 GMT',
+  'Wed, 15 Jul 2020 11:20:32 GMT',
   'etag',
-  'W/"10849270469145892691"',
+  'W/"7534781789484185536"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10499,29 +10732,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'eda89647889b39aaabdd4ba4b92bc350',
-  'Content-Length',
-  '525',
+  'c2a3e37f92d8eb72277d7283ba5203bc',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=bzVklE49R0OIyr0LJWc72aTWDV8AAAAAQUIPAAAAAAB5beg/1BP/p4VQ2P7XQuAY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=crVsezucR8SsbbGOLa51FYDmDl8AAAAAQUIPAAAAAADe68DaNrjcpcE68aH03O9x; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JxkpLVc1ckMUKy0lKsJtVwAAAACt+ZFQ/gnFIZHbfAd8ePku; path=/; Domain=.contentful.com',
+  'nlbi_673446=Tbs4W86c6nvl0zAsKsJtVwAAAAChycAtGW7edFqMECkroC2x; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=1lQPDhharxEd+PlMOoVtA6TWDV8AAAAA2jXpQmeDVXsNpKGqMaz/Nw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=J38NO9XflkS7hQ9OOoVtA4DmDl8AAAAAg0Gmc+Uhojc8MfhrYm7RPA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-8163897-8163903 NNNN CT(93 93 0) RT(1594742436131 30) q(0 0 2 -1) r(5 5) U5'
+  '7-12575534-12575536 NNNN CT(87 88 0) RT(1594812031867 37) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10538,7 +10771,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10546,7 +10779,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:35.801Z",
+    "updatedAt": "2020-07-15T11:20:31.279Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10599,9 +10832,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:37 GMT',
+  'Wed, 15 Jul 2020 11:20:33 GMT',
   'etag',
-  '"15837268598995971550"',
+  '"17156288789629272913"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10619,15 +10852,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd73423319c549b0cab63ac95b0cb2dfd',
+  '6b02b803b753f39d1fb3bde27eac8f6b',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Ob++oSnLTQSkhBDjzQA/EqXWDV8AAAAAQUIPAAAAAAAd2TppK/Bu/Tzz8DrUVCAX; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YfdqPRLdS7mfFKm6FehxJ4DmDl8AAAAAQUIPAAAAAAB+/816Yvpsu1aYCtNuMTSt; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Jp+9EqK94VCWUSA+KsJtVwAAAAA1t0ni4MD90bmAJ17YuIwP; path=/; Domain=.contentful.com',
+  'nlbi_673446=lghReXJOqUSh/JrbKsJtVwAAAACEFNRSZPrAHIjM0YD9w0eJ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Y0XpQ5qx/D6Z+PlMOoVtA6XWDV8AAAAAUx6Lbi1oe/yGW66VlkMGiQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=q/mPPJhnRG4Ahw9OOoVtA4DmDl8AAAAALaK3rOiD1k1w/0XRugRscw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10635,7 +10868,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20323590-20323603 NNYN CT(94 98 0) RT(1594742436735 36) q(0 0 2 -1) r(4 4) U5'
+  '13-36010361-36010374 NNYN CT(87 88 0) RT(1594812032474 29) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10676,8 +10909,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -10707,9 +10940,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:37 GMT',
+  'Wed, 15 Jul 2020 11:20:33 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -10729,7 +10962,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '707a1e6185245e4fab58c9ba7feb7521',
+  '8b8b94f0b42ca16edd8a175b5a72893a',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -10741,11 +10974,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=crCXehEoQiustGcPeFpMdKXWDV8AAAAAQUIPAAAAAADZduyiG3uL7WCRXmU3WSNI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=X/jWEYCQRtWtFBd52FP6LoHmDl8AAAAAQUIPAAAAAAB3EaNfZfRx+EAPx4rA9If5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=3yTbVD298zc8XeJhKsJtVwAAAAAd5kX/VLOGglcJloX4ADjq; path=/; Domain=.contentful.com',
+  'nlbi_673446=F5RUPcAajDRuzIpNKsJtVwAAAADDnI6ZkIkr3o8p58eDeksm; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=DAluPA6IjRb8+PlMOoVtA6XWDV8AAAAAWPMmxEKN1ccKXvwd1pLn6A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=PoUJAALWa19ciA9OOoVtA4HmDl8AAAAANXfP/CgpBEORDqNJ5f9Nog==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10753,7 +10986,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-13779077-13779080 NNYN CT(85 86 0) RT(1594742437227 26) q(0 0 2 -1) r(3 3) U5'
+  '13-36010553-36010567 NNYN CT(87 92 0) RT(1594812033096 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10769,8 +11002,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:29.878Z",
-    "updatedAt": "2020-07-14T16:00:38.470Z",
+    "createdAt": "2020-07-15T11:20:25.720Z",
+    "updatedAt": "2020-07-15T11:20:34.382Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10779,8 +11012,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-14T16:00:34.458Z",
-    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+    "publishedAt": "2020-07-15T11:20:30.042Z",
+    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10845,9 +11078,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:38 GMT',
+  'Wed, 15 Jul 2020 11:20:34 GMT',
   'etag',
-  'W/"13334694213749400769"',
+  'W/"7815567457951041915"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10865,21 +11098,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e539ce06f55bac72820697204e67a161',
+  'b772a4e0f80b956dc1613b74fc03b85e',
   'Content-Length',
-  '462',
+  '466',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=T9er0W/bQJaTwmP8t7LQDabWDV8AAAAAQUIPAAAAAABZ3mPu43hMdUlrxBy9wDfx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3n0A5HeKSE+OB9/84Z2gHoLmDl8AAAAAQUIPAAAAAAA3DiQtysb1w8Ic2KvQ9xvv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=IvGQF12yDHHza8HnKsJtVwAAAAA+IYTAk4uXpzuJz6WnHbqX; path=/; Domain=.contentful.com',
+  'nlbi_673446=juynTqdcjV3ZL2l8KsJtVwAAAABorRFOvJM96colkzRR+sUo; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=E3pWdP9pkgK4+flMOoVtA6bWDV8AAAAAXRE6LB1MJs3Vb0+rS7sxFQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=G8qVBQ41CzXDiQ9OOoVtA4LmDl8AAAAA4/LlRXMVP65KXZ1cfyMulw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-17406609-17406615 NNNN CT(92 93 0) RT(1594742437677 24) q(0 0 1 -1) r(5 5) U5'
+  '13-36010660-36010680 NNNN CT(86 175 0) RT(1594812033504 38) q(0 0 3 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10895,8 +11128,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:29.878Z",
-    "updatedAt": "2020-07-14T16:00:39.059Z",
+    "createdAt": "2020-07-15T11:20:25.720Z",
+    "updatedAt": "2020-07-15T11:20:35.000Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10905,8 +11138,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-14T16:00:39.059Z",
-    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+    "publishedAt": "2020-07-15T11:20:35.000Z",
+    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10971,9 +11204,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:39 GMT',
+  'Wed, 15 Jul 2020 11:20:35 GMT',
   'etag',
-  'W/"13656252347462647717"',
+  'W/"12807943782668852324"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10983,29 +11216,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '2d05768074ca20815163a9e44e2d90d5',
-  'transfer-encoding',
-  'chunked',
+  'ac8eeb946fa79f2d06041d730c631a0f',
+  'Content-Length',
+  '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=SOcAZ6CKSUuJGrYuG+UMZKbWDV8AAAAAQUIPAAAAAABctIE/Lx74kO6NEnTgOaji; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=wT62ykJuR7C4ywtWa15vUILmDl8AAAAAQUIPAAAAAACZfUtmlPjOsn22cTAOe4GE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=yMDhT3duvimbq3BaKsJtVwAAAABkG9gZyW7ZaNDMzH0MvHXa; path=/; Domain=.contentful.com',
+  'nlbi_673446=72nsXkDeMX7jCivGKsJtVwAAAADOtm5QRmxN6uaZG0Za2MhV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=qv73aPwoMUBo+vlMOoVtA6bWDV8AAAAAvKW1jdN5OkSWlxVqErLCJw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=d05GL2V5RzMjjA9OOoVtA4LmDl8AAAAA2veOJ9gNUYfiC0uP14GYeA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27006284-27006293 NNNN CT(107 95 0) RT(1594742438382 34) q(0 0 2 -1) r(5 5) U5'
+  '12-30380826-30380833 NNNN CT(100 94 0) RT(1594812034334 26) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11032,7 +11265,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11040,7 +11273,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:40.068Z",
+    "updatedAt": "2020-07-15T11:20:35.616Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11088,9 +11321,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:40 GMT',
+  'Wed, 15 Jul 2020 11:20:35 GMT',
   'etag',
-  'W/"3859509757060937986"',
+  'W/"8868377458383301141"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11100,29 +11333,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '30c6651bb0189021329c458409022b06',
+  '21031e7f39848d5f018ad44442840bb3',
   'Content-Length',
-  '421',
+  '420',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=On9OlifOS2OIAtLXUjK2HafWDV8AAAAAQUIPAAAAAAAvwdRa6kBiXrVPLNgnD1bJ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=34aNG/4eQQOyCO+ryONLo4PmDl8AAAAAQUIPAAAAAACqUd6H/JpCocnd+qmwDWLB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XLVTYNqHpV+JYcdnKsJtVwAAAACD9ew0gw+MB+pEFoIXv2eW; path=/; Domain=.contentful.com',
+  'nlbi_673446=KmEqNXO4gTY341dWKsJtVwAAAADCBojKyJjnXMK3S55o2Kxl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=2j82DjotymZQ+/lMOoVtA6fWDV8AAAAAXgw+K8DH+ZZqLwLFUL5dVw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1lofN2/loARmjQ9OOoVtA4PmDl8AAAAASD1tzgJS4eikK50stTWtJg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13779327-13779339 NNNN CT(86 175 0) RT(1594742439191 35) q(0 0 2 -1) r(5 5) U5'
+  '9-9350466-9350471 NNNN CT(97 94 0) RT(1594812034930 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11139,7 +11372,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-14T16:00:30.513Z",
+    "createdAt": "2020-07-15T11:20:26.475Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11147,7 +11380,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:40.068Z",
+    "updatedAt": "2020-07-15T11:20:35.616Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11205,9 +11438,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:40 GMT',
+  'Wed, 15 Jul 2020 11:20:36 GMT',
   'etag',
-  'W/"6791806466301085612"',
+  'W/"11663115142137028786"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11225,21 +11458,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '0cb4f57e2b0bac6b2483225c28244bd1',
+  '0fced3543c9d0ff75e3eb91dea1ec3e1',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vDHmBAB3TkigYYWRanHa/KjWDV8AAAAAQUIPAAAAAAD3OAgIxVjz0PNS+UmCTgvv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Q9S58vnoTWaf9+lgCmzb14PmDl8AAAAAQUIPAAAAAAACNF98teoxsCa6GOtgYvVu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NzwjY/jC+Esm8qpaKsJtVwAAAABH3N9wx5+9Eu1wLMPrP796; path=/; Domain=.contentful.com',
+  'nlbi_673446=LRjDY/rlokUfoy5UKsJtVwAAAAA+SH1leS37DtCw8Imzvl0A; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=G2bGa5j9vjrt+/lMOoVtA6jWDV8AAAAA0WyD/o74K3vzvCJvJLcVqg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=HcOoLLmnyneWjg9OOoVtA4PmDl8AAAAA/cKZaO2OQXvuT0UcNXaebQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27006733-27006752 NNNN CT(94 95 0) RT(1594742439911 44) q(0 0 2 -1) r(4 4) U5'
+  '9-9350559-9350566 NNNN CT(87 90 0) RT(1594812035550 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11276,7 +11509,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:41 GMT',
+  'Wed, 15 Jul 2020 11:20:36 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -11288,23 +11521,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '7d7ae1fd6721ef698d02fbf5034c1fd5',
+  '6d25a7a5e10a11c7b9743779d6749897',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YnFNJDrJQ+mmC9J2bQM1U6jWDV8AAAAAQUIPAAAAAACZlH7sLhesKaMIPXQXwjRy; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AhDRPPOeRhqwMXOYTtNdSITmDl8AAAAAQUIPAAAAAACyJCAaUrd2F0mmT2fWzthM; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bfOAFJGcwSe5XFhDKsJtVwAAAAAkFPJXI5c6HXDhEbU76dDO; path=/; Domain=.contentful.com',
+  'nlbi_673446=EY2FGj8HcwwUZIdKKsJtVwAAAADykTwUvSLuzz+XkDzmTFGe; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=chCODLg1+mGT/PlMOoVtA6jWDV8AAAAAOUZynaXaeXpxd47Br8axHQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=5cfmJqSJ1kfvjw9OOoVtA4TmDl8AAAAAy5bMijuGBJlv6bKdJwFalA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11312,7 +11545,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20324575-20324581 NNYN CT(98 100 0) RT(1594742440555 34) q(0 0 2 -1) r(4 4) U5'
+  '14-47493498-47493515 NNYN CT(86 88 0) RT(1594812036164 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11329,7 +11562,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "68d305ba68ce7a4e228c7a1343716a77"
+  "requestId": "5ec99f6153fe80bec0c0595f253605ee"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -11353,9 +11586,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:41 GMT',
+  'Wed, 15 Jul 2020 11:20:37 GMT',
   'etag',
-  '"8464795426721667471"',
+  '"5653506158891860887"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11365,23 +11598,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '68d305ba68ce7a4e228c7a1343716a77',
+  '5ec99f6153fe80bec0c0595f253605ee',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FItN/2pYSNGr/KcBjQGjCqnWDV8AAAAAQUIPAAAAAACPyECBP10hLKOdHAworgtA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=keuHXYoPRDyVzJoSSX/FJYXmDl8AAAAAQUIPAAAAAABZR6a6gtv0cwBvZCPideXA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=nEwPP1lRYmwPyE3QKsJtVwAAAAAFuyv0x4lGq4sfnOo5UJXu; path=/; Domain=.contentful.com',
+  'nlbi_673446=Z9UXByJP8BDS0qazKsJtVwAAAAAhj2TE53LDHVrW1cQJ9tgP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=YhKAFNvBzBYa/flMOoVtA6nWDV8AAAAArK0hgtu0GGQJZpxTT1eeQw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=fisLTp54lDEqkQ9OOoVtA4XmDl8AAAAAWg1xcCb7CZbw7JHP4oG93Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11389,7 +11622,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-9014683-9014685 NNYN CT(88 89 0) RT(1594742441141 27) q(0 0 2 -1) r(3 3) U5'
+  '14-47493712-47493726 NNYN CT(87 175 0) RT(1594812036768 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11430,8 +11663,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -11461,9 +11694,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:42 GMT',
+  'Wed, 15 Jul 2020 11:20:38 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -11483,7 +11716,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5a8ed060348bc9cb03da373f4e1950d5',
+  'f03f632f384fd3d818e278c66aaa491f',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -11495,11 +11728,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=z2nvAtTxSPi0JY78Z8/PtqrWDV8AAAAAQUIPAAAAAACuyxgJI8hsZAdyTcr7XYYw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=NoNbBl/AQrCwmEE6RfplUobmDl8AAAAAQUIPAAAAAABVHSTwYzSSwQg8spIVidNx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=mQT5NyJHXFa5Ba1IKsJtVwAAAADn2srJooGptCzR0Ovf03oF; path=/; Domain=.contentful.com',
+  'nlbi_673446=QcBzTwnIYHM8EfX3KsJtVwAAAABqE3xqoV/Z+h5+IfzB8xBR; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=tIfeMBiED2a2/flMOoVtA6rWDV8AAAAAfP1x4gyGACKFWNdFszF9BQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=CzZuGkU8FBwylA9OOoVtA4bmDl8AAAAAv9BWrM2AA76JGYHH6HQcHw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11507,12 +11740,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-13779920-13779922 NNYN CT(86 88 0) RT(1594742441787 30) q(0 0 1 -1) r(2 2) U5'
+  '14-47493979-47493992 NNYN CT(87 960 0) RT(1594812037404 39) q(0 0 10 -1) r(12 12) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/customSidebar', {"name":"Custom sidebar","fields":[],"description":"How to add, remove and update widgets"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-14T16:00:43.116Z","updatedAt":"2020-07-14T16:00:43.116Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-15T11:20:39.661Z","updatedAt":"2020-07-15T11:20:39.661Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -11534,9 +11767,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:43 GMT',
+  'Wed, 15 Jul 2020 11:20:39 GMT',
   'etag',
-  '"7387142411929750360"',
+  '"4914214561177050231"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11546,29 +11779,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'd3cd5aea114da5173dab30b20c8790bd',
+  '07fea76d609de0753e9b70b0a8badd61',
   'Content-Length',
   '882',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=sTzgawnmQTWo/5bhA028q6rWDV8AAAAAQUIPAAAAAABna803mK+UDqrificw7B3H; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fQlSu/VBQViZb6U1VMSSe4fmDl8AAAAAQUIPAAAAAACnym0Z5YUufVeT2LLKZsyL; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=lKrQB1hofUVuV0vOKsJtVwAAAAABrg3wHSzCErNG1dqMiH3X; path=/; Domain=.contentful.com',
+  'nlbi_673446=7YlNMCqhYW7YqOcnKsJtVwAAAAAMNSw+/a38f/7AdGdrZPTb; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Y0xDSXHNhw6X/vlMOoVtA6rWDV8AAAAAPtJJt5uGAi4bEJ//Kdvv4g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=mq9MVx8TU3u1lQ9OOoVtA4fmDl8AAAAA4JGJIi+9dGV/zmvsenMFrQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20325012-20325025 NNNN CT(86 87 0) RT(1594742442379 32) q(0 0 1 -1) r(5 5) U5'
+  '12-30381994-30382001 NNNN CT(87 90 0) RT(1594812038836 32) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11584,8 +11817,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "customSidebar",
     "type": "ContentType",
-    "createdAt": "2020-07-14T16:00:43.116Z",
-    "updatedAt": "2020-07-14T16:00:43.752Z",
+    "createdAt": "2020-07-15T11:20:39.661Z",
+    "updatedAt": "2020-07-15T11:20:40.300Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -11609,8 +11842,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-14T16:00:43.752Z",
-    "publishedAt": "2020-07-14T16:00:43.752Z",
+    "firstPublishedAt": "2020-07-15T11:20:40.300Z",
+    "publishedAt": "2020-07-15T11:20:40.300Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -11649,9 +11882,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:43 GMT',
+  'Wed, 15 Jul 2020 11:20:40 GMT',
   'etag',
-  'W/"10531551812988891727"',
+  'W/"17868315011244829329"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11669,21 +11902,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b2580325890e8241cd75c36f41d40c72',
-  'Content-Length',
-  '387',
+  '9a4cd031c64b197355b31ea5d4e20511',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=5Nj9/3XmQlGb4FkRkgFhuavWDV8AAAAAQUIPAAAAAAA0Bw2jecjpfjEgIdU84xAe; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sHygekRTQ2KENBLOhKc3uIjmDl8AAAAAQUIPAAAAAAAUEQ3kmX1M5V8QM25pZmZg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Rt/OYrzAegfKyXGZKsJtVwAAAAAblZ4H9zG5kVGfI/WOoMfB; path=/; Domain=.contentful.com',
+  'nlbi_673446=rh7WASloiypY6FThKsJtVwAAAAAtYOwgAYVBC1cufvibkosi; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=qHkXBJfLfQgx//lMOoVtA6vWDV8AAAAATcE1AzqdHSxPzayvMtLcmA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=iPX+aTfOQCQnlw9OOoVtA4jmDl8AAAAAPxQ1p5NOVft4LzxLFzOAew==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-6345453-6345454 NNNN CT(94 90 0) RT(1594742443081 35) q(0 0 2 -1) r(4 4) U5'
+  '14-47494376-47494384 NNNN CT(94 97 0) RT(1594812039638 32) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11724,7 +11957,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-14T16:00:43.831Z",
+    "createdAt": "2020-07-15T11:20:40.502Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11732,7 +11965,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:45.389Z",
+    "updatedAt": "2020-07-15T11:20:41.053Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11780,9 +12013,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:45 GMT',
+  'Wed, 15 Jul 2020 11:20:41 GMT',
   'etag',
-  'W/"2482464552590765206"',
+  'W/"5351772243695509863"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11792,29 +12025,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'af312b889f8312fbe9733d2dde1e35c1',
+  '6153b1b52a56a3ade8b2daa39f3319e7',
   'Content-Length',
-  '461',
+  '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fdDt6IDeR6W5uqt+cikJGq3WDV8AAAAAQUIPAAAAAAA1uRVXusTMqu6iy8Y08G1S; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kcW4qXGGQUCVBOPhOpb+9YjmDl8AAAAAQUIPAAAAAAAs62s0X6V12BeyNzwdpa7F; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=kuqML+yhI3BjamjUKsJtVwAAAAC9iJ3HjgivC7BwCXblqgA5; path=/; Domain=.contentful.com',
+  'nlbi_673446=PoeYHGQ45TdYbcAWKsJtVwAAAABOmS0AOlQRp55J2+jIovcM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=QsuEY/W9OSfWAPpMOoVtA63WDV8AAAAA5A4Px3jFp+mgPZumd6+E4g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=XJ22Xt4EDnRSmA9OOoVtA4jmDl8AAAAA8CUConbybFw/sJWkuHbRBQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-8165076-8165091 NNNN CT(93 94 0) RT(1594742444703 31) q(0 0 2 -1) r(4 4) U5'
+  '9-9351332-9351339 NNNN CT(87 86 0) RT(1594812040386 34) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11855,7 +12088,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 3,
-    "createdAt": "2020-07-14T16:00:43.831Z",
+    "createdAt": "2020-07-15T11:20:40.502Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11863,7 +12096,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:46.032Z",
+    "updatedAt": "2020-07-15T11:20:41.581Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11911,9 +12144,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:46 GMT',
+  'Wed, 15 Jul 2020 11:20:41 GMT',
   'etag',
-  'W/"7655125878187309121"',
+  'W/"2388484434711758909"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11923,29 +12156,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'acafc61738a0e4e60c8d9e58c67bc12b',
+  'aa9dada961986608a0f45a98a7feb9ae',
   'Content-Length',
-  '461',
+  '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=b66eXn4oS8yzpEolIkH5AK3WDV8AAAAAQUIPAAAAAADzYuUjimzcxKc6qQLICM7F; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=HzvaNLPlQUeyRhJ6AoSE1YnmDl8AAAAAQUIPAAAAAAD7dEkbqpuKDNZYvj0NU2VI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=h8xvevImHFt6pyZ5KsJtVwAAAACqchDcgK1+orXOaOwwCzo7; path=/; Domain=.contentful.com',
+  'nlbi_673446=+aIta3B4h2bf3Yb8KsJtVwAAAAAxFG1p0om4mdGcjXm0GlN2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0t62THh7KDYDAvpMOoVtA63WDV8AAAAAdTN5VXZQNWUSxr5MImHS3w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=XgxSE/4NsntzmQ9OOoVtA4nmDl8AAAAAo3b3YxQlipHfT8BnqeWHFg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27008259-27008270 NNNN CT(97 97 0) RT(1594742445215 39) q(0 0 2 -1) r(5 5) U5'
+  '3-10884145-10884152 NNNN CT(93 100 0) RT(1594812040882 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11986,7 +12219,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-14T16:00:43.831Z",
+    "createdAt": "2020-07-15T11:20:40.502Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11994,7 +12227,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:46.514Z",
+    "updatedAt": "2020-07-15T11:20:43.054Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12042,9 +12275,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:46 GMT',
+  'Wed, 15 Jul 2020 11:20:43 GMT',
   'etag',
-  'W/"344986861367895499"',
+  'W/"7320513427971703336"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12062,21 +12295,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '606baf6261cdbaf6d9efb3a38738ef41',
+  '090d090b86ab936b189ee55c17238e3a',
   'Content-Length',
-  '461',
+  '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=aW94RbaRQiaOUfM3J9ilda7WDV8AAAAAQUIPAAAAAADXb1m9z8WjwYlQKtD5E5GY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=CbR+HcBkRUifko98WdwrhYrmDl8AAAAAQUIPAAAAAADVlu9RnGIyAhjpmxFuKTAS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=fsbfXt+MnxqBJbYBKsJtVwAAAACSNOp0R5SMPPEHoGe/NI8t; path=/; Domain=.contentful.com',
+  'nlbi_673446=4RCbJsVbhGeIuOXFKsJtVwAAAAA07d0pwm3wC56UqbczZ+2Q; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=2unoSQpIw1u1AvpMOoVtA67WDV8AAAAAJRtaI2HvrLR6pnBzs9GkPg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=OK6TKaRwvGbFnA9OOoVtA4rmDl8AAAAAg1q46UaZ90BzwKeMKVX6Nw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-8165271-8165284 NNNN CT(93 95 0) RT(1594742445837 27) q(0 0 2 -1) r(4 4) U5'
+  '14-47494995-47495055 NNNN CT(86 87 0) RT(1594812041380 1049) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12117,7 +12350,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-14T16:00:43.831Z",
+    "createdAt": "2020-07-15T11:20:40.502Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12125,7 +12358,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:47.108Z",
+    "updatedAt": "2020-07-15T11:20:43.669Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12173,9 +12406,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:47 GMT',
+  'Wed, 15 Jul 2020 11:20:43 GMT',
   'etag',
-  'W/"6499892780095129292"',
+  'W/"15842520626996732315"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12185,29 +12418,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '1e6ecd55ad8c9193eafc5efe873f2d01',
+  '860e8583155fee6bfa0f109051f7977f',
   'Content-Length',
   '461',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=CFtzQI2RQlGhqSL4QoyGzK7WDV8AAAAAQUIPAAAAAAAdZWAm8d6Kv5PUXy+5kZVK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fwbQe/ltTpOJmzdQ757ng4vmDl8AAAAAQUIPAAAAAADwSTV6UQ2c9yqTuCQHKjkj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=MmwjOoxuVzaq3D2wKsJtVwAAAABamVCXEE8Vz1UKe/B0BV7U; path=/; Domain=.contentful.com',
+  'nlbi_673446=xKEFZyL0yUX8Rb1XKsJtVwAAAAADqYZtCCLuQX2oAZ9ibMXl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ut93HuEz5m1ZA/pMOoVtA67WDV8AAAAAO7sjBT7G8al9/V8D9+4AxA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=qASVSmHtumoUng9OOoVtA4vmDl8AAAAA0XKF7qT5PNQZsBzGjukRjw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27008599-27008613 NNNN CT(86 87 0) RT(1594742446358 33) q(0 0 2 -1) r(5 5) U5'
+  '14-47495211-47495235 NNNN CT(94 179 0) RT(1594812042922 29) q(0 0 3 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12242,7 +12475,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-14T16:00:43.831Z",
+    "createdAt": "2020-07-15T11:20:40.502Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12250,7 +12483,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:47.669Z",
+    "updatedAt": "2020-07-15T11:20:44.373Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12298,9 +12531,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:47 GMT',
+  'Wed, 15 Jul 2020 11:20:44 GMT',
   'etag',
-  'W/"7549707802854929659"',
+  'W/"5550279822272295734"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12318,21 +12551,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '49fac64db3e645b3be8d6dcb5d1c8a7f',
+  '8d79104b7e6a6f0f8ef0e8d44c0d7223',
   'Content-Length',
-  '449',
+  '447',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/7YyC9T+RUGISVXy7CCwQK/WDV8AAAAAQUIPAAAAAAA/WRPlIgIN/7FG0cE3RxqQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Pmyoq8YETRy9RH71f8ggTYzmDl8AAAAAQUIPAAAAAADfYG4mR48dqleBI2z5y/gS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=0BucTNOROwmlRz4FKsJtVwAAAADPh6EDNinG3B71c/uX4NNk; path=/; Domain=.contentful.com',
+  'nlbi_673446=elcUXWrrGgk2Q7nKKsJtVwAAAACATJDmwvbvFSDEtO5GHevs; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=pKw2cIGQg3XfA/pMOoVtA6/WDV8AAAAA7bJdfm4/xwAbiV/teoQpUA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=CrHZTJddvmd+nw9OOoVtA4zmDl8AAAAAtfzCPqBNq8J8bmi7TjG/SQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27008802-27008812 NNNN CT(96 95 0) RT(1594742446992 36) q(0 0 2 -1) r(3 3) U5'
+  '13-36013822-36013833 NNNN CT(88 87 0) RT(1594812043715 36) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12349,7 +12582,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-14T16:00:43.831Z",
+    "createdAt": "2020-07-15T11:20:40.502Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12357,7 +12590,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:47.669Z",
+    "updatedAt": "2020-07-15T11:20:44.373Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12423,9 +12656,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:48 GMT',
+  'Wed, 15 Jul 2020 11:20:45 GMT',
   'etag',
-  'W/"12305616659862115590"',
+  'W/"2549979886228979859"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12435,29 +12668,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '0d999dd39e75a2df282b6c5f77be8ba6',
-  'transfer-encoding',
-  'chunked',
+  '30c7f1889270653cb938321ef15847d2',
+  'Content-Length',
+  '435',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=zIou199FQfK4YE5r9ZRWXK/WDV8AAAAAQUIPAAAAAACKgNYyCottj8IQTCxaaiB0; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=aIOaqgPDRAq4deGDeBKX9ozmDl8AAAAAQUIPAAAAAABSuHGTPa6ABiwEIpy/cO9r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=5VfAVdmwjwFG5zgOKsJtVwAAAABYn0ilXdvkTCNaIKGGzAF2; path=/; Domain=.contentful.com',
+  'nlbi_673446=bthKSfaFGXyccdGnKsJtVwAAAAD+CcOWnxUrmpk+4NV2Jomk; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=/nkYC99lfU1VBPpMOoVtA6/WDV8AAAAAIlh5L2V2zIioh3L2dCse6g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=irxYOGLaigWtoA9OOoVtA4zmDl8AAAAA8FqUH32Pc9S7PTarlIswFw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-13780889-13780896 NNNN CT(98 99 0) RT(1594742447493 35) q(0 0 2 -1) r(3 3) U5'
+  '14-47495659-47495670 NNNN CT(94 97 0) RT(1594812044350 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12542,7 +12775,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:48 GMT',
+  'Wed, 15 Jul 2020 11:20:45 GMT',
   'etag',
   'W/"9102674631899357591"',
   'Server',
@@ -12554,29 +12787,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '92bef8e3b0a6f59b975cba34c08c37a5',
-  'Content-Length',
-  '375',
+  '915207304ad8c3368e6b9399a162eaf4',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=GoKMLXDFSvKxuGPFv1+sWbDWDV8AAAAAQUIPAAAAAAAGVS9CEdSGZXpXb9fkz+Yk; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=x4qRHoimSuC8JGs2hJOChY3mDl8AAAAAQUIPAAAAAADgCJjfe5Fo3ftpQyULKnh7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qM2EYTD4MAuzL1bDKsJtVwAAAAD7EmxNlFdEB7h07tyOAclm; path=/; Domain=.contentful.com',
+  'nlbi_673446=DSA6Q3Hohgn7TeXjKsJtVwAAAACs4Y14T8VdR3qY5h72VLpO; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=zlOZLDkM6UHKBPpMOoVtA7DWDV8AAAAA5mHftDWO/pzVXC7UZE3v8w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=6fCfeIHTp2gIog9OOoVtA43mDl8AAAAA1tvAr043z3ucH7qJGWj2ow==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13531135-13531146 NNNN CT(88 87 0) RT(1594742448007 37) q(0 0 2 -1) r(3 3) U5'
+  '9-9351974-9351979 NNNN CT(86 86 0) RT(1594812044978 39) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12617,8 +12850,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -12648,9 +12881,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:49 GMT',
+  'Wed, 15 Jul 2020 11:20:46 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -12670,7 +12903,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '47b814f6947c0d248062268ac41f8f4b',
+  '1aaf5cb33a10b88e6747417821171314',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -12682,11 +12915,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=hpO70gvVRIufZNEpMq1ABrDWDV8AAAAAQUIPAAAAAADUp15JxwjlXyxvGbO39LUB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vLLmksM3SECQMw4bPm9cDI3mDl8AAAAAQUIPAAAAAABiZV0NJTbVT0ve3CGJ4lyQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qSI/JIt/nA71OcoxKsJtVwAAAADaujKPZVrXya3Ejps11mIT; path=/; Domain=.contentful.com',
+  'nlbi_673446=/FREAGWA7CxWWi1aKsJtVwAAAAChseS8t3v3XV69bGt4iWtX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=RX/tKBn+tn0sBfpMOoVtA7DWDV8AAAAA31Ozf0oNLsLf64ZK7+zdhA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=8stwLqxIwG7cog9OOoVtA43mDl8AAAAA6sznKKLJuBlazPIzl/1ftQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -12694,7 +12927,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-5259612-5259618 NNYN CT(100 99 0) RT(1594742448445 30) q(0 0 2 -1) r(3 3) U5'
+  '11-24200822-24200833 NNYN CT(87 87 0) RT(1594812045412 31) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12754,7 +12987,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:49.773Z",
+    "updatedAt": "2020-07-15T11:20:46.662Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12802,9 +13035,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:49 GMT',
+  'Wed, 15 Jul 2020 11:20:46 GMT',
   'etag',
-  'W/"16455332812432625297"',
+  'W/"6300795379564271779"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12822,21 +13055,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '9cbe2e4001f27d43c27f9e5837f8e6e2',
+  'a3ba8bdb7099db0ae1d45f9ec14e694d',
   'Content-Length',
   '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vSmK3CBtSSqslBQjt+DXdbHWDV8AAAAAQUIPAAAAAAAuglF1HrfCHy9zoLvMNXAS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SH3qipzoSpyGgnZdwhk8jY7mDl8AAAAAQUIPAAAAAAD7t/vEQmZcp5UAJTwEOmov; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AjwVFq/QPGKlnxunKsJtVwAAAACrAoX4i7t44n3wMYayhdqX; path=/; Domain=.contentful.com',
+  'nlbi_673446=TsuDZUru1BF7MRidKsJtVwAAAACkOKCxJqMx/Ta7H3l4yFCW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=kv9Tev+xGn/QBfpMOoVtA7HWDV8AAAAASKOtANeZdy3CPpoehqRaeA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=4uoLbaeCPV5NpA9OOoVtA47mDl8AAAAAP0tZeuHzLgBgCGEd+iiALw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27009426-27009433 NNNN CT(87 179 0) RT(1594742449022 33) q(0 0 3 -1) r(4 4) U5'
+  '11-24200947-24200954 NNNN CT(96 94 0) RT(1594812045992 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12896,7 +13129,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:50.308Z",
+    "updatedAt": "2020-07-15T11:20:47.365Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12944,9 +13177,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:50 GMT',
+  'Wed, 15 Jul 2020 11:20:47 GMT',
   'etag',
-  'W/"3525807837851847895"',
+  'W/"12246231550174047110"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12964,21 +13197,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '85f9e3bb28cddee8bf62a33b88d3b9aa',
+  'f4686ee9529b64d9a6a228367777bdd0',
   'Content-Length',
-  '541',
+  '540',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=C38tHGtDTGy2vRDd1QBLRbLWDV8AAAAAQUIPAAAAAAAfT63sAdwryO434CKNe+aX; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SYWQeZ9cTRSDwEJA+pWAPY/mDl8AAAAAQUIPAAAAAACBFDOq1jkVPdU/dc5lsaMb; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ayGrEejbLwGNC9yDKsJtVwAAAAB4N1dPFBjmml/50qVW1HOd; path=/; Domain=.contentful.com',
+  'nlbi_673446=UGCsPYEnZCNUypprKsJtVwAAAABHrT462yhR3soQdSZ8Gp0h; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=vInWZ+CvE2pBBvpMOoVtA7LWDV8AAAAAtWWKzNR3IKne6FL1Gez1rw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1xT9QF9GOR7CpQ9OOoVtA4/mDl8AAAAAx/heQ6jCHUYo2yAX6hSl1A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27009592-27009608 NNNN CT(95 95 0) RT(1594742449631 33) q(0 0 2 -1) r(4 4) U5'
+  '14-47496472-47496481 NNNN CT(88 89 0) RT(1594812046618 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13038,7 +13271,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:51.119Z",
+    "updatedAt": "2020-07-15T11:20:47.859Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13086,9 +13319,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:51 GMT',
+  'Wed, 15 Jul 2020 11:20:47 GMT',
   'etag',
-  'W/"11550344503687094556"',
+  'W/"13579519715100886220"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13106,21 +13339,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '18daa1924ddb54df1c4e43ce402d0928',
+  '30e39315c9a9942e4c097df002798cd2',
   'Content-Length',
   '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lyCiSGJmRuG/xVBVYWYgvrLWDV8AAAAAQUIPAAAAAAC9NbqJPzGd7cTLpmKlaf7R; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=hj9nKZ83QxawcjbK8eO7JY/mDl8AAAAAQUIPAAAAAAA1P19Q/yD0pBmHhIaIiv4r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=/2GEHlsvak5z0SK0KsJtVwAAAAAsmPSOyfk/pn5ojqODJFYh; path=/; Domain=.contentful.com',
+  'nlbi_673446=WNWqRJfqBVm8gJArKsJtVwAAAAAQIzjENbVrDnvzk0r4bl1c; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=VfhiN72bXBmOB/pMOoVtA7LWDV8AAAAA6jtvHHE+mDc0DdwygVRGSw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ScDkUlOIGnPGpg9OOoVtA4/mDl8AAAAAXelYHTvmRcBvWT1masWDig==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-20327131-20327141 NNNN CT(97 97 0) RT(1594742450249 33) q(0 0 2 -1) r(6 6) U5'
+  '6-7443372-7443381 NNNN CT(86 87 0) RT(1594812047210 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13180,7 +13413,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:51.727Z",
+    "updatedAt": "2020-07-15T11:20:48.345Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13228,9 +13461,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:51 GMT',
+  'Wed, 15 Jul 2020 11:20:48 GMT',
   'etag',
-  'W/"107759787027299487"',
+  'W/"2585629672618438490"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13248,21 +13481,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '972abc471f40cb5a5e5fd73077394e0f',
+  '5e766863b89d1e3ed4ba90276cc41db2',
   'Content-Length',
   '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Xbto6qZxRECOj2VmkoZvZ7PWDV8AAAAAQUIPAAAAAAB88rWzGGwvjYKQQN18IL5U; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=is0u/qoOTV+iSTgp6DCiR5DmDl8AAAAAQUIPAAAAAAA6kTPm7jCF1CM3NiFjp6to; expires=Wed, 14 Jul 2021 14:42:28 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=udGbb7v3RFPJHAy3KsJtVwAAAAC6kfLQWyktWrlJB6NuS+2+; path=/; Domain=.contentful.com',
+  'nlbi_673446=UUPnJSLUEiWtozagKsJtVwAAAAB1koNk/D3bBaoWByoRXANz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=+aSIFIeumytuCPpMOoVtA7PWDV8AAAAAixtFzInuyZGidLXwCfcA/Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nnO/HUM7Rwuwpw9OOoVtA5DmDl8AAAAAgj0St4qWu0Aaw1ZZO3Yofw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-2536479-2536480 NNNN CT(85 86 0) RT(1594742451085 31) q(0 0 1 -1) r(3 3) U5'
+  '0-1832221-1832222 NNNN CT(93 94 0) RT(1594812047682 28) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13316,7 +13549,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:52.345Z",
+    "updatedAt": "2020-07-15T11:20:49.219Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13364,9 +13597,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:52 GMT',
+  'Wed, 15 Jul 2020 11:20:49 GMT',
   'etag',
-  'W/"10720502177319649590"',
+  'W/"17085535333605885126"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13384,21 +13617,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e0c626065cd19438f49327f41cbf9615',
+  '1c1c9f52bfb11a2222e9b214f318de6c',
   'Content-Length',
   '524',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Yiq4OlLwT16DUOmGwEI0r7TWDV8AAAAAQUIPAAAAAACwDCV8FE7FzHmoQsZ0h8kU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ImwXYbUpTwePEWMEJ5V9i5DmDl8AAAAAQUIPAAAAAABoBqCz49Ij4Oqva4CoGHst; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=VH40CIFl5lskt5dYKsJtVwAAAACi57WNzkf1unYLQApo0Kpi; path=/; Domain=.contentful.com',
+  'nlbi_673446=WDjQZ+iv4Ggr/bc6KsJtVwAAAACq5NEa92o3AhIaxfJDk8W+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Y5bFeCoJq3ICCfpMOoVtA7TWDV8AAAAAPsCn4YsgB4oIMzV+6ZcNiA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=vbNdTorH91t7qQ9OOoVtA5DmDl8AAAAAWE0U4u6LTi3i5N6e6eot4g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-6346023-6346026 NNNN CT(87 88 0) RT(1594742451689 37) q(0 0 2 -1) r(3 3) U5'
+  '14-47496986-47496994 NNNN CT(90 90 0) RT(1594812048243 28) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13423,7 +13656,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-14T16:00:52.345Z",
+    "updatedAt": "2020-07-15T11:20:49.219Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -13500,9 +13733,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:52 GMT',
+  'Wed, 15 Jul 2020 11:20:49 GMT',
   'etag',
-  'W/"11545231734773879195"',
+  'W/"16753442353884750983"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13520,21 +13753,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '393c4ae688b081a3697ade13c23ac845',
+  '879e756df7c16142f9944b5aae54b715',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MP2Ahrs7TCWdFhLIWrwlb7TWDV8AAAAAQUIPAAAAAAAoqQLBN07ymmUqDUF12G5Q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=1/7XMCVaTj+QNKFWfAS/T5HmDl8AAAAAQUIPAAAAAABmdp1uU6YdFffAaHMrMY0p; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=jz5QOY1w2HoSXcDxKsJtVwAAAACaTTHPgLodJrOciN6G7rMp; path=/; Domain=.contentful.com',
+  'nlbi_673446=t0A2W/9zpHeZgejSKsJtVwAAAADRS9t1xtf1rEWszy0KUMRP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0T8yKhkEwSmlCfpMOoVtA7TWDV8AAAAA0ijTsON3kwvYfWwfRaVuIA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=EhCkANbrXxSIqg9OOoVtA5HmDl8AAAAAfiTzJu+4dQL642deJuw/tw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-4142188-4142190 NNNN CT(92 93 0) RT(1594742452293 34) q(0 0 2 -1) r(3 3) U5'
+  '11-24201625-24201635 NNNN CT(93 94 0) RT(1594812049060 39) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13544,8 +13777,47 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   "sys": {
     "type": "Array"
   },
-  "total": 0,
-  "items": []
+  "total": 1,
+  "items": [
+    {
+      "sys": {
+        "type": "Tag",
+        "id": "longexampletag",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "bohepdihyxin"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "env-integration",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "createdAt": "2020-07-15T11:20:11.344Z",
+        "updatedAt": "2020-07-15T11:20:11.344Z",
+        "version": 1
+      },
+      "name": "long example marketing"
+    }
+  ]
 }
 , [
   'Access-Control-Allow-Headers',
@@ -13569,9 +13841,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:53 GMT',
+  'Wed, 15 Jul 2020 11:20:50 GMT',
   'etag',
-  '"9177491833369070274"',
+  '"235608248538559367"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13589,15 +13861,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '6256ce44c5aab0ad4c8a7008a8c98ace',
+  '9f7dbc746a35c2ef0c8bdb965e57af7e',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=f2+bAQBARleh9JVbCf4kyLXWDV8AAAAAQUIPAAAAAABbwpxWqHilB8ibaSHP+5pR; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=C4DSJFXzRy+bSJs3BnUPdJLmDl8AAAAAQUIPAAAAAADZUly6qc3laNEGotz6mmvW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=2M6CC4OOuiavMGydKsJtVwAAAADlhpt63B8FHMS6ylg1IiCX; path=/; Domain=.contentful.com',
+  'nlbi_673446=RfwcF6So60fEZrluKsJtVwAAAABltBb+EvJxPOh2heOexy30; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ysktQDCoTSQpCvpMOoVtA7XWDV8AAAAA9O+rYJZRDBtGdJQsPSzPVA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=zdZaSQmChXISrA9OOoVtA5LmDl8AAAAAzMyYDkuZJfglIk7Q2KUKow==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13605,7 +13877,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '1-1685440-1685442 NNYN CT(93 95 0) RT(1594742452906 30) q(0 0 2 -1) r(3 3) U5'
+  '9-9352597-9352599 NNYN CT(88 88 0) RT(1594812049672 29) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13646,8 +13918,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -13677,9 +13949,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:54 GMT',
+  'Wed, 15 Jul 2020 11:20:50 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -13691,15 +13963,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '4aa49e0a0b3de8bb10e98ddf7c6282a8',
+  '3ea795fde2fe731a70621049017c2c60',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -13711,11 +13983,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=QNWWgjuZTkSa5YvAgov8mbXWDV8AAAAAQUIPAAAAAADCUTlDmTywUj1x1a6V2HvV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=NfOldbhuTwWitVXjzYyxQpLmDl8AAAAAQUIPAAAAAABZIi/SDR7xZblJck3UJ+en; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=EQJSeZvDWDyHwUMuKsJtVwAAAADzP/+7DnAcw3ZV5Kd6HHwX; path=/; Domain=.contentful.com',
+  'nlbi_673446=a83TCAu0XXF/vGO6KsJtVwAAAAA2yeFi1ds/gi60ERYmxagi; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=XdDRfK56ukmaCvpMOoVtA7XWDV8AAAAAtoomzapbR7nJYUryAvnbHQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=WPFeNE8ypxcBrQ9OOoVtA5LmDl8AAAAAKeW0xnfXxcZczUR26c0gFg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13723,12 +13995,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-6346144-6346148 NNYN CT(94 94 0) RT(1594742453437 32) q(0 0 2 -1) r(3 3) U5'
+  '13-36015878-36015901 NNYN CT(93 95 0) RT(1594812050288 35) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":0},"name":"marketing"})
-  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-14T16:00:54.593Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-14T16:00:54.593Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
+  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-15T11:20:51.359Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T11:20:51.359Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -13750,9 +14022,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:54 GMT',
+  'Wed, 15 Jul 2020 11:20:51 GMT',
   'etag',
-  '"5757577779022189902"',
+  '"15929164439664930325"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13762,29 +14034,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '99e8557b70d0a66cbaa8511a62167f99',
+  'b9c460c0556907e43262f5f687023e9e',
   'Content-Length',
   '740',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+3YR17zkRN+8nRJQNa6cOrbWDV8AAAAAQUIPAAAAAABJqqdupzsHC6ZmRmb5VMkq; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=akc65/HXTuaqQbToHfym85PmDl8AAAAAQUIPAAAAAAA03WR0H0vhSAhUqiXPlRBE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=yZ/AI0ykfWNfXtdIKsJtVwAAAABz9FOrz0cNMMW+7aDBn+Nw; path=/; Domain=.contentful.com',
+  'nlbi_673446=FecONtKPqCUVAkezKsJtVwAAAAB2JFJrX8BwJlI7HhFnSdgG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=GaHNdTAfcmMPC/pMOoVtA7bWDV8AAAAA2UdBE6e+R1YHY5JL6OwGNg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nWxTBNToFF39rQ9OOoVtA5PmDl8AAAAAIDJNrKRhp9ykaMH8uAUXJQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-13532020-13532025 NNNN CT(87 88 0) RT(1594742453945 31) q(0 0 2 -1) r(4 4) U5'
+  '14-47497856-47497870 NNNN CT(87 87 0) RT(1594812050720 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13821,8 +14093,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-14T16:00:54.593Z",
-    "updatedAt": "2020-07-14T16:00:54.593Z",
+    "createdAt": "2020-07-15T11:20:51.359Z",
+    "updatedAt": "2020-07-15T11:20:51.359Z",
     "version": 1
   },
   "name": "marketing"
@@ -13849,9 +14121,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:55 GMT',
+  'Wed, 15 Jul 2020 11:20:51 GMT',
   'etag',
-  '"4053287262629635354"',
+  '"14972952534566751389"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13861,23 +14133,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '5889a1845e37c956085ef9a01345ea0d',
+  '87fc2419a3481198e62e95c97f463d23',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=asNiN9qORx6sQXmIRGIyhrbWDV8AAAAAQUIPAAAAAABCtjt8sJBBLcPwejojjjl5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WWgpIPsiQgi7nkcHtQDp9pPmDl8AAAAAQUIPAAAAAAAB97zZtmGTXjMbJxz+B7Mv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=a5qANjYlkmvGuqoIKsJtVwAAAABkA0XvR3bIWdyseT45K6AB; path=/; Domain=.contentful.com',
+  'nlbi_673446=gfAgHirljWrVzDcpKsJtVwAAAAD/Jv+IRqp2vwDbC3e4W4y8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=iXRKfjD8pVyaC/pMOoVtA7bWDV8AAAAAxT7tiyBExViey6SENP4b4g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=GFxyZ+tpOk41rw9OOoVtA5PmDl8AAAAA99kcbmRIOsHP9xtQUXV3pA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13885,7 +14157,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-5259881-5259882 NNYN CT(93 94 0) RT(1594742454401 26) q(0 0 2 -1) r(4 4) U5'
+  '11-24202170-24202179 NNYN CT(93 93 0) RT(1594812051334 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13895,7 +14167,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   "sys": {
     "type": "Array"
   },
-  "total": 1,
+  "total": 2,
   "items": [
     {
       "sys": {
@@ -13929,11 +14201,49 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-14T16:00:54.593Z",
-        "updatedAt": "2020-07-14T16:00:54.593Z",
+        "createdAt": "2020-07-15T11:20:51.359Z",
+        "updatedAt": "2020-07-15T11:20:51.359Z",
         "version": 1
       },
       "name": "marketing"
+    },
+    {
+      "sys": {
+        "type": "Tag",
+        "id": "longexampletag",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "bohepdihyxin"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "env-integration",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "createdAt": "2020-07-15T11:20:11.344Z",
+        "updatedAt": "2020-07-15T11:20:11.344Z",
+        "version": 1
+      },
+      "name": "long example marketing"
     }
   ]
 }
@@ -13954,14 +14264,16 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'env-integration',
   'cf-space-id',
   'bohepdihyxin',
+  
+  
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:55 GMT',
+  'Wed, 15 Jul 2020 11:20:52 GMT',
   'etag',
-  '"14463358499897617033"',
+  'W/"1725391273288666372"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13971,31 +14283,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '76008b1ff6485fef4b4dde11b92c4db0',
+  '1ef0760148841d757be4bfc617a9285e',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lRy5wnckRKCaoIXhkMh0qrfWDV8AAAAAQUIPAAAAAABw3491D+1lAHCzomPeFgqI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=anphh0ReTsCxQYDhjkpX3JTmDl8AAAAAQUIPAAAAAAAuQ0Yry0zDhECe62vS6Ufh; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bWh6fdM+NXQK2XNbKsJtVwAAAABmdFzto1CQLOlgqnJV5bw4; path=/; Domain=.contentful.com',
+  'nlbi_673446=6/tgKibcZnZXLvpjKsJtVwAAAACLMPaTRfCvpN3HqoN5JDzB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0TrGUCxjcz4lDPpMOoVtA7fWDV8AAAAA338nxRcJCh6XJCd6mJjN1w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=MKk5BwbfknQqsA9OOoVtA5TmDl8AAAAADs/lIz4wKz0EKQkC3gukAQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
   'X-Iinfo',
-  '4-9016182-9016189 NNYN CT(93 93 0) RT(1594742454968 38) q(0 0 1 -1) r(3 3) U5'
+  '13-36016322-36016349 NNNN CT(94 113 0) RT(1594812051929 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14036,8 +14346,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -14067,9 +14377,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:56 GMT',
+  'Wed, 15 Jul 2020 11:20:53 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -14089,7 +14399,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '8df42ad93ee56e3723012761d6c8fb65',
+  'b568ea7d916d5c26a99e0d756a9cd9b7',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -14101,11 +14411,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=yb0AyFZ1TP2eO543foe1xLfWDV8AAAAAQUIPAAAAAAAI5d2CxCQy+qMHVw14u93u; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=aMUFwvNbQJKTDhnEGt6Dc5XmDl8AAAAAQUIPAAAAAADHWBVarF5tIbgd95qgrQjH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=7Mg5JZwzliV053eZKsJtVwAAAADqy3Ce7KAJC2/7iUVw5/Pu; path=/; Domain=.contentful.com',
+  'nlbi_673446=5G90AC7MexjAIiNzKsJtVwAAAABj0HC0tmpg75obwrCxGA65; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=q/0GOyOMI0m6DPpMOoVtA7fWDV8AAAAALRC6+FPkIZGxrUUEWPhLQw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/FqYLrVaRlmNsg9OOoVtA5XmDl8AAAAAT8MdKeyOCTC4QCIND26Kbw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14113,12 +14423,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-20328637-20328648 NNYN CT(87 87 0) RT(1594742455574 33) q(0 0 1 -1) r(2 2) U5'
+  '13-36016544-36016562 NNYN CT(93 93 0) RT(1594812052542 33) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":1},"name":"better marketing"})
-  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-14T16:00:54.593Z","updatedAt":"2020-07-14T16:00:56.672Z","version":2},"name":"better marketing"}, [
+  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-15T11:20:51.359Z","updatedAt":"2020-07-15T11:20:54.241Z","version":2},"name":"better marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -14140,9 +14450,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:56 GMT',
+  'Wed, 15 Jul 2020 11:20:54 GMT',
   'etag',
-  '"17387467672040922824"',
+  '"2965724126806960779"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14152,29 +14462,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '195b6ee5a5e6ee204f350ce78f5489af',
+  'fe7cf5647f84e485e68319ca9a8427d0',
   'Content-Length',
   '747',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Y9YyQWp7S2apz9xidpAITbjWDV8AAAAAQUIPAAAAAACY/5sjemPVj3HAE5G1Vsyk; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BtJ/ZWjXR4KMLtqc4qlXSJXmDl8AAAAAQUIPAAAAAACh0yq9YGWuUKxrYLtnW5uu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8oj6WrL1IyYRudjNKsJtVwAAAADLd/FdRLn6TGPH4+MbWEuM; path=/; Domain=.contentful.com',
+  'nlbi_673446=VHaIEYKBXirFFL99KsJtVwAAAAAR5WFi940cIL1DoPut7nq7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=A/9rGd6WczooDfpMOoVtA7jWDV8AAAAA3WfUJ6JR9wtCudzP0mgWwA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=gLUGFdx5rh+dsw9OOoVtA5XmDl8AAAAAZaLiBRby8nrbYMqwatRaDA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-27011475-27011492 NNNN CT(99 103 0) RT(1594742455995 35) q(0 0 2 -1) r(4 4) U5'
+  '10-14431620-14431629 NNNN CT(93 93 0) RT(1594812053577 30) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14211,8 +14521,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-14T16:00:54.593Z",
-    "updatedAt": "2020-07-14T16:00:56.672Z",
+    "createdAt": "2020-07-15T11:20:51.359Z",
+    "updatedAt": "2020-07-15T11:20:54.241Z",
     "version": 2
   },
   "name": "better marketing"
@@ -14239,9 +14549,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:57 GMT',
+  'Wed, 15 Jul 2020 11:20:54 GMT',
   'etag',
-  '"17387467672040922824"',
+  '"2965724126806960779"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14251,23 +14561,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '96310ea522d2f052a225eb5aff7989e5',
+  '8ef53c272490417b82ab59d42e392bf0',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=eNPUAkvkT2+u0DmuJ38xxLnWDV8AAAAAQUIPAAAAAAAUNf0+Lwx9NRDzKwttym3a; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=299a305XQoC84HAW4R9AlJbmDl8AAAAAQUIPAAAAAACIdIvTDGu3fFK5KuVe8TH9; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CCwRMBmy3TOVH/BaKsJtVwAAAABBS9Z09bnED4ihiwbRl6G0; path=/; Domain=.contentful.com',
+  'nlbi_673446=gtXZGyVgsA6Ywi2OKsJtVwAAAAAMiP1xdGqknXWXRaeqv8PY; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ybLnFBdJOC6mDfpMOoVtA7nWDV8AAAAAeN+6UXyhPJKxvCdaDcjizQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=g9ApQqSgv1FrtA9OOoVtA5bmDl8AAAAAn0nU2a9o0uN5yV6JxUiXKw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14275,7 +14585,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '2-3149832-3149835 NNYN CT(89 96 0) RT(1594742456595 34) q(0 0 2 -1) r(4 4) U5'
+  '7-12577938-12577942 NNYN CT(87 87 0) RT(1594812054048 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14285,7 +14595,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   "sys": {
     "type": "Array"
   },
-  "total": 1,
+  "total": 2,
   "items": [
     {
       "sys": {
@@ -14319,11 +14629,49 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-14T16:00:54.593Z",
-        "updatedAt": "2020-07-14T16:00:56.672Z",
+        "createdAt": "2020-07-15T11:20:51.359Z",
+        "updatedAt": "2020-07-15T11:20:54.241Z",
         "version": 2
       },
       "name": "better marketing"
+    },
+    {
+      "sys": {
+        "type": "Tag",
+        "id": "longexampletag",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "bohepdihyxin"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "env-integration",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "createdAt": "2020-07-15T11:20:11.344Z",
+        "updatedAt": "2020-07-15T11:20:11.344Z",
+        "version": 1
+      },
+      "name": "long example marketing"
     }
   ]
 }
@@ -14344,14 +14692,16 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'env-integration',
   'cf-space-id',
   'bohepdihyxin',
+  
+  
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:57 GMT',
+  'Wed, 15 Jul 2020 11:20:55 GMT',
   'etag',
-  '"17120536850921208281"',
+  'W/"12627871901362631166"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14361,31 +14711,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'fac4edf1cd90965fff630b236da40b99',
+  '4ef30785622097855abd556eaedcc416',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=tBU3uTCqR2ykL4KHZ2pqA7nWDV8AAAAAQUIPAAAAAACMzed+ujSBKbpaJfYX/mb8; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kAJ0YmTXTxi5udIgM7CVipbmDl8AAAAAQUIPAAAAAABaHRwwhG0YPEunINOHwX9a; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WI4KQgUUnz6TGVUsKsJtVwAAAAA8GzodjQPv1c4Y88Bgxc3v; path=/; Domain=.contentful.com',
+  'nlbi_673446=BWkjNrbByVQVMDZQKsJtVwAAAACC38hwlRS4aPzZ9IJyeGCz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=4XfCXajwTFBLDvpMOoVtA7nWDV8AAAAA68AdyPMdGbWxsol8gW629Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=eUGMbSQ4v3KftQ9OOoVtA5bmDl8AAAAA3H2UNg5JGaLP8SyH0azH+Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
   'X-Iinfo',
-  '5-13532562-13532569 NNYN CT(113 93 0) RT(1594742457217 32) q(0 0 2 -1) r(4 4) U5'
+  '12-30386709-30386722 NNNN CT(86 87 0) RT(1594812054598 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14426,8 +14774,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-14T15:59:32Z",
-        "updatedAt":"2020-07-14T15:59:32Z"
+        "createdAt":"2020-07-15T11:19:28Z",
+        "updatedAt":"2020-07-15T11:19:28Z"
       }
     }
   ]
@@ -14457,9 +14805,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:58 GMT',
+  'Wed, 15 Jul 2020 11:20:55 GMT',
   'etag',
-  'W/"f22cb9b177121e851327f03346d48b93"',
+  'W/"0c620f18e31bd26710de56f85f1c4e18"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -14471,15 +14819,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'f02ae2401ea2dfd7fb699fd7150ac655',
+  'a863d72256577e358abf53cf33c2805b',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -14491,11 +14839,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=47cQT+PZTZSgLeLndDuLFrrWDV8AAAAAQUIPAAAAAAB2tX8UN9VFOCvOhM7dLCmg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=cHPbg6HPRfSCbb4Kgzf/mZfmDl8AAAAAQUIPAAAAAAAhBir05DKxYvOqfc9QmGes; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AD5qHjm1F3YekBfcKsJtVwAAAABakQor/742E1Cbwx9jj5Vd; path=/; Domain=.contentful.com',
+  'nlbi_673446=uewpSOz5tC4gMPv3KsJtVwAAAACNs4Jip1Ja/MI92p+pLAmM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=18NbdX1G9S6eDvpMOoVtA7rWDV8AAAAAU8kTM8YfPIlaTjkzJBZpEw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=bGF6QZgJ/kTRtg9OOoVtA5fmDl8AAAAABKA7qhMV5kE+WA6O7FzdNw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14503,7 +14851,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-27011931-27011943 NNYN CT(93 93 0) RT(1594742457693 31) q(0 0 2 -1) r(3 3) U5'
+  '6-7443853-7443860 NNYN CT(94 96 0) RT(1594812055206 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14530,7 +14878,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:58 GMT',
+  'Wed, 15 Jul 2020 11:20:56 GMT',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14540,27 +14888,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'a6bb1391ca251e7857c67ed0f666e50e',
+  'bd3a91e9372192e04bd7be633a6605ac',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=aTGj1L6KSQKyEJaX+aeKErrWDV8AAAAAQUIPAAAAAACuppY3ZQDescn0yY4qpU72; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=4X+YdLIETSSXwrA0g0MxPJjmDl8AAAAAQUIPAAAAAACwMq1fXqRhVsthMCPfyLqF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=eIP4IfqoumEy7s4MKsJtVwAAAADUDMEHbFqUKOj3SZ5oxT9W; path=/; Domain=.contentful.com',
+  'nlbi_673446=xfuHMktQYRmCKJABKsJtVwAAAAAxL9jHpDTwpO5fLikh3JrA; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=okWvVOwCInEuD/pMOoVtA7rWDV8AAAAAyPzsyygulO0/rRJHNsjIwg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=fvSnIW4RMWLGtw9OOoVtA5jmDl8AAAAAlZZU0ihIp1tP1akCwGt1hA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-5260112-5260117 NNNN CT(88 89 0) RT(1594742458241 57) q(0 0 2 -1) r(4 4) U5'
+  '4-15469688-15469694 NNNN CT(93 93 0) RT(1594812055614 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14577,7 +14925,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "6fe00046935559ccd9213ac4bf591acd"
+  "requestId": "6ad0b13eaec148e07fd0727fd120c247"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -14601,9 +14949,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:00:59 GMT',
+  'Wed, 15 Jul 2020 11:20:56 GMT',
   'etag',
-  '"6451860625274420159"',
+  '"14807791832860259092"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14613,23 +14961,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '6fe00046935559ccd9213ac4bf591acd',
+  '6ad0b13eaec148e07fd0727fd120c247',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=DULghJTrQaeHLg772dqudLvWDV8AAAAAQUIPAAAAAAAo/6AkxJnaTBKMYe0Vc5XZ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=OW9oTe/hRHGRoxS++GJBRJjmDl8AAAAAQUIPAAAAAABVE0y912Bkki9qgMAXp+37; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=KkIqHoz9j3ZQ3xZRKsJtVwAAAABvN9t76xcndICy2i6p57D2; path=/; Domain=.contentful.com',
+  'nlbi_673446=wxbTDDXky2ELTb57KsJtVwAAAADwVnefRrEjmCXtXrXuLYMl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=yS+3GvPnNlO9D/pMOoVtA7vWDV8AAAAAUuti997LJXSB9ouVobWR+A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=snnPR6Eq51AauQ9OOoVtA5jmDl8AAAAAy5f45lRElQT9APxNRyTezg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14637,7 +14985,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '6-4142610-4142611 NNYN CT(87 87 0) RT(1594742458860 31) q(0 0 2 -1) r(4 4) U5'
+  '3-10885134-10885140 NNYN CT(93 94 0) RT(1594812056231 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14662,7 +15010,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Tue, 14 Jul 2020 16:01:00 GMT',
+  'Wed, 15 Jul 2020 11:20:58 GMT',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -14674,15 +15022,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '1c5595c56d33e78c0c9f3c34530186e7',
+  '7d7b155b4acd205a38442176c8497103',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -14694,13 +15042,13 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=XJ1aGDjZQky6kc/JvHtxYbzWDV8AAAAAQUIPAAAAAABuSSC0AR8CzLSwklnv4j2n; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MP3ZwU1BRpG8ZphXPkEjt5nmDl8AAAAAQUIPAAAAAACQIYL+bCHa4RmbjuvuwTk5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=j9o8dqKOKTOunMhhKsJtVwAAAAAQ5zPyKnyrLV4liJsazJwG; path=/; Domain=.contentful.com',
+  'nlbi_673446=vBgzW1fquinLNOORKsJtVwAAAACowxNbZJuHeQG665m8FRjE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=vwvxDPtO9FM+EfpMOoVtA7zWDV8AAAAAbGUqwAUc8dC2RQi+YC5OoQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=tVkjYI85i13ivA9OOoVtA5nmDl8AAAAAClDnG2tKZ/oawDqav+vh6g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '2-3149926-3149927 NNNN CT(92 93 0) RT(1594742459369 37) q(0 0 1 -1) r(10 10) U5'
+  '6-7444023-7444025 NNNN CT(88 89 0) RT(1594812056848 32) q(0 0 2 -1) r(11 11) U5'
 ]);

--- a/test/fixtures/contentful-migration-integration.js
+++ b/test/fixtures/contentful-migration-integration.js
@@ -35,7 +35,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -47,27 +47,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:24:59 GMT',
-  'ETag',
+  'Tue, 14 Jul 2020 15:59:31 GMT',
+  'etag',
   'W/"9f8886bb475af980f12a1a32fbc74d55"',
-  'Referrer-Policy',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -80,23 +80,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '4b4e0f89ae8497d34a7965908860e0f0',
-  'X-Download-Options',
+  'd6435e071f7e6f2be3206d9d85e95823',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FfxqWwtUQbqT8qqaeZp+U9pEB18AAAAAQUIPAAAAAABfgLKDFLTy0c2A5c0lhafi; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BW4VHShsTrOLVOtQIeS/dWPWDV8AAAAAQUIPAAAAAACApH2+h6v/NIRTynQmA0IF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SPVTEzwBAgUi9ysWYMlkBAAAAABpH1VOJj5njzZqidjNQgZa; path=/; Domain=.contentful.com',
+  'nlbi_673446=X1LbFWSoqRtUgI4kKsJtVwAAAADD2AKyPU9IHQ01M1+ZJe3h; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=m+c9aLa07yG1s1sGPWpmA9pEB18AAAAAFa/9Eg7I4pC7XUZF0g7LwQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=wJ6dIDWAbxxxtflMOoVtA2PWDV8AAAAA4Jl2krP+lLLEGiic5pujYg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -104,12 +104,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-26738708-26738710 NNYY CT(0 0 0) RT(1594311898322 34) q(0 0 0 -1) r(2 2) U5'
+  '9-5255586-5255587 NNYN CT(90 90 0) RT(1594742370761 41) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration', {"name":"env-integration"})
-  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-09T16:25:00Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-09T16:25:00Z"}}, [
+  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-14T15:59:32Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-14T15:59:32Z"}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -120,62 +120,62 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:00 GMT',
-  'ETag',
-  'W/"7054f2d88f6e69c2b9dbfff1f540c20f"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:32 GMT',
+  'etag',
+  'W/"4f05bbd781578a262c5dfe3e24b0ce22"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '735e7c9e6db10324fa705c53715830ca',
-  'X-Download-Options',
+  'dea219f2244834711e05121a1a79f22c',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Content-Length',
   '707',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=VM+Z+PJ2SlKAxhKOsN7o7ttEB18AAAAAQUIPAAAAAADrwxTpIZgvJhCnraASFFtf; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=wutDcZboRgWJnel0gjhEUWTWDV8AAAAAQUIPAAAAAAA/aPftnwhIcRuE+o70SdhY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NNq1PmNs3zi5jXAeYMlkBAAAAACFjdSQQXyq7VC6VXDzr/iQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=8hqEcq/wRxAymsiqKsJtVwAAAABCrGkRQbfgqn6+frly1SRt; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=aEk+LMpdQWWstFsGPWpmA9tEB18AAAAAhnP5BuxkWAz5A4lAwyNCwg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=bmXuSz6OO2qYtvlMOoVtA2TWDV8AAAAAc5I8vgPIReO8JAWC7XFDBg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55392486-55392490 NNNY CT(0 0 0) RT(1594311898650 26) q(0 0 0 -1) r(10 10) U5'
+  '9-5255625-5255627 NNNN CT(88 88 0) RT(1594742371337 30) q(0 0 2 -1) r(11 11) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -207,7 +207,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt":"2020-07-09T16:25:00Z",
+    "createdAt":"2020-07-14T15:59:32Z",
     "updatedBy":{
       "sys":{
         "type":"Link",
@@ -215,12 +215,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "updatedAt":"2020-07-09T16:25:00Z"
+    "updatedAt":"2020-07-14T15:59:33Z"
   }
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -232,27 +232,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:01 GMT',
-  'ETag',
-  'W/"75ff57ac5f5bc26336602224480791f8"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:33 GMT',
+  'etag',
+  'W/"13e0007531e699aec6e7033be00b9b51"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -265,23 +265,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e8367b10870c1d6ec1dad13d3aa3253a',
-  'X-Download-Options',
+  'bd4cae807cd58264b4df716fa62963f9',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=poeUVy6vQ6i8Tc55swdtXtxEB18AAAAAQUIPAAAAAAAV2QDMJJSvY9LRtXck3e4v; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AUHdWSwXQbqVRRB/Lk2qeWXWDV8AAAAAQUIPAAAAAABgCWp3GEXL7Avlm2whN0iW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RviyYUWBQzYyKMY/YMlkBAAAAACaXKvJTQcIpjTVK19OexZU; path=/; Domain=.contentful.com',
+  'nlbi_673446=LgogV+yfhmVvvG/BKsJtVwAAAABpRsGcy4rFr3xJxm+qP1+/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=6vUBFrblCAC0tVsGPWpmA9xEB18AAAAAn5/VFFozlHjywLjOO5hHNg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=sDKXFS0k5RqAt/lMOoVtA2XWDV8AAAAAODr+KeBnpMAYIvXuUuE3cg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -289,7 +289,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86045821-86045832 NNYY CT(0 0 0) RT(1594311899863 24) q(0 0 0 -1) r(7 7) U5'
+  '13-20307479-20307503 NNYN CT(96 100 0) RT(1594742372649 38) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -326,7 +326,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:01 GMT',
+  'Tue, 14 Jul 2020 15:59:34 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -346,15 +346,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '7fe682109d0518440db10c22bc77e243',
+  '1218f2bb40d8f8b4af2e412919ba51d3',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=TiS+CGMrSHqh60+X/XIu9N1EB18AAAAAQUIPAAAAAADAfFo/wFCUuL77jgEJFJX+; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Z2A1VxiLQiSIGCIrBXwDbGbWDV8AAAAAQUIPAAAAAACDqKOsxTCeJnX9wdX5yKUG; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=cwvdV5yxCWWmXdELYMlkBAAAAABENANfJDSxQS4JbhZ2hi4o; path=/; Domain=.contentful.com',
+  'nlbi_673446=aU3PPLPbZ1ipsK+VKsJtVwAAAAB9vpdsAX6qBzQxrw6PPQBt; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=JxsaEdXyiHePtlsGPWpmA91EB18AAAAA3wxn/Rj23PnHVY2tRlSdjA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=fEWSGk1BYlpHuPlMOoVtA2bWDV8AAAAAtit6BtYKRYghqbgx4p/RUg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -362,7 +362,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66921432-66921442 NNYN CT(93 93 0) RT(1594311900702 38) q(0 0 2 -1) r(6 6) U5'
+  '13-20307723-20307738 NNYN CT(87 87 0) RT(1594742373651 34) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -403,15 +403,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -423,27 +423,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:02 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:35 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -456,23 +456,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '2351574da06cc2f959a8d9acce51992e',
-  'X-Download-Options',
+  '7c8aa55353358ef7668ce95b19775036',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lot0CMoWQI6Uu/QdMGiYSt5EB18AAAAAQUIPAAAAAADTMmW4BQHiYg0wpOdn2TDD; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=oUofq5vLQ1idHx8tget/vmfWDV8AAAAAQUIPAAAAAAA7zSn6dVQz4m78c6Xgieyp; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=a2f6HjQB5k3xIKi2YMlkBAAAAABofbqhO4doj6PX/cj6C3gP; path=/; Domain=.contentful.com',
+  'nlbi_673446=dlsTf5FfGn5tyvnrKsJtVwAAAACpEQxxMOQ/v0RgwjSpOX2E; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Gycxe97RDRCut1sGPWpmA95EB18AAAAAGNhysbpKY6vvEPnVEoITXg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3srvUFE5R3o2uflMOoVtA2fWDV8AAAAA3bCQAw2tPM5o5DsJ4LAiJQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -480,12 +480,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '2-9264447-9264449 NNYY CT(0 0 0) RT(1594311901530 34) q(0 0 0 -1) r(7 7) U5'
+  '12-17393592-17393601 NNYN CT(93 95 0) RT(1594742374483 47) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog', {"name":"angry dog","fields":[{"id":"woofs","name":"woof woof","type":"Number","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-09T16:25:03.323Z","updatedAt":"2020-07-09T16:25:03.323Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-14T15:59:36.539Z","updatedAt":"2020-07-14T15:59:36.539Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -507,9 +507,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:03 GMT',
+  'Tue, 14 Jul 2020 15:59:36 GMT',
   'etag',
-  '"10692450299847994942"',
+  '"8051465262240085603"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -527,21 +527,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '32fc331b2cf8dc5be5b64a64fb3c311f',
+  'be1fc046553b3b419999029db1343090',
   'Content-Length',
   '1051',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ieJ0GaOhTNWXDczD7vNRJt5EB18AAAAAQUIPAAAAAADcM9d8RrcETfmfXbnuhe4L; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=xt2bD6SCS2K+PQm41Awxl2jWDV8AAAAAQUIPAAAAAABzyi8ePgNd2JOWwU56O/ip; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=kloCRK+NN1c59I8PYMlkBAAAAABOxoqor6eVHvrCgHAfoPqT; path=/; Domain=.contentful.com',
+  'nlbi_673446=y3OjZMifsTj3bQPCKsJtVwAAAAB3cstwOFwYeJelVP1ak5Xl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Qh95MVr2nTE4uFsGPWpmA95EB18AAAAAQdghOLPdAtdJk5wgLaIgKw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=mO7pORgmrGUbuvlMOoVtA2jWDV8AAAAA7xgG5414nmqPhHqTcSRn5Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86046549-86046562 NNNY CT(0 0 0) RT(1594311902430 33) q(0 0 0 -1) r(4 4) U5'
+  '14-26987702-26987714 NNNN CT(93 93 0) RT(1594742375529 36) q(0 0 2 -1) r(10 10) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -557,8 +557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:03.794Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:37.439Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -582,8 +582,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
-    "publishedAt": "2020-07-09T16:25:03.794Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "publishedAt": "2020-07-14T15:59:37.439Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -633,9 +633,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:04 GMT',
+  'Tue, 14 Jul 2020 15:59:37 GMT',
   'etag',
-  'W/"10718090535463505466"',
+  'W/"7761196522538835660"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -645,29 +645,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '453c84ec912266108e54dbbb85565ce8',
-  'transfer-encoding',
-  'chunked',
+  '3f3396b1354164ef2d4c3aeb13e62055',
+  'Content-Length',
+  '441',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=q0g6uvIkTYOXG5ZZqa0AZd9EB18AAAAAQUIPAAAAAABGfTjJLYbfaedcSjJFXvCk; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=M60Gv1RiQ3uXwmhpfdr6gmnWDV8AAAAAQUIPAAAAAADTc+ecL/HUb/m1l3Xs6PQB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hqjKTyyAoB3CJxMyYMlkBAAAAACc6xQDseBKmqiDIMJyOLo2; path=/; Domain=.contentful.com',
+  'nlbi_673446=hG9CC9nLO3Tx9FIrKsJtVwAAAAAT/3OkWshYLAU3u0NekiuX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=yTBbed0yCUftuFsGPWpmA99EB18AAAAAsox0Wxa146V9xdm+//u0qQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=SCG+NlAo7R/yuvlMOoVtA2nWDV8AAAAA/oxLfQXACS3Z/TaTjiFYMQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27141785-27141786 NNNY CT(0 0 0) RT(1594311902926 30) q(0 0 0 -1) r(5 5) U5'
+  '12-17394102-17394114 NNNN CT(93 93 0) RT(1594742376737 32) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -683,8 +683,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:03.794Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:37.439Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -693,8 +693,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:03.794Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:37.439Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -759,9 +759,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:04 GMT',
+  'Tue, 14 Jul 2020 15:59:38 GMT',
   'etag',
-  'W/"2679592502292985425"',
+  'W/"6448194171137651990"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -779,21 +779,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a7f6a593151d58d3ee0698eb7d50ec8e',
-  'transfer-encoding',
-  'chunked',
+  '38f1f736a9467dd6dea2ffd5d6707dba',
+  'Content-Length',
+  '442',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=8qNyjtKaSZ+efY9om+hCtuBEB18AAAAAQUIPAAAAAACX09gx3s8Dwle3xAO7VKAL; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=RQb12jjUSmyzy+h5HNF01GrWDV8AAAAAQUIPAAAAAABEs9yPl8ALtVi69ZZLq0fr; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NZeBIwxrW2WWV2AxYMlkBAAAAABio+9LdBbls1wQYtspjhpa; path=/; Domain=.contentful.com',
+  'nlbi_673446=gOPgNthJpx38X0IoKsJtVwAAAACjLq9A+l65VWHkuBunh7sQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=2EvvY82VohKsuVsGPWpmA+BEB18AAAAAq1StiAghPosTs/O/CWfCWA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0oanIKDgdEVzu/lMOoVtA2rWDV8AAAAAGiz+fuy6f3e/kFexe6DcDA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66922145-66922153 NNNY CT(0 0 0) RT(1594311903753 28) q(0 0 0 -1) r(3 3) U5'
+  '14-26988438-26988449 NNNN CT(93 93 0) RT(1594742377640 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -818,8 +818,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:03.323Z",
-        "updatedAt": "2020-07-09T16:25:03.794Z",
+        "createdAt": "2020-07-14T15:59:36.539Z",
+        "updatedAt": "2020-07-14T15:59:37.439Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -828,8 +828,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-09T16:25:03.794Z",
-        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+        "publishedAt": "2020-07-14T15:59:37.439Z",
+        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -896,9 +896,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:10 GMT',
+  'Tue, 14 Jul 2020 15:59:43 GMT',
   'etag',
-  'W/"3726170834583369418"',
+  'W/"13692349416730014677"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -916,21 +916,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'dda40b62e1d08bace6cbc93fcd7a6bd5',
+  '2c25490411a2f5274c0b587295fad6c3',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=0qVgcPfdS62e4CXCXKJPuOVEB18AAAAAQUIPAAAAAABTg7AbZmQltKEATr2PbmH3; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=8pgkA6JNSJSNwmbyvWuebW/WDV8AAAAAQUIPAAAAAAC141GqaA9Z0mwL4tje+hV/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=itjXdzlN7U6cFiFQYMlkBAAAAACGxKkiFsRx/M+JXn1UmM7+; path=/; Domain=.contentful.com',
+  'nlbi_673446=8Xy/QysRmUpj75hjKsJtVwAAAAAvRozKcRNlCBqID4EDUE49; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=dhaHT++U7i6lv1sGPWpmA+VEB18AAAAARzttJAv/ninNQpOZDUYxVQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nXqtGpkzcz/GwflMOoVtA2/WDV8AAAAAwvSciVT3bAHHfT2VIimEow==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86048480-86048488 NNNY CT(0 0 0) RT(1594311909270 35) q(0 0 0 -1) r(2 2) U5'
+  '11-13770450-13770453 NNNN CT(91 91 0) RT(1594742383161 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -971,15 +971,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -991,27 +991,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:10 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:45 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -1024,23 +1024,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '53db55e6bf5a01211e0de9b5524e6cdc',
-  'X-Download-Options',
+  '397be94a0c89e7cd868c0d4309403b35',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=gu+QVH8FRw6OC9qsb9A7i+ZEB18AAAAAQUIPAAAAAACvX7aJLJwMfctcYh8W7oG4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WvetzpFrTyyJoEF8iX4J5HHWDV8AAAAAQUIPAAAAAACcBqF5wTFRp4v9nkDd/yQs; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ttsLLprm32oRK4nJYMlkBAAAAABqBBR3IpGpm90/NVwPGlKp; path=/; Domain=.contentful.com',
+  'nlbi_673446=B8DEOLkjsBWHyMOiKsJtVwAAAACy00VjC+uwoLurtAEfCdlh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=tz7JKObQG3O5wFsGPWpmA+ZEB18AAAAAr0poM66aDkC4eTF6EE8+Pw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7F5qEpUj43iaxPlMOoVtA3HWDV8AAAAA3zXCqzDhzLc0Jo9cADwNmQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1048,7 +1048,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86048596-86048609 NNYY CT(0 0 0) RT(1594311909696 31) q(0 0 0 -1) r(7 7) U5'
+  '14-26990724-26990733 NNYN CT(88 87 0) RT(1594742384689 34) q(0 0 1 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1064,8 +1064,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:11.460Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:46.518Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1074,8 +1074,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:03.794Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:37.439Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1140,9 +1140,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:11 GMT',
+  'Tue, 14 Jul 2020 15:59:46 GMT',
   'etag',
-  'W/"5226526402958839353"',
+  'W/"17009879483529396695"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1160,21 +1160,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '55ce45d0c37902929a6e218a48d576d9',
+  '41b955b2e0c9409aabe01cd293841ecd',
   'Content-Length',
   '446',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=T4r39nnvTiu2DnCmV55NtOZEB18AAAAAQUIPAAAAAACYMtDMc1ZnG7k2w4mHNjTw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3ERSb8OpTvG9RANrWps2pHLWDV8AAAAAQUIPAAAAAADtKcJakwPDwp+AbPyNmwNS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xTAsOW0A6RpcCcfsYMlkBAAAAADM8aKIVHJKF3HcHlc9+N2z; path=/; Domain=.contentful.com',
+  'nlbi_673446=ypG+B6/uw3F24DXBKsJtVwAAAADuD0bzF74TeNJ2NgS9q6RN; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=aTjAN32VdR5KwVsGPWpmA+ZEB18AAAAAvz5PQ4dgsZH2D/JkpUS4MQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=KQD1aMYM7C1DxflMOoVtA3LWDV8AAAAApcxeN7NjwiTzGDXptdmGWQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55394887-55394892 NNNY CT(0 0 0) RT(1594311910706 30) q(0 0 0 -1) r(2 2) U5'
+  '7-7154761-7154763 NNNN CT(86 88 0) RT(1594742385781 31) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1190,8 +1190,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:11.848Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:47.040Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1200,8 +1200,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:11.848Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:47.040Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1266,9 +1266,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:12 GMT',
+  'Tue, 14 Jul 2020 15:59:47 GMT',
   'etag',
-  'W/"232822418921518007"',
+  'W/"13834337006343995036"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1286,21 +1286,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'e32bf1876a569ba1c1c93857ea686756',
+  'a9853d2f0afa74d2a3c6c2ddfa97b676',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mW8hZUteTsWPYHjY5ueSm+dEB18AAAAAQUIPAAAAAAAMDzI26oDvHIImI1koIp/1; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lpXKQe4HR+6BhvfZZ8891XLWDV8AAAAAQUIPAAAAAADig+8DhVUepIlLWCP/x05I; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SLgTM6X7fhXI5I24YMlkBAAAAAAMbvtcdwseOhX5GnCYcEdX; path=/; Domain=.contentful.com',
+  'nlbi_673446=ORSaXiJNon9rKlofKsJtVwAAAAA3BaGgb87KcTLCTbLHArPp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=RHHxLV5lVXLXwVsGPWpmA+dEB18AAAAA85q+1RHJTyDHQipNOGL2fQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=H6R3e03VBwzExflMOoVtA3LWDV8AAAAAq7Aita1oM5u5K4qFGoL//Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66923847-66923851 NNNY CT(0 0 0) RT(1594311911118 32) q(0 0 0 -1) r(4 4) U5'
+  '14-26991273-26991283 NNNN CT(92 94 0) RT(1594742386357 35) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1316,8 +1316,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:12.485Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:47.823Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1326,8 +1326,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:11.848Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:47.040Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1381,9 +1381,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:12 GMT',
+  'Tue, 14 Jul 2020 15:59:47 GMT',
   'etag',
-  'W/"2927921332069189198"',
+  'W/"2112654971627075758"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1401,21 +1401,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '40eb4540dd1ee7fda7b53a35c460bc79',
+  'f8155733774fa2a8b49688cff150c7ea',
   'Content-Length',
-  '375',
+  '374',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=IBtGrwKeT0iMBh8xn1zp7edEB18AAAAAQUIPAAAAAACCc2aJ1XuyxubRJ2ydnqeP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YPDr0YzNTCaAmaiN+4tREnPWDV8AAAAAQUIPAAAAAACQN0uszW2afzKu8fXLFoId; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=G8cGC/IPnEgvrhjqYMlkBAAAAAB4kHHIplfkf44XCImHuNAq; path=/; Domain=.contentful.com',
+  'nlbi_673446=zHrrM8f6ZEmHEhBOKsJtVwAAAACD+KuvT8ZU36S2dw6bQjey; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=91VpT8olIEBOwlsGPWpmA+dEB18AAAAAVLHt69bjere5z5XwfV7S0g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ok2/dF+ZDHBVxvlMOoVtA3PWDV8AAAAARVP4UhTp6Q1eQKs2uiS+8Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86049189-86049200 NNNY CT(0 0 0) RT(1594311911738 32) q(0 0 0 -1) r(2 2) U5'
+  '3-6341568-6341570 NNNN CT(87 88 0) RT(1594742386962 58) q(0 0 1 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1431,8 +1431,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:13.052Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:48.344Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1441,8 +1441,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-09T16:25:13.052Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:48.344Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1496,9 +1496,124 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:13 GMT',
+  'Tue, 14 Jul 2020 15:59:48 GMT',
   'etag',
-  'W/"15997666040028119424"',
+  'W/"11539890348999363549"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'd8c3b23bc8db1af197a68f26a74d9369',
+  'Content-Length',
+  '370',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=L6D0y1thSaOEI3HiH3WHUXTWDV8AAAAAQUIPAAAAAABTR1HjLF53HPmpJDhf+9FM; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=clEEX3X2ahRuCAh1KsJtVwAAAAASiHXfoRJSAIDaWWGrLBK7; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=4zyaQHLis0D2xvlMOoVtA3TWDV8AAAAAG0GbbeNX5857/PMGekRokw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '5-13522032-13522037 NNNN CT(86 89 0) RT(1594742387685 33) q(0 0 1 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:48.344Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 5,
+    "publishedAt": "2020-07-14T15:59:48.344Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 3,
+    "version": 6,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "angry dog",
+  "description": "super angry",
+  "fields": []
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 15:59:48 GMT',
+  'etag',
+  'W/"11539890348999363549"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1516,136 +1631,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '14c777a1b03daf7c988a2d731b007ebf',
+  '06eee3f8cca4c0f2724eb1267e3a7224',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=U5tHeu29TgaTaDbWdke70+hEB18AAAAAQUIPAAAAAAAOTwWMQ/XvpeutkBohcCZr; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=RfQT7OpWQCqJjS3RQGXZDnTWDV8AAAAAQUIPAAAAAAAj2cAy6Pr0xu6nvvDXmnhT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RgO2XzAp3TkOZRD4YMlkBAAAAACYX8jWdQOf39dAinangBeS; path=/; Domain=.contentful.com',
+  'nlbi_673446=einhHP9sCyWkAv+yKsJtVwAAAADckfOrH4npyWnL++0kJDin; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=qcewAj+mhRcrw1sGPWpmA+hEB18AAAAAFphhevC+e8iaz6IpZ9rz9w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=LwAfIAXfRThUx/lMOoVtA3TWDV8AAAAABGSIDti7bpy5AHY3/+THKg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26739772-26739775 NNNN CT(94 94 0) RT(1594311912144 32) q(0 0 2 -1) r(5 5) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:13.052Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 5,
-    "publishedAt": "2020-07-09T16:25:13.052Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 3,
-    "version": 6,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "angry dog",
-  "description": "super angry",
-  "fields": []
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Thu, 09 Jul 2020 16:25:13 GMT',
-  'etag',
-  'W/"15997666040028119424"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '1a7fff22c179e0a8c81507b60492c055',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=SJZ1kJ0PT+G/E9fsVP4wRulEB18AAAAAQUIPAAAAAACeVkHW1FkLI3OTTCTrSsZX; expires=Fri, 09 Jul 2021 11:06:46 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=cluuZwrYQSazXYYLYMlkBAAAAADq2yf7vHxjXDveqHncQCW4; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=y2W9N3gHpmPww1sGPWpmA+lEB18AAAAAIkArQ1z07+YfHCF2oQdDng==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '0-2794462-2794465 NNNY CT(0 0 0) RT(1594311912965 31) q(0 0 0 -1) r(4 4) U5'
+  '13-20311444-20311449 NNNN CT(93 95 0) RT(1594742388231 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1670,8 +1670,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:03.323Z",
-        "updatedAt": "2020-07-09T16:25:13.052Z",
+        "createdAt": "2020-07-14T15:59:36.539Z",
+        "updatedAt": "2020-07-14T15:59:48.344Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -1680,8 +1680,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 5,
-        "publishedAt": "2020-07-09T16:25:13.052Z",
-        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+        "publishedAt": "2020-07-14T15:59:48.344Z",
+        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -1737,9 +1737,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:14 GMT',
+  'Tue, 14 Jul 2020 15:59:49 GMT',
   'etag',
-  'W/"14910209425744553100"',
+  'W/"18429099488360793111"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1757,21 +1757,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e2f7cfcd54ce32fc9616b2e33190c3e2',
+  'bbfe6999bef951562523222dac723811',
   'Content-Length',
   '435',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=8RJw4UOBQhuxXSP8M+HRvulEB18AAAAAQUIPAAAAAADNgwWVxkDaDjV5bTz4s0D+; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=auzuvkEMRxSIo/wRTjdqCXXWDV8AAAAAQUIPAAAAAACSlLeu6USKSgd/AevFofX6; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SRIfQybY6wPvDqM7YMlkBAAAAAAWCEZpdg66hTHLW3ngWxiX; path=/; Domain=.contentful.com',
+  'nlbi_673446=ewLBaU5rnTrositlKsJtVwAAAAB/9aEhhVsdyZCo0psas50t; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=JoRAd1jERGFqxFsGPWpmA+lEB18AAAAAm4foj8oyJaZLJWuy0Jcm5Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=vZ0HaVDSMCLNx/lMOoVtA3XWDV8AAAAAHOdwsgvl56r92Wql83wqsQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-21639669-21639674 NNNY CT(0 0 0) RT(1594311913576 33) q(0 0 0 -1) r(1 1) U5'
+  '11-13771248-13771253 NNNN CT(92 91 0) RT(1594742388763 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1812,15 +1812,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -1832,27 +1832,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:15 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:49 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -1865,23 +1865,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '17d2e2194a38b47e410b2d199eaea49f',
-  'X-Download-Options',
+  '0eb6e6c3b63f1364a29b0c8c58108c51',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Bw6Qx5ssSoOwLIhbxH/5cOpEB18AAAAAQUIPAAAAAAAu425Mghshr5FMaEMborvo; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rNbJHEqRTICUxqYsMyNRG3XWDV8AAAAAQUIPAAAAAADuBfgyz3/31kt2KsxjY+1r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=wjVjcI3ARBmpr+9WYMlkBAAAAAD9uuIk4OUaIMBXSTcQvs2l; path=/; Domain=.contentful.com',
+  'nlbi_673446=nHE6fw01SG1BO2o7KsJtVwAAAABHdgwWhFfWvWGKG+gUMpjG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=vnv3UHCLelBRxVsGPWpmA+pEB18AAAAATSwxTD4UycP5gn1mP7GYBg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=5SnncTPNYH49yPlMOoVtA3XWDV8AAAAALL9qxm+5qygmSOTzciVidA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1889,7 +1889,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86049826-86049834 NNYY CT(0 0 0) RT(1594311913882 25) q(0 0 0 -1) r(6 6) U5'
+  '3-6341732-6341735 NNYN CT(92 92 0) RT(1594742389219 34) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1905,8 +1905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:15.735Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:50.328Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1915,8 +1915,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-09T16:25:13.052Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:48.344Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1981,9 +1981,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:15 GMT',
+  'Tue, 14 Jul 2020 15:59:50 GMT',
   'etag',
-  'W/"7638184034428287910"',
+  'W/"7991568740491863076"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2001,21 +2001,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e3b4e783a7294c0b9b1b84eb6a9c5748',
+  'a980d805eee771b0a8ddc43126a16820',
   'Content-Length',
   '496',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=G7P5smf4RkKFPm0eipLSn+tEB18AAAAAQUIPAAAAAADeHus5s/JxgMcYuoinkmZh; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=NUFd+Il5RTG2qVcFcpBWrnbWDV8AAAAAQUIPAAAAAADoHmWv2BNV5WJQPzi5MQVF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CZzGBCerEV/+9msgYMlkBAAAAAAJW38jMVRxHPQ9lrwbcjFg; path=/; Domain=.contentful.com',
+  'nlbi_673446=VMo5AF5IChMOpZSfKsJtVwAAAAByoQX3G6jHXL1V6bFTm2ep; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=9+9Vfp5xfiL5xVsGPWpmA+tEB18AAAAA/i1229oRfWbbExDokJqC1Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Elf7ZP9ueU7FyPlMOoVtA3bWDV8AAAAAa804YrQyvlmnJBGhrZlBpw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55395660-55395668 NNNN CT(87 88 0) RT(1594311914806 28) q(0 0 2 -1) r(4 4) U5'
+  '3-6341754-6341759 NNNN CT(94 102 0) RT(1594742389636 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2031,8 +2031,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:16.143Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:50.905Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2041,8 +2041,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-09T16:25:16.143Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:50.905Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2107,135 +2107,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:16 GMT',
+  'Tue, 14 Jul 2020 15:59:51 GMT',
   'etag',
-  'W/"1162459728137802232"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'a12d6171e9e8030f76af111a140e50bb',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=KyqUkMAzTI2bWqtQqoU47+tEB18AAAAAQUIPAAAAAAAGq+mn9mhFhWzqmJViyZwy; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=XE50BKt8dHp6ASkfYMlkBAAAAAD7166lkQud4FHLE7rky4+B; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=ww9xZ9sYRG9ixlsGPWpmA+tEB18AAAAAQFQQXFRHmQt/U+cCWaZuJQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '14-86050253-86050262 NNNY CT(0 0 0) RT(1594311915432 32) q(0 0 0 -1) r(2 2) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:16.143Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 7,
-    "publishedAt": "2020-07-09T16:25:16.143Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 4,
-    "version": 8,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "goodboys",
-      "name": "number of times he has been called a good boy",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Thu, 09 Jul 2020 16:25:16 GMT',
-  'etag',
-  'W/"1162459728137802232"',
+  'W/"7028925680526682898"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2253,21 +2127,147 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'c41b508d7525d87394e3ca47d8875859',
+  '746bd488b2df027216de0b1e7572ce03',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=bKIyblDNTfufmF4sKUiJUOtEB18AAAAAQUIPAAAAAABFNtuLLo0GeilP9RGBUrDE; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WblmqFUuSE2tOttOUb4ZcHbWDV8AAAAAQUIPAAAAAABENUh2TnyVkfkucf5SLjDA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=fvXTeJvb0CI7D9rHYMlkBAAAAADaH1uRnYnjCnOYi81jXQ2D; path=/; Domain=.contentful.com',
+  'nlbi_673446=YCsnHt8pykLUCgUAKsJtVwAAAAAZCJWbojGNw3ZLcGWl04qE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=QuMAfsEfESKjxlsGPWpmA+tEB18AAAAACB737vkuSR3vSF+sxUrCDQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=NEFEKfe93R5syflMOoVtA3bWDV8AAAAAZA1h/l+31hWyJnR9KBTiWQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41049037-41049045 NNNY CT(0 0 0) RT(1594311915750 39) q(0 0 0 -1) r(2 2) U5'
+  '14-26992502-26992513 NNNN CT(87 94 0) RT(1594742390251 32) q(0 0 2 -1) r(5 5) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:50.905Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 7,
+    "publishedAt": "2020-07-14T15:59:50.905Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 4,
+    "version": 8,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "goodboys",
+      "name": "number of times he has been called a good boy",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 15:59:51 GMT',
+  'etag',
+  'W/"7028925680526682898"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '7bb76a067437bd26a399ef7057239821',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=LaRCNvVGQnKioux+gWUUJ3fWDV8AAAAAQUIPAAAAAADKaggsNQn4XnApWoDAKwXg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=60n7J5R6b091w7I0KsJtVwAAAAAcsz6hrJCdiChshRXZZMnb; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=FgeFQKqnOkfCyflMOoVtA3fWDV8AAAAAxvIwZ10NeOsB8JY4lMSWnw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '4-9009661-9009667 NNNN CT(93 94 0) RT(1594742390787 31) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2292,8 +2292,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:03.323Z",
-        "updatedAt": "2020-07-09T16:25:16.143Z",
+        "createdAt": "2020-07-14T15:59:36.539Z",
+        "updatedAt": "2020-07-14T15:59:50.905Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -2302,8 +2302,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 7,
-        "publishedAt": "2020-07-09T16:25:16.143Z",
-        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+        "publishedAt": "2020-07-14T15:59:50.905Z",
+        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -2370,9 +2370,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:16 GMT',
+  'Tue, 14 Jul 2020 15:59:51 GMT',
   'etag',
-  'W/"7046238294136992912"',
+  'W/"9386130412272337565"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2382,29 +2382,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  'dabdb72181ddb17eba74dd6e0de519e8',
-  'transfer-encoding',
-  'chunked',
+  '262a9f8a928cc0e6be573b443edc4cfa',
+  'Content-Length',
+  '554',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=V2H3LZhXRBueWldVSBcSv+xEB18AAAAAQUIPAAAAAAD2vE2Vdp2wFnMVLDpbFtHT; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=pLbLjKtpT3ab6WiZJJlqInfWDV8AAAAAQUIPAAAAAADG4WmZu2j7d6mJa/1xrSOe; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ok9ibZUA2AcYdmgeYMlkBAAAAADRIRRc6QGOoKrB3JoqMwj7; path=/; Domain=.contentful.com',
+  'nlbi_673446=uIhrRWdD6l+rUeB8KsJtVwAAAACbllGV8+3dHzi1YakHnp/i; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=N2gfdBl+6XzsxlsGPWpmA+xEB18AAAAAgwwR9sX9ISMAP6grPTC2vQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0xCxKEO2szwmyvlMOoVtA3fWDV8AAAAAwAPcF1qSUMiqOa2CklRAcA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-42737992-42737994 NNNY CT(0 0 0) RT(1594311916038 26) q(0 0 0 -1) r(2 2) U5'
+  '14-26992803-26992809 NNNN CT(89 90 0) RT(1594742391249 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2421,7 +2421,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-09T16:25:03.987Z",
+    "createdAt": "2020-07-14T15:59:37.648Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2429,7 +2429,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:16.209Z",
+    "updatedAt": "2020-07-14T15:59:50.994Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2480,9 +2480,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:17 GMT',
+  'Tue, 14 Jul 2020 15:59:52 GMT',
   'etag',
-  '"8848235822135652323"',
+  '"15450428136113776622"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2500,15 +2500,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '1635f1037eb84dc41d42212d6d1ef839',
+  'dbf9419de9d6d7a2c18c902a2534b8a1',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=SZ7CQXVlQcO3tRxF6nirxexEB18AAAAAQUIPAAAAAACo0iPqjGqj68ktIEmiERYn; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=cZWbMZXWQdi6dFkA9nQTynjWDV8AAAAAQUIPAAAAAABhDl46ZJtXwXVXVtjlQGwx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AkJfTbttBxlG0oAyYMlkBAAAAACm1xr4BuAw4thAhtfiJ5EK; path=/; Domain=.contentful.com',
+  'nlbi_673446=JHzffeAaeDw0Q8jXKsJtVwAAAABNHvAkhgMK0SZgUqnKi0E4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=cS5nPoIeoj5jx1sGPWpmA+xEB18AAAAAKNY7/zaZtn7ezXxMzzMIUA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=4kUbTuNI5W/zyvlMOoVtA3jWDV8AAAAALEvSTg9AxioBIVRgIIWjqA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2516,7 +2516,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '6-13874432-13874435 NNYN CT(86 87 0) RT(1594311916302 32) q(0 0 2 -1) r(3 3) U5'
+  '3-6341882-6341886 NNYN CT(85 88 0) RT(1594742391883 34) q(0 0 1 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2557,15 +2557,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -2577,56 +2577,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:18 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:53 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'd8cdc591025040290edf9b56f23041e1',
-  'X-Download-Options',
+  'a2a9ccdbb76bc98d5eb2419ffaba1671',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=enqdYb0DQOykxBVF8fT25O1EB18AAAAAQUIPAAAAAAC8HKhVd9ZjALyPccXSASD4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=9KK7gnHJTHu4VAAyqP8O5HnWDV8AAAAAQUIPAAAAAACxDPRZ7RIgoxzIQevBtOc2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=C2y2PpdSJz5Cfx95YMlkBAAAAACW7sGGgsTb+6V9ba3JwosE; path=/; Domain=.contentful.com',
+  'nlbi_673446=RK8xQa0wql2FlS+nKsJtVwAAAADGHGkS0FA9sEx+5vsS96xS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=rzOTdLHoli+jyFsGPWpmA+1EB18AAAAAGgYAQiMaCDEtk1gNr83A3A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=fVvyHS/b8Fhky/lMOoVtA3nWDV8AAAAATPPNg/VfYzgdty23GMy1IA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2634,7 +2634,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '7-27374452-27374456 NNYN CT(93 93 0) RT(1594311916766 20) q(0 0 2 -1) r(9 9) U5'
+  '14-26993287-26993296 NNYN CT(87 87 0) RT(1594742392713 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2650,8 +2650,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:18.597Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:53.832Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2660,8 +2660,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-09T16:25:16.143Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:50.905Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2726,9 +2726,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:18 GMT',
+  'Tue, 14 Jul 2020 15:59:53 GMT',
   'etag',
-  'W/"3211865957038243333"',
+  'W/"15185963368281600899"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2738,29 +2738,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '44387c67cd24d76ae6eda5645387c6d5',
-  'transfer-encoding',
-  'chunked',
+  'c1d23ed915eb9fb089984b9ab4b645da',
+  'Content-Length',
+  '501',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=12e3QsJ+Rx2CWuIUm0xxO+5EB18AAAAAQUIPAAAAAADWt+6cOX9vkKkD6t2ieUj8; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=wmPzWPcCRKC8MyCVTZbYRHnWDV8AAAAAQUIPAAAAAABCEPz6+BOV9bIrzl8g28lf; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TKmXWrrsaE1jDEQiYMlkBAAAAAC1Eej80cW4MoCUrggYATYP; path=/; Domain=.contentful.com',
+  'nlbi_673446=GYm1d87YTHCRJf+CKsJtVwAAAAB3WC0BgeWDBiYk/uMUUG91; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=XrzMes5wIzkdyVsGPWpmA+5EB18AAAAABLEFopG7X1cmzU4rD0rXMQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=9aWgXfRnJnXsy/lMOoVtA3nWDV8AAAAANmrmWOh1/wsSVRHA4i9TqQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55396381-55396387 NNNY CT(0 0 0) RT(1594311917878 31) q(0 0 0 -1) r(1 1) U5'
+  '14-26993392-26993400 NNNN CT(87 88 0) RT(1594742393149 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2776,8 +2776,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:18.902Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:54.396Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2786,8 +2786,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-09T16:25:18.902Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:54.396Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2852,9 +2852,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:18 GMT',
+  'Tue, 14 Jul 2020 15:59:54 GMT',
   'etag',
-  'W/"14506092796344775312"',
+  'W/"842318945658093321"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2864,34 +2864,34 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '013d2150a9d95378cce395b819b23406',
-  'transfer-encoding',
-  'chunked',
+  'e82def8b65f9bd38a6288c8f6b3bcd63',
+  'Content-Length',
+  '497',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=cV8QLBx2TqmFZaFBOl886O5EB18AAAAAQUIPAAAAAADSxplyOmBrX7YZFwabEN4G; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=IPjUYtalR2yRQbTEquKDDnrWDV8AAAAAQUIPAAAAAABPdMlG+JQd7m2Ro+F9A94Z; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=agqvMZqCdVN22RGLYMlkBAAAAACcbUWz44lDNRX1h7lctuu3; path=/; Domain=.contentful.com',
+  'nlbi_673446=CJIwBUR5uRFNQJhqKsJtVwAAAAC3FDFQ2d+94tq6vwKhPhXJ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=GSUMaBla2BeDyVsGPWpmA+5EB18AAAAA7ssZNxIjWjKOto7WeZtCTQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ro3tXk1MIQN1zPlMOoVtA3rWDV8AAAAAB1Qa0kIsw9zPLip1RjxLLA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-42738298-42738301 NNNY CT(0 0 0) RT(1594311918191 20) q(0 0 0 -1) r(2 2) U5'
+  '14-26993562-26993574 NNNN CT(92 92 0) RT(1594742393737 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/editor_interface', {"controls":[{"fieldId":"aDifferentId"}]})
-  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-09T16:25:03.987Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-09T16:25:19.246Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-14T15:59:37.648Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-14T15:59:55.024Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -2913,9 +2913,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:19 GMT',
+  'Tue, 14 Jul 2020 15:59:55 GMT',
   'etag',
-  '"9617718487684677262"',
+  '"15999300434070215171"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2925,29 +2925,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '5242e79c38fd3480fd8ed077e46c2852',
+  'cd9a472c99d7a23a083beb45ae36454e',
   'Content-Length',
   '922',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=pKFnIyvpS7GGkmy42b6Ka+5EB18AAAAAQUIPAAAAAABtq56Pc6m8V9xUX/r7YhxV; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BpL5xxg8Sv6LoBV2Zlyz5nrWDV8AAAAAQUIPAAAAAADgevRrfHs8UeiJePYQq0vA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=fn0ncXJEpwL3DrOoYMlkBAAAAACexr30SOxtbT2IgMy9UFww; path=/; Domain=.contentful.com',
+  'nlbi_673446=M7n+GhRN0jnsD2gJKsJtVwAAAABM26uZzYYevZL6sVQurZor; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=bAxPLYr+fETnyVsGPWpmA+5EB18AAAAApVFm8djlnjsUJyfe9uLMtA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=4gD2NW2a+XEAzflMOoVtA3rWDV8AAAAAiWNwa5kTMtjXxsw2Wu61hg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26740384-26740386 NNNY CT(0 0 0) RT(1594311918524 29) q(0 0 0 -1) r(2 2) U5'
+  '13-20312908-20312918 NNNN CT(94 102 0) RT(1594742394334 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2963,8 +2963,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:19.576Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:55.496Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2973,8 +2973,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-09T16:25:18.902Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-14T15:59:54.396Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3039,261 +3039,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:19 GMT',
+  'Tue, 14 Jul 2020 15:59:55 GMT',
   'etag',
-  'W/"4301013271912430813"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '8',
-  'X-Contentful-Request-Id',
-  'e912e66a1016bc14dcc65b5b0cddeac9',
-  'Content-Length',
-  '495',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=AE5Sr80rSmmkbkPWVZWzye9EB18AAAAAQUIPAAAAAAAvLVQwG3w7NwcmEUYdBVF9; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=eB7nJpb25gRyUx1cYMlkBAAAAABvMEBD+E3dXiIzClHcAbpR; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=kJRSanvURzhgylsGPWpmA+9EB18AAAAAn6OtzsknSRMBsn4Or5K+eA==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '5-42738391-42738399 NNNY CT(0 0 0) RT(1594311918810 31) q(0 0 0 -1) r(2 2) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:20.044Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 11,
-    "publishedAt": "2020-07-09T16:25:20.044Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 6,
-    "version": 12,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "aDifferentId",
-      "name": "ID switching is fun!",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Thu, 09 Jul 2020 16:25:20 GMT',
-  'etag',
-  'W/"5070260442711112897"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '7',
-  'X-Contentful-Request-Id',
-  'b6e4c412d6ee047b49ad6f7a7fe1885a',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=B86wXjiESNCvOQO/wlQV9u9EB18AAAAAQUIPAAAAAACSo6My0TS3T0Ebwe4tfKqb; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=CFW3fd153UoOwvRyYMlkBAAAAAAuoj4hXEmh2kNR19inXB6m; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=wKr/cQ+KxDvnylsGPWpmA+9EB18AAAAAHf89ao/yIclpnac9CitW/w==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '4-26740463-26740467 NNNY CT(0 0 0) RT(1594311919312 33) q(0 0 0 -1) r(3 3) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:20.044Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 11,
-    "publishedAt": "2020-07-09T16:25:20.044Z",
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 6,
-    "version": 12,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "aDifferentId",
-      "name": "ID switching is fun!",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Thu, 09 Jul 2020 16:25:20 GMT',
-  'etag',
-  'W/"5070260442711112897"',
+  'W/"8017555108429248175"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3311,21 +3059,273 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'cdddf4d764a37b546cbfa31e6923b6f4',
+  '701abbe551cb748aa335ec02e2c23fb8',
   'Content-Length',
-  '490',
+  '493',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=bEmAZAQDSwe9mhzQ6G1qR+9EB18AAAAAQUIPAAAAAAAGZEpRD2L7B78aQzS3lkkR; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MgRhAcsyQxWxqnDOxFXWWXvWDV8AAAAAQUIPAAAAAADd0J5RfrGnObOZWIxSvdBA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=2fWLLnvvNFw9eUcpYMlkBAAAAACh0qHJ2kLwmmU3oKjG9cPy; path=/; Domain=.contentful.com',
+  'nlbi_673446=89lKGunVH3/9vKSCKsJtVwAAAAC8wLMmtpGE0VcTIXU95YRy; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=JdenOjWeOEFDy1sGPWpmA+9EB18AAAAAd3CzMI7CS6vAJHBuIHnang==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=LS3IGQbk62ZtzflMOoVtA3vWDV8AAAAA+y9PYCkY1PhA7g33DujqaQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86051568-86051573 NNNY CT(0 0 0) RT(1594311919722 43) q(0 0 0 -1) r(2 2) U5'
+  '6-4138283-4138288 NNNN CT(86 88 0) RT(1594742394805 29) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:56.033Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 11,
+    "publishedAt": "2020-07-14T15:59:56.033Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 6,
+    "version": 12,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "aDifferentId",
+      "name": "ID switching is fun!",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 15:59:56 GMT',
+  'etag',
+  'W/"3439410942897877923"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  'a4dae81709efd7f5aa6a741c6c58916b',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=EEIjoBdOTvWWkz7f9w2TGnvWDV8AAAAAQUIPAAAAAADNnpjY+CdyZa/h5LA4o76/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=jeriRwxUeB6Qrm1bKsJtVwAAAACEt01HsMwiCxoeS6K2cjHe; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=pdQaOFAZRBnxzflMOoVtA3vWDV8AAAAAsb1P8d4QHbj7lkZru9NOfQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '11-13772113-13772118 NNNN CT(92 92 0) RT(1594742395369 35) q(0 0 1 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:56.033Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 11,
+    "publishedAt": "2020-07-14T15:59:56.033Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 6,
+    "version": 12,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "aDifferentId",
+      "name": "ID switching is fun!",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 15:59:56 GMT',
+  'etag',
+  'W/"3439410942897877923"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '49b82039f6ad20656b651e8e84fbf6c1',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=IUFOpOcVTxWdPWt4uy08enzWDV8AAAAAQUIPAAAAAAC5TwgT2cHCOPZciXXy4uNg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=SXc5Dp+qjiWE3rSSKsJtVwAAAAD8gO0r/Gjuhh1aUK+Ivbin; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=06LmLfLFriNVzvlMOoVtA3zWDV8AAAAAGDV3RU8IWpVHVXbs3bhtOw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '14-26993985-26993999 NNNN CT(92 93 0) RT(1594742395985 34) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3350,8 +3350,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:03.323Z",
-        "updatedAt": "2020-07-09T16:25:20.044Z",
+        "createdAt": "2020-07-14T15:59:36.539Z",
+        "updatedAt": "2020-07-14T15:59:56.033Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -3360,8 +3360,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 11,
-        "publishedAt": "2020-07-09T16:25:20.044Z",
-        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+        "publishedAt": "2020-07-14T15:59:56.033Z",
+        "firstPublishedAt": "2020-07-14T15:59:37.439Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -3428,9 +3428,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:20 GMT',
+  'Tue, 14 Jul 2020 15:59:57 GMT',
   'etag',
-  'W/"13244042601259833950"',
+  'W/"8887087949937762504"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3440,29 +3440,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '2f4a11dbf49565db95b053208985f349',
+  '003fca335606a3442a12b33a769de32d',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=N/4IeJCPQuKde85zXo4/6PBEB18AAAAAQUIPAAAAAAAfbuIOjs2a9nvccuiwugLo; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=QhRs+4/sRZyf94zshQDrLX3WDV8AAAAAQUIPAAAAAADTbk79E8unF/qoFKyY+9s1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xWXBRYz/RTVK0BfuYMlkBAAAAACUiZaLfMWdnw9mk8mM1s5Y; path=/; Domain=.contentful.com',
+  'nlbi_673446=sp7dWrIEVTrLhWOQKsJtVwAAAACR6iZuekECsii71TSVQ6Gv; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=JulIec8lYwOBy1sGPWpmA/BEB18AAAAABlQe5CPkuuAKAAGXf480qQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=dCIQGCxh9hDtzvlMOoVtA33WDV8AAAAA+Jysg08/uR8qo5gqVb/5HA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-27374664-27374666 NNNY CT(0 0 0) RT(1594311920014 33) q(0 0 0 -1) r(2 2) U5'
+  '14-26994187-26994197 NNNN CT(89 89 0) RT(1594742396597 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3499,7 +3499,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:21 GMT',
+  'Tue, 14 Jul 2020 15:59:58 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -3511,23 +3511,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '2ca963d392b9bcfe43b3358cbad92647',
+  'fe026f330bf11ffc85d25817ea16edb8',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=slx9vRglTKWMqzJfaAD9FvBEB18AAAAAQUIPAAAAAABgUTvPdVnlJjE1tx8Tq3Ik; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=tDEUiu1aTca4umAn4cU6in7WDV8AAAAAQUIPAAAAAADMh0WrAaDwrzZruIJsOtN4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8A21eJR1fGzadpFkYMlkBAAAAABzsCYkODGh5BHs9BwewU+9; path=/; Domain=.contentful.com',
+  'nlbi_673446=+TvIadbkLzpbjWTRKsJtVwAAAAAiylykoapWoQ2iJblQfQJW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=v422CYe83hYezFsGPWpmA/BEB18AAAAAXYZ+YcPwm236mUVMpX9uOA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Y/+Cc/RJAnj+z/lMOoVtA37WDV8AAAAAUf1EyBlajdwHRDtcAgYbyw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3535,7 +3535,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86051720-86051726 NNYY CT(0 0 0) RT(1594311920336 28) q(0 0 0 -1) r(4 4) U5'
+  '3-6342343-6342346 NNYN CT(93 92 0) RT(1594742397999 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3576,15 +3576,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -3596,27 +3596,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:21 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 15:59:59 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -3629,23 +3629,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'af523484fa2085489163fdf0e2223ddd',
-  'X-Download-Options',
+  '58e984e0646233224b931f6459a33d5f',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ycN+D8OGSYCvQ2Y6bSVKPPBEB18AAAAAQUIPAAAAAAD4KP1DQsbbUEJPsXPH8LwP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AWTr5EwjTXW0mJousuQUR37WDV8AAAAAQUIPAAAAAABblnV8G8amFvwF81mot5w1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zbcTRBr1SVs1yk8ZYMlkBAAAAAACsnkfT6yZ/BnP7Bsxlp/7; path=/; Domain=.contentful.com',
+  'nlbi_673446=U5UVSNzcMDEYlgDqKsJtVwAAAAAgK93uPh+3/d2Xir5+RpxP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=jx3XQ2+vdBNwzFsGPWpmA/BEB18AAAAAGFeqF94I9k/VEfX2GSDpQw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=y3PzQOJSJy2G0PlMOoVtA37WDV8AAAAAsKnBpzD+M07K5j4z6yzu9g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3653,7 +3653,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66926019-66926027 NNYY CT(0 0 0) RT(1594311920834 26) q(0 0 0 -1) r(1 1) U5'
+  '14-26994692-26994698 NNYN CT(91 94 0) RT(1594742398665 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3669,8 +3669,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:03.323Z",
-    "updatedAt": "2020-07-09T16:25:21.756Z",
+    "createdAt": "2020-07-14T15:59:36.539Z",
+    "updatedAt": "2020-07-14T15:59:59.855Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3678,7 +3678,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "Environment"
       }
     },
-    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "firstPublishedAt": "2020-07-14T15:59:37.439Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3736,9 +3736,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:21 GMT',
+  'Tue, 14 Jul 2020 15:59:59 GMT',
   'etag',
-  'W/"3288684190985338390"',
+  'W/"66922666318594733"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3756,21 +3756,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '04ee4eec2ac25aac79569f1166675f94',
-  'transfer-encoding',
-  'chunked',
+  'b8cfd56f6b59904bb00fa656b80af780',
+  'Content-Length',
+  '464',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+8qi2VLhRQ2FMLCmhYdAQ/FEB18AAAAAQUIPAAAAAACHQCkRK2A42Xb+OFn2bfmH; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kr3ZSEDBT/+l2465hCEOGn/WDV8AAAAAQUIPAAAAAAAvS/Ew3URZMuF88X+sOXMa; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=02/tT8F1RFzeGTDYYMlkBAAAAABVT/r+78O9swQF5GkO1TvQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=pKKIB3S5tVXdYbR5KsJtVwAAAAB2oEtAiyuu1E+4GJVYdt/D; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=oYpHfbFsDmO/zFsGPWpmA/FEB18AAAAAf4b2k2gBO4hJEIDv4SyEmg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=QfpvEcnvnDQr0flMOoVtA3/WDV8AAAAAymuvfkaZIJLBWGWVJsiMUw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-27374762-27374764 NNNY CT(0 0 0) RT(1594311921034 28) q(0 0 0 -1) r(2 2) U5'
+  '13-20314000-20314008 NNNN CT(95 94 0) RT(1594742399157 35) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3797,7 +3797,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:22 GMT',
+  'Tue, 14 Jul 2020 16:00:00 GMT',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3815,19 +3815,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a16133d2d7acd857be6d55f38b65e886',
+  'a9ae1b2ceee0d7d1a9b9f3829f3eaadf',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=gLbEBVv/RBet5c14Tg/8zfFEB18AAAAAQUIPAAAAAADHhHtpmphOKfONQKTSI08L; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vfxlVFFER82m1tgwReV9P4DWDV8AAAAAQUIPAAAAAAAOvJezPnjkv4nrR0WE6s47; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NPKNV0VZo0B8F8wjYMlkBAAAAACUPQLY2oDNS5FBZWUGkmk5; path=/; Domain=.contentful.com',
+  'nlbi_673446=8mUIVLTGTiFS37KAKsJtVwAAAADddc5CLyaoPKyXomU00czQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=aaTpchY1nhsGzVsGPWpmA/FEB18AAAAAWov97nhFiTEHVJwhEpEqkw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=AcrNf+laxAvf0flMOoVtA4DWDV8AAAAAaolQU+F2PupOeXbi5KB9DQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26740639-26740644 NNNY CT(0 0 0) RT(1594311921364 30) q(0 0 0 -1) r(3 3) U5'
+  '10-8159648-8159651 NNNN CT(86 89 0) RT(1594742399883 28) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3844,7 +3844,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "2a6181a793aabadf90f800c454834744"
+  "requestId": "5a99d8971677027743d159b16ebe2dce"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -3868,9 +3868,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:22 GMT',
+  'Tue, 14 Jul 2020 16:00:01 GMT',
   'etag',
-  '"17118622069612008956"',
+  '"11653283982414078269"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3888,15 +3888,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '2a6181a793aabadf90f800c454834744',
+  '5a99d8971677027743d159b16ebe2dce',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=aJgaryYTSkmSxvTC7WV3kfFEB18AAAAAQUIPAAAAAAA3mQZa2WmDqLJpnYJ9/vV1; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Cp8otIDRQIK684BgrX3TCoHWDV8AAAAAQUIPAAAAAACcZoxveZOKIO6gE8HKSe3S; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=YBfKPKJKPVqZeQf/YMlkBAAAAABIt+DhZ1U/iNnUjHQvWp4i; path=/; Domain=.contentful.com',
+  'nlbi_673446=GpenVaAI109Cb3+QKsJtVwAAAABtkpG/t5Kg1WXWIbAjz+6r; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=yI20bsOgiU9MzVsGPWpmA/FEB18AAAAA6EOKDnCzQbiNEZkCE7/gtw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=20u2GNf7ETe/0vlMOoVtA4HWDV8AAAAA1QeyymRCgn4VSYIce2Mo+Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3904,7 +3904,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-55397095-55397101 NNYY CT(0 0 0) RT(1594311921680 34) q(0 0 0 -1) r(1 1) U5'
+  '14-26995266-26995275 NNYN CT(95 114 0) RT(1594742400355 32) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3941,7 +3941,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:22 GMT',
+  'Tue, 14 Jul 2020 16:00:02 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -3953,23 +3953,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '0dd9999f6f2ecb1da79380c25121c51e',
+  'becf84e251588beefdb8b326714ab917',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/LizykGpTLy+kMGTn3pFEfJEB18AAAAAQUIPAAAAAAC3JmD7fFtkYNRmOx2rY3LS; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=a2w6rRupTbK2RBq2YQIa74HWDV8AAAAAQUIPAAAAAACDfLNxLbfZA6D5iRjwXaeT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=0dS7DxTLkCXTOWaTYMlkBAAAAADw8eScdtrwVDgvvSXa8uLz; path=/; Domain=.contentful.com',
+  'nlbi_673446=l2ktGyBKITz8BNLRKsJtVwAAAABDzRw3aIFOg8rLhReyPPrV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=CH9DPfeZliP0zVsGPWpmA/JEB18AAAAAerxkJsvTRhzeMP4ltT3LfA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=T3TMFgLlwBF80/lMOoVtA4HWDV8AAAAAcjM1xWTQ3fl5jsAQgr95GQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3977,7 +3977,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '2-9265144-9265145 NNYN CT(93 93 0) RT(1594311922082 27) q(0 0 1 -1) r(3 3) U5'
+  '9-5257053-5257059 NNYN CT(89 98 0) RT(1594742401299 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4018,15 +4018,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -4038,27 +4038,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:23 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:02 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -4071,23 +4071,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'beeadb3e3299c7b866b262037a1f6de9',
-  'X-Download-Options',
+  '230767b423139ffe7ad6cd1b8c46ac33',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=DxUsaNSSRCioRbT5kKO1dPJEB18AAAAAQUIPAAAAAAA3x6sDvrHKG/fhy8pfAIb3; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kOObGLkIQK2AZ0adYZ8PYYLWDV8AAAAAQUIPAAAAAACtGNokjhvrJlI3KBx8+RZf; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ZDw3UG1c6zO2Bn/DYMlkBAAAAAAmf6ifzmezGzHMVmZPzX9X; path=/; Domain=.contentful.com',
+  'nlbi_673446=IA2aX1vV4gXzputJKsJtVwAAAABDV6X/y1jI8AcjnW1HWsFl; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=zqz0PI6uQzc+zlsGPWpmA/JEB18AAAAA0H/sKrizWP+bIgrLcf8N5Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=I3trKVwJT1GF1PlMOoVtA4LWDV8AAAAA7Xt54Wds0QO020oJ0luWOQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4095,12 +4095,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66926432-66926442 NNYY CT(0 0 0) RT(1594311922592 33) q(0 0 0 -1) r(1 1) U5'
+  '10-8159833-8159834 NNYN CT(96 191 0) RT(1594742401948 43) q(0 0 3 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dieatary-food', {"name":"Dieatary Food","fields":[{"id":"name","type":"Symbol","name":"name of the food","validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}]},{"id":"calories","type":"Link","linkType":"Asset","name":"amount of calories the food contains","validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}]}],"description":"Food with up to 500 calories"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-09T16:25:23.756Z","updatedAt":"2020-07-09T16:25:23.756Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-14T16:00:03.504Z","updatedAt":"2020-07-14T16:00:03.504Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4122,9 +4122,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:23 GMT',
+  'Tue, 14 Jul 2020 16:00:03 GMT',
   'etag',
-  '"10647023984675792264"',
+  '"15413338736341783902"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4134,29 +4134,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '050679a06c1fc0dfd9bb6154938bd66c',
+  '0b97b16ec3277d4f1a0fa048e6b0be2c',
   'Content-Length',
   '1783',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=OnOq0BlzRS6gx2YirtrE4vNEB18AAAAAQUIPAAAAAABV4f43XPOY4FSk8F9KJN64; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ADyB8FhITRyP8qmSwvP8/4PWDV8AAAAAQUIPAAAAAADhCIAlSsAJVLbDGmKArqRu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=52c7CXpIcBGFaJ6jYMlkBAAAAABtSzzbsfk58qUOS/QKEki/; path=/; Domain=.contentful.com',
+  'nlbi_673446=6o6XO6xNvGzC+UwMKsJtVwAAAAAYwuWwrdUdXVEU1yR8Q9P0; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=RpocaVlFZ1bazlsGPWpmA/NEB18AAAAAlMUpVmo+Hd+sCMBTlJjbXw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=j/qcJntJlW1z1flMOoVtA4PWDV8AAAAASKgtjZERqImYFDcGSL3V5g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66926489-66926499 NNNY CT(0 0 0) RT(1594311922898 25) q(0 0 0 -1) r(3 3) U5'
+  '8-2535089-2535091 NNNN CT(93 93 0) RT(1594742402528 34) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4172,8 +4172,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:23.756Z",
-    "updatedAt": "2020-07-09T16:25:24.097Z",
+    "createdAt": "2020-07-14T16:00:03.504Z",
+    "updatedAt": "2020-07-14T16:00:04.219Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4197,8 +4197,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:24.097Z",
-    "publishedAt": "2020-07-09T16:25:24.097Z",
+    "firstPublishedAt": "2020-07-14T16:00:04.219Z",
+    "publishedAt": "2020-07-14T16:00:04.219Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4282,9 +4282,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:24 GMT',
+  'Tue, 14 Jul 2020 16:00:04 GMT',
   'etag',
-  'W/"6050121518920068446"',
+  'W/"4656321227028868333"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4302,21 +4302,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '162bf50edf5d1525ff825088b8c6ef88',
+  'df68e3150365081b05877238f5c20d75',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=LD/SGZBuRNOLpWj2OKyeQ/NEB18AAAAAQUIPAAAAAAA+Upi8+SyWQVG0DBl9BMvE; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Ht6TNMdrQ7qyqjrYCAkViITWDV8AAAAAQUIPAAAAAAD9y1xEfB66m0dZS1GFMDWf; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qQnyJgerl3iSd+skYMlkBAAAAACiqC4BRzCnvCHxIRTIE7bQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=qrMcS+D7+DpGGsvYKsJtVwAAAAAWB4Azx+960RAb8F94un45; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=febQS740TjRLz1sGPWpmA/NEB18AAAAANJSJEFATLtH6gCNIY0lEfw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=oXkCcl5e2VU41vlMOoVtA4TWDV8AAAAAQ8ACF4F5ae8Jb3oblfl7xg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '2-9265189-9265191 NNNY CT(0 0 0) RT(1594311923366 32) q(0 0 0 -1) r(3 3) U5'
+  '14-26996189-26996199 NNNN CT(85 89 0) RT(1594742403567 37) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4332,8 +4332,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:23.756Z",
-    "updatedAt": "2020-07-09T16:25:24.097Z",
+    "createdAt": "2020-07-14T16:00:03.504Z",
+    "updatedAt": "2020-07-14T16:00:04.219Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4342,8 +4342,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:24.097Z",
-    "firstPublishedAt": "2020-07-09T16:25:24.097Z",
+    "publishedAt": "2020-07-14T16:00:04.219Z",
+    "firstPublishedAt": "2020-07-14T16:00:04.219Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -4442,9 +4442,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:24 GMT',
+  'Tue, 14 Jul 2020 16:00:04 GMT',
   'etag',
-  'W/"16242354007701607109"',
+  'W/"16093084401735594068"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4462,21 +4462,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'e8983262210c20de8700ca3118756ece',
+  '8012195717abd244f9a240d4d99f2596',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=5zh9HPEgRCqFt22WZoJPYPREB18AAAAAQUIPAAAAAADAuy+7N01jq3F5ps8j+OeH; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ivAfQPC+RjWrGHcZljI5BoTWDV8AAAAAQUIPAAAAAAB2q1DCiEl9GeHwoKQmgqno; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NrXvNnOwm1hFPir4YMlkBAAAAACk8SElkUTMm7dCa/kY2Lwg; path=/; Domain=.contentful.com',
+  'nlbi_673446=JQLxA2LikS+K8UUrKsJtVwAAAADJuMhH2dSYim0jBHwADrPH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=PHA1EfO5pSjqz1sGPWpmA/REB18AAAAA+osfDcFbm7zYvG/fZYQb5w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=D7BRIZix6XPM1vlMOoVtA4TWDV8AAAAA2CP3FRDuOIpkA+977hGeoQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41050466-41050475 NNNN CT(94 96 0) RT(1594311923814 37) q(0 0 2 -1) r(4 4) U5'
+  '5-13524477-13524480 NNNN CT(93 94 0) RT(1594742404175 29) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4513,7 +4513,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:25 GMT',
+  'Tue, 14 Jul 2020 16:00:05 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -4533,15 +4533,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd175043cd5b1b6c2565f7b1a36b11919',
+  'a563163d440e1209d748070a5b1e2e05',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ZO5p1mJ6SsmGLxxdqIk0wPREB18AAAAAQUIPAAAAAADEOxMj2kIlwlTllakOpJEP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=7WCgrfj5TuSYTq3biJ0KF4XWDV8AAAAAQUIPAAAAAACbJi28u9sFs2ESX6nLaWr8; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=EIJZN14TmV650HtDYMlkBAAAAABwWVJO1qnjQRxP6cVyyjTU; path=/; Domain=.contentful.com',
+  'nlbi_673446=XozpKkFt02BK3e/hKsJtVwAAAABk+eRDy0e2E3LiVVO8j1KJ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=ifJpWQ+hSWlp0FsGPWpmA/REB18AAAAA/O3yal1gwo4CQx9Gbv2mzQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=hBeMCy4AzTyT1/lMOoVtA4XWDV8AAAAATsdnMh2+V7bVFf+v/N3DZA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4549,7 +4549,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86052949-86052962 NNYY CT(0 0 0) RT(1594311924432 34) q(0 0 0 -1) r(2 2) U5'
+  '14-26996563-26996576 NNYN CT(94 95 0) RT(1594742404777 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4590,15 +4590,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -4610,27 +4610,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:25 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:05 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -4643,23 +4643,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '0d1480069f5d018878a72e9bfe47074a',
-  'X-Download-Options',
+  '8d8b1facc92aae56f5907e0d2eb6a6c3',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3kBu7MDjRoS0LKaTnglE1fREB18AAAAAQUIPAAAAAADvc4uOy55B70kclzy5rsIT; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kL7/myIoQl+ryqlCr9R3YoXWDV8AAAAAQUIPAAAAAABHlYFqUrmp8Ihc8PZ+Nkyn; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GXeSJMiwfU5baWX0YMlkBAAAAAAvV0SfGXnIpluZST3BOyx3; path=/; Domain=.contentful.com',
+  'nlbi_673446=N8rXDewtdH+7Ysf1KsJtVwAAAAAUnMbDvRMdn8hAVAq2DpMI; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=WM2Uf5nrdB+q0FsGPWpmA/REB18AAAAAqmjOKfqdNWItzoVN+tx57Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=vdDndbIhhRHv1/lMOoVtA4XWDV8AAAAAwzjL8gKzCtQNZujA1vCFRQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4667,12 +4667,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-55397707-55397720 NNYY CT(0 0 0) RT(1594311924738 25) q(0 0 0 -1) r(1 1) U5'
+  '9-5257277-5257278 NNYN CT(93 94 0) RT(1594742405255 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food', {"name":"foooood","displayField":"taste","fields":[{"id":"taste","type":"Symbol","name":"what it tastes like"}],"description":" well, food"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-09T16:25:25.909Z","updatedAt":"2020-07-09T16:25:25.909Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-14T16:00:06.759Z","updatedAt":"2020-07-14T16:00:06.759Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4694,9 +4694,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:25 GMT',
+  'Tue, 14 Jul 2020 16:00:07 GMT',
   'etag',
-  '"13935677294334095123"',
+  '"15268465080734638946"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4706,29 +4706,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '83aba324d2f63a1299d989fa0c3ef148',
+  '30ef18e9d880dd5b959bd6ae8d50f749',
   'Content-Length',
   '1064',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=xbC0kjQ2QY277iyBU+pMSfVEB18AAAAAQUIPAAAAAAClUjWpDGiTS5yn8UIO2yC0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=JKPWlgyVSsu8ZEuqlL1Ki4bWDV8AAAAAQUIPAAAAAACpXBeLRhM9Adt9D8CvMKCe; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=owIceMsJGCXV4eWaYMlkBAAAAACqyK9KwB9nZbdPh0nD3zmA; path=/; Domain=.contentful.com',
+  'nlbi_673446=WPfqTgIe3luQwUbAKsJtVwAAAACNx3bD5vax9JW5Y+TqXoD2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=C+A7e3U3AQI70VsGPWpmA/VEB18AAAAAniaQzWw3tsd8EgA/nI/QQQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=VA+obCIayiwD2flMOoVtA4bWDV8AAAAAWOQ20itC2nwJ9ABbBkb6Mg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41050691-41050695 NNNY CT(0 0 0) RT(1594311925050 28) q(0 0 0 -1) r(4 4) U5'
+  '10-8160343-8160345 NNNN CT(100 101 0) RT(1594742405817 36) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4744,8 +4744,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:25.909Z",
-    "updatedAt": "2020-07-09T16:25:26.577Z",
+    "createdAt": "2020-07-14T16:00:06.759Z",
+    "updatedAt": "2020-07-14T16:00:07.633Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4769,8 +4769,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
-    "publishedAt": "2020-07-09T16:25:26.577Z",
+    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
+    "publishedAt": "2020-07-14T16:00:07.633Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4820,9 +4820,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:26 GMT',
+  'Tue, 14 Jul 2020 16:00:07 GMT',
   'etag',
-  'W/"14647378867660032396"',
+  'W/"16233065968810141319"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4840,21 +4840,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e4f485951098e70057ce049e97d53e18',
-  'transfer-encoding',
-  'chunked',
+  'fd3730b89ee7485dfc4df3f6f86c1788',
+  'Content-Length',
+  '447',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=u9ZLGwJLTWGbJARwOI9ge/ZEB18AAAAAQUIPAAAAAABSK6ENEASYCETn2/g9l6ES; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=06xmQA4FRLSjHjYk0LhA1YfWDV8AAAAAQUIPAAAAAABiS7r7st3EQ0SWX4oMhwFl; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=MrQEVdpj4hpC6+vrYMlkBAAAAABwTtqmt/c0jgt6PVwbidMZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=aETrZGv9GSt9GcPrKsJtVwAAAAAHP7woNzqxTxlyZCNzNKSC; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=tSyndTJ1AG7d0VsGPWpmA/ZEB18AAAAA7tGJslD0A381M6mCXaizUg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=LybBUEUbT0Ip2vlMOoVtA4fWDV8AAAAArQjoHkjS5og/fJI2ib6eMw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86053253-86053268 NNNN CT(86 87 0) RT(1594311925672 40) q(0 0 1 -1) r(4 4) U5'
+  '7-7156655-7156659 NNNN CT(93 94 0) RT(1594742406825 27) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4879,8 +4879,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "food",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:25.909Z",
-        "updatedAt": "2020-07-09T16:25:26.577Z",
+        "createdAt": "2020-07-14T16:00:06.759Z",
+        "updatedAt": "2020-07-14T16:00:07.633Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -4889,8 +4889,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-09T16:25:26.577Z",
-        "firstPublishedAt": "2020-07-09T16:25:26.577Z",
+        "publishedAt": "2020-07-14T16:00:07.633Z",
+        "firstPublishedAt": "2020-07-14T16:00:07.633Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -4957,9 +4957,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:27 GMT',
+  'Tue, 14 Jul 2020 16:00:08 GMT',
   'etag',
-  'W/"17090761978903646731"',
+  'W/"7080602346270485044"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4969,29 +4969,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '74f18f1479b1907210e5022ef699906e',
+  '96e4d0ba759ca5ea968d45207cafa9f8',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=KB5MAszLTZqtj2LvVmr25PZEB18AAAAAQUIPAAAAAABobhNDz9Fm40sIMoIYFoYQ; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=1dxme0LlQwOdzFjnTX4RaIjWDV8AAAAAQUIPAAAAAAACRjHDtnM8W7HNtgm+sG+7; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=BcbJN0dPTypr7SefYMlkBAAAAAC6MlEDNm/FoCQ3QqWrOUOU; path=/; Domain=.contentful.com',
+  'nlbi_673446=Wi7/MFFTmUUOv8PGKsJtVwAAAAAtXXvGZ2SddrCe7XlFBQLE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=UcGcBt+fxzdz0lsGPWpmA/ZEB18AAAAAB6I7KQU4Kgwg93sekKQH6A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=NwwXNgILCWXT2vlMOoVtA4jWDV8AAAAAWm+MfFz0unPSOb2IJS/wsA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-20701113-20701118 NNNY CT(0 0 0) RT(1594311926280 30) q(0 0 0 -1) r(4 4) U5'
+  '5-13525235-13525239 NNNN CT(87 87 0) RT(1594742407657 28) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5032,15 +5032,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -5052,56 +5052,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:27 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:08 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '5586d8ddbf4ca71ba78131398b8fb478',
-  'X-Download-Options',
+  '2e5c3d430b56c87773777ab44bcd2e6e',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=XxQCkhM+RXKoy32CribtBvdEB18AAAAAQUIPAAAAAACoAqM9BvE5SrxMvisdwe2I; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=a3sUPWjtQyexnkRrTiMBrojWDV8AAAAAQUIPAAAAAAAuOK/0FOOSuy3N7IRCYK+t; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=OSfMDe65wTGddrLcYMlkBAAAAAD2DnngUgjTnMw5LWbSbgYV; path=/; Domain=.contentful.com',
+  'nlbi_673446=u/LuHsFLLy0iVFiIKsJtVwAAAACI84jHJdhUQMFgTVMfL2Uq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=ZfthH+zQ7ke00lsGPWpmA/dEB18AAAAApcvgjt+shwHgc/Rh7MDifg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0HZCT6Gx3HRp2/lMOoVtA4jWDV8AAAAAPcj3yxYnkcd3WMpWTjbmVg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5109,7 +5109,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-26741145-26741148 NNYY CT(0 0 0) RT(1594311926892 33) q(0 0 0 -1) r(1 1) U5'
+  '6-4139267-4139269 NNYN CT(94 94 0) RT(1594742408293 34) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5125,8 +5125,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:25.909Z",
-    "updatedAt": "2020-07-09T16:25:27.862Z",
+    "createdAt": "2020-07-14T16:00:06.759Z",
+    "updatedAt": "2020-07-14T16:00:09.600Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5135,8 +5135,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:26.577Z",
-    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
+    "publishedAt": "2020-07-14T16:00:07.633Z",
+    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5251,185 +5251,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:27 GMT',
+  'Tue, 14 Jul 2020 16:00:09 GMT',
   'etag',
-  'W/"15616522819024614663"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '8',
-  'X-Contentful-Request-Id',
-  'f4481a88a61373a776cad9cf61bbf952',
-  'Content-Length',
-  '591',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=K9rizgzSQpOl7Q0rvmf8SPdEB18AAAAAQUIPAAAAAABar2V4MIbb3cxRVz73gWV3; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=B4UkJRTtiCDj3vkuYMlkBAAAAAAsPnZy558m2lD0vrz9XVta; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=PPtzOf9vEBcE01sGPWpmA/dEB18AAAAAb1F/scsbczKuzdri9AcKYQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '11-41050979-41050986 NNNY CT(0 0 0) RT(1594311927096 37) q(0 0 0 -1) r(2 2) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "food",
-    "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:25.909Z",
-    "updatedAt": "2020-07-09T16:25:28.232Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:28.232Z",
-    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 2,
-    "version": 4,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": "taste",
-  "name": "foooood",
-  "description": " well, food",
-  "fields": [
-    {
-      "id": "calories",
-      "name": "How many calories does it have?",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "taste",
-      "name": "what it tastes like",
-      "type": "Symbol",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "producer",
-      "name": "Food producer",
-      "type": "Symbol",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "vegan",
-      "name": "Vegan friendly",
-      "type": "Boolean",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "gmo",
-      "name": "Genetically modified food",
-      "type": "Boolean",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "sugar",
-      "name": "Amount of sugar",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Thu, 09 Jul 2020 16:25:28 GMT',
-  'etag',
-  'W/"6623412258601009463"',
+  'W/"9911136001177961075"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5447,25 +5271,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bfee7c632b5b84aced32201626b94d3f',
-  'transfer-encoding',
-  'chunked',
+  '38d6b0fd12646a626f3fc42bd442a7c7',
+  'Content-Length',
+  '592',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=oJOqHdJaT5SwfOlVQkvjlPdEB18AAAAAQUIPAAAAAAC8lMBqlcGn1PvayOEVox58; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=LXPHq1caQ3iSPvK70XZAhonWDV8AAAAAQUIPAAAAAADBSphDazpGxai2EKUVmGYc; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CtTzBFZ3XCaCesqdYMlkBAAAAACrjnkl0FEoT1ngOETtjNED; path=/; Domain=.contentful.com',
+  'nlbi_673446=PSAhE4IgQF9AqkRRKsJtVwAAAADtlaVVUxF2o3VUr0MmfoSv; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=kQhGSYvRSmtk01sGPWpmA/dEB18AAAAA8kE7s3loWoH6ci71rmffZg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=i+nHUfGZnFMU3PlMOoVtA4nWDV8AAAAA2eSlWFksXrSire7aorQEtg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86053824-86053845 NNNY CT(0 0 0) RT(1594311927508 29) q(0 0 0 -1) r(2 2) U5'
+  '2-3148398-3148400 NNNN CT(91 92 0) RT(1594742408883 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/food')
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food/published')
   .reply(200, {
   "sys": {
     "space": {
@@ -5477,8 +5301,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:25.909Z",
-    "updatedAt": "2020-07-09T16:25:28.232Z",
+    "createdAt": "2020-07-14T16:00:06.759Z",
+    "updatedAt": "2020-07-14T16:00:10.150Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5487,8 +5311,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:28.232Z",
-    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
+    "publishedAt": "2020-07-14T16:00:10.150Z",
+    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5603,9 +5427,185 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:28 GMT',
+  'Tue, 14 Jul 2020 16:00:10 GMT',
   'etag',
-  'W/"6623412258601009463"',
+  'W/"12096556430046982097"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'e9beb2f7392adb01e33090e566807fc8',
+  'Content-Length',
+  '598',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=497Aur0kT2SLI7+BRKu4i4nWDV8AAAAAQUIPAAAAAADPOD/QeXUtCSzuSSRRFWLL; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=t3acSRz55xnPeXGeKsJtVwAAAAA+GQZBVoc3JsaeAOkZMHTo; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=Ho2MXUq51TGm3PlMOoVtA4nWDV8AAAAAK03vMW6e+xIuBeVDgxGyxQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '13-20316599-20316603 NNNN CT(87 90 0) RT(1594742409499 32) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/food')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "food",
+    "type": "ContentType",
+    "createdAt": "2020-07-14T16:00:06.759Z",
+    "updatedAt": "2020-07-14T16:00:10.150Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 3,
+    "publishedAt": "2020-07-14T16:00:10.150Z",
+    "firstPublishedAt": "2020-07-14T16:00:07.633Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 2,
+    "version": 4,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": "taste",
+  "name": "foooood",
+  "description": " well, food",
+  "fields": [
+    {
+      "id": "calories",
+      "name": "How many calories does it have?",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "taste",
+      "name": "what it tastes like",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "producer",
+      "name": "Food producer",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "vegan",
+      "name": "Vegan friendly",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "gmo",
+      "name": "Genetically modified food",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "sugar",
+      "name": "Amount of sugar",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 16:00:10 GMT',
+  'etag',
+  'W/"12096556430046982097"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5623,21 +5623,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'bf7432123a653941ce0b0375bacb04d7',
+  'd5ccddd28526754a9ca5207ddbbd87a1',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=pYjES1WATJarQiKkv9FCmPhEB18AAAAAQUIPAAAAAABHLQUQ4ekeq4z4rBkPIMB/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WIqLlSzwTIeYLyrtkzxqEYrWDV8AAAAAQUIPAAAAAABax6W89IulkYAqvvIlbwRw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=rQIlO3+ru0mSx9DKYMlkBAAAAABBJVl+hbet4zhC/qGiRfJB; path=/; Domain=.contentful.com',
+  'nlbi_673446=zMeWeTXBNypk2eXNKsJtVwAAAAA1YKEXRqQT8g3UJ+LNZbpL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=v92XaTSLVR2401sGPWpmA/hEB18AAAAAOULFLYmEqh6y7u9vR4PV/Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=hlBkW/JGGwwa3flMOoVtA4rWDV8AAAAAzJNEiDzNU0POE8jfYgJiWw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55398425-55398435 NNNY CT(0 0 0) RT(1594311927908 34) q(0 0 0 -1) r(2 2) U5'
+  '12-17400737-17400746 NNNN CT(86 87 0) RT(1594742410119 29) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5674,7 +5674,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:28 GMT',
+  'Tue, 14 Jul 2020 16:00:11 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -5686,23 +5686,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '25785b6c75e555705b9f39fde3e31156',
+  'f1605e9f522a2546c91b245389e4e5a9',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/P2jHGDnRl6cchqVT/e/0fhEB18AAAAAQUIPAAAAAADa5xQQ8uaH+5gvDlpyLN1J; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3/tEWI+eR7iIqaSdkJe42YrWDV8AAAAAQUIPAAAAAAAfPLh7Rc0ef26m0IF84rx7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=+1T+XLnSYxCwrPOaYMlkBAAAAAAEfiiCfR0CgDO8GaImXIDe; path=/; Domain=.contentful.com',
+  'nlbi_673446=lRj7N2P7WAlXZTatKsJtVwAAAADB+X1vzVCfumlcfYwTHCVW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=vc+eCAkVlwMi1FsGPWpmA/hEB18AAAAAXhN3p6bWTwKbEfW+OTM6lQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=p1eMc07YpjiI3flMOoVtA4rWDV8AAAAAQdaZbqraYsYtrdbmZbuniA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5710,7 +5710,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-20701189-20701192 NNYY CT(0 0 0) RT(1594311928234 28) q(0 0 0 -1) r(2 2) U5'
+  '10-8160816-8160824 NNYN CT(86 86 0) RT(1594742410556 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5751,15 +5751,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -5771,56 +5771,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:29 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:12 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'eb108f0095ddbf3236997dafd8123d74',
-  'X-Download-Options',
+  '76f3c68a18346ad72cd1752273ab6ade',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=HeqisWPBSFeue8/NBQfqpvhEB18AAAAAQUIPAAAAAAA4uvB/TRs3xVuiHBHCekOO; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=HPt8k8MeTbG8EFD/C1edWozWDV8AAAAAQUIPAAAAAACC2MJe+hRCyFv/iXiWwWWv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Y9jEbrpU92xrGqDQYMlkBAAAAABJ8pDqOQzPRUq0fSck+xck; path=/; Domain=.contentful.com',
+  'nlbi_673446=4LIMS21oXWk7lTs+KsJtVwAAAAB4csAv/cy3MrVpS6hSVR/4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=57nrV4Kdk1qN1FsGPWpmA/hEB18AAAAAFvY4u1KmROcQ/dGX8P5auA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=AtebUKSRyFaH3vlMOoVtA4zWDV8AAAAAq5HfNUgbGZAo1h4cMkLVPA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5828,12 +5828,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-55398572-55398578 NNYN CT(88 86 0) RT(1594311928524 24) q(0 0 2 -1) r(3 3) U5'
+  '12-17400958-17400971 NNYN CT(93 94 0) RT(1594742411129 35) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/person', {"name":"Person","fields":[{"id":"age","name":"Age","type":"Number","required":true},{"id":"fullName","name":"Full name","type":"Symbol","required":true,"localized":true}],"description":"A content type for a person"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-09T16:25:29.850Z","updatedAt":"2020-07-09T16:25:29.850Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-14T16:00:12.848Z","updatedAt":"2020-07-14T16:00:12.848Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -5855,9 +5855,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:29 GMT',
+  'Tue, 14 Jul 2020 16:00:12 GMT',
   'etag',
-  '"7332829308841050924"',
+  '"16330242251810075220"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5867,29 +5867,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '8a4f6b4e701926ba6362f88b8c15af5c',
+  '707cf28120102d166b5fb7633bf265c6',
   'Content-Length',
   '1269',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=5qLbnO6xR5mo+VEghqF1pflEB18AAAAAQUIPAAAAAABbc1n5fDRuVsb4etL9N4ih; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=xcMrXgt8Rz6FUQN/chubs4zWDV8AAAAAQUIPAAAAAABj+k4ow0Q38XG09/yIRpxD; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=DJQ/e8u8S3KJNpGpYMlkBAAAAAAYTHqx6YvqjoEmuhSHhGQ2; path=/; Domain=.contentful.com',
+  'nlbi_673446=UgpJYo+sZzxM+MbsKsJtVwAAAACKPbCoeVjk6jWn3fto0Gjq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=iEzoYrQetHsy1VsGPWpmA/lEB18AAAAAV7+T2ZDcsCdDhryg16mjKQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=uQA8YASQIw463/lMOoVtA4zWDV8AAAAAkIeGWsgs5nApWRDnYWeJvA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-13874925-13874928 NNNN CT(93 94 0) RT(1594311928898 26) q(0 0 2 -1) r(4 4) U5'
+  '14-26998752-26998757 NNNN CT(89 89 0) RT(1594742412175 26) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5905,8 +5905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:29.850Z",
-    "updatedAt": "2020-07-09T16:25:30.290Z",
+    "createdAt": "2020-07-14T16:00:12.848Z",
+    "updatedAt": "2020-07-14T16:00:13.465Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5930,8 +5930,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
-    "publishedAt": "2020-07-09T16:25:30.290Z",
+    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
+    "publishedAt": "2020-07-14T16:00:13.465Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -5991,9 +5991,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:30 GMT',
+  'Tue, 14 Jul 2020 16:00:13 GMT',
   'etag',
-  'W/"15637892669674338975"',
+  'W/"14016083358203130093"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6011,26 +6011,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '7de7ee70bafb8eabf92a694078288fd3',
+  '90268f4e860104b16199403a8e06799f',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/2Hnx/jbSJaq7FhZ7SmcSflEB18AAAAAQUIPAAAAAABulahYgDrDO3JKkWv7SoZQ; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ns2KsNr/R6Wi9K6TGaK0W43WDV8AAAAAQUIPAAAAAADmoVzykeeOxcgSPDUt97y5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8XRyHLucnmp0voskYMlkBAAAAACfmzIzV9tt3jqOM12BJWa3; path=/; Domain=.contentful.com',
+  'nlbi_673446=Z3ACWAONkFHdn8kuKsJtVwAAAACBzbC7rDdshXN3T8rdziea; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=P661bCkvNwWR1VsGPWpmA/lEB18AAAAAJyYbme2YqHDp3Jo0kNOqNQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=yFo3NlT9ymL13/lMOoVtA43WDV8AAAAA6spzvyi+iCwX9IDwe+0PrQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86054470-86054485 NNNY CT(0 0 0) RT(1594311929562 33) q(0 0 0 -1) r(3 3) U5'
+  '14-26998913-26998924 NNNN CT(93 94 0) RT(1594742412771 31) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/animal', {"name":"Animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","required":true},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","required":false}],"description":"An animal"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-09T16:25:30.832Z","updatedAt":"2020-07-09T16:25:30.832Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-14T16:00:14.117Z","updatedAt":"2020-07-14T16:00:14.117Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -6052,9 +6052,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:30 GMT',
+  'Tue, 14 Jul 2020 16:00:14 GMT',
   'etag',
-  '"17989775881492960242"',
+  '"14484180835877969120"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6072,21 +6072,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '3f5415468a108e2c50761abfc6cb5bf1',
+  '50f3e549b4854cc05a6800508180a741',
   'Content-Length',
   '1292',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=0Db7T4DPRpqDYoxB07y/5fpEB18AAAAAQUIPAAAAAAAOawt6z5br+DBHEyODm8KK; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kg74E1ARROOp5VIim20Oo43WDV8AAAAAQUIPAAAAAADLBnizTyimLap9PCPmUwdz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=DkH4UggDADUB1/QSYMlkBAAAAAD9Wx8FUFUfvZO1Jh1vSACB; path=/; Domain=.contentful.com',
+  'nlbi_673446=KlWQRrtYNzG8Sx9sKsJtVwAAAACoGFsFV3Vq4xNFz8qnApi9; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=rD6gZTEzeE4N1lsGPWpmA/pEB18AAAAA19gD9jgCElmOuMtAaFYmtQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=yRhgQAMBZk7I4PlMOoVtA43WDV8AAAAAw3n31VGGUyNvgSScrj2wwg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86054602-86054604 NNNY CT(0 0 0) RT(1594311929958 26) q(0 0 0 -1) r(4 4) U5'
+  '12-17401368-17401373 NNNN CT(86 88 0) RT(1594742413395 34) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6102,8 +6102,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:30.832Z",
-    "updatedAt": "2020-07-09T16:25:31.293Z",
+    "createdAt": "2020-07-14T16:00:14.117Z",
+    "updatedAt": "2020-07-14T16:00:14.874Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6127,8 +6127,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
-    "publishedAt": "2020-07-09T16:25:31.293Z",
+    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
+    "publishedAt": "2020-07-14T16:00:14.874Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -6188,9 +6188,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:31 GMT',
+  'Tue, 14 Jul 2020 16:00:14 GMT',
   'etag',
-  'W/"12219047309239319921"',
+  'W/"12875455613032629404"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6208,21 +6208,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd61f2b32ac0df6cc9545fa79602aa08c',
-  'transfer-encoding',
-  'chunked',
+  '2abdc21340d407c8243487cab8489834',
+  'Content-Length',
+  '484',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=j7U11CcuQZ6kj0VYAdrkG/pEB18AAAAAQUIPAAAAAACcLqZ2b9IGJsKD4HGq2NQI; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=TgH49ixFRUqH4JZQy1gnLY7WDV8AAAAAQUIPAAAAAADXCaENFQXeiEQbI/incNW8; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=KAQIV3522THR3yEXYMlkBAAAAACMR0kf6FLu94iYjXxIi3ai; path=/; Domain=.contentful.com',
+  'nlbi_673446=kfrUclZMFkp4OMnxKsJtVwAAAAAeEDHIvRMgOsQUD1i7yha/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=3KvOTwHxTQSW1lsGPWpmA/pEB18AAAAAJbYzWKwrGEp8sRLQK9jeig==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=5r23HhlUMgwz4vlMOoVtA47WDV8AAAAAwk9G8ChJJJSoh5gco4iahg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-21640961-21640966 NNNY CT(0 0 0) RT(1594311930569 26) q(0 0 0 -1) r(3 3) U5'
+  '11-13775311-13775316 NNNN CT(87 87 0) RT(1594742414212 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6238,8 +6238,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:29.850Z",
-    "updatedAt": "2020-07-09T16:25:32.040Z",
+    "createdAt": "2020-07-14T16:00:12.848Z",
+    "updatedAt": "2020-07-14T16:00:15.536Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6248,8 +6248,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:30.290Z",
-    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
+    "publishedAt": "2020-07-14T16:00:13.465Z",
+    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6335,9 +6335,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:32 GMT',
+  'Tue, 14 Jul 2020 16:00:15 GMT',
   'etag',
-  'W/"11088506612956257108"',
+  'W/"10179108162775744838"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6347,29 +6347,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'ddbf87d4d1e38274494031d20658d6af',
+  '16465dc163700b20f806e5b33655ce25',
   'Content-Length',
   '519',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=C4sG0MKTQB2+0rxwlW5GJ/tEB18AAAAAQUIPAAAAAACO3Wp+KSWpXC7JYYMD6EdS; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=b8gchYpfSmKy3gW34rzV84/WDV8AAAAAQUIPAAAAAABGmg4Xcwl4WNIYoWvE3XJG; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XNrXZVsiIRBBCbXSYMlkBAAAAACSkMJUJrXZGr6B4Vph9YTg; path=/; Domain=.contentful.com',
+  'nlbi_673446=Sjt0ZLd1J0mqzYfPKsJtVwAAAADCHqhNqadw97Cut32sW7ss; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=TQQ7JylAIRdJ11sGPWpmA/tEB18AAAAAcj+Z3IJSJjAgB55utuJrJQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=dGMeJ9GN6R7+4vlMOoVtA4/WDV8AAAAAkhC4iPPwgxntlGEW1KEviw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27144207-27144209 NNNN CT(93 93 0) RT(1594311930988 35) q(0 0 2 -1) r(5 5) U5'
+  '12-17401776-17401784 NNNN CT(86 88 0) RT(1594742414823 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6385,8 +6385,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:29.850Z",
-    "updatedAt": "2020-07-09T16:25:32.618Z",
+    "createdAt": "2020-07-14T16:00:12.848Z",
+    "updatedAt": "2020-07-14T16:00:16.138Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6395,8 +6395,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:32.618Z",
-    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
+    "publishedAt": "2020-07-14T16:00:16.138Z",
+    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6482,9 +6482,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:32 GMT',
+  'Tue, 14 Jul 2020 16:00:16 GMT',
   'etag',
-  'W/"12367945497557339651"',
+  'W/"7048743671037706340"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6502,21 +6502,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'c0e8ad337a47427234e90a35f874b279',
+  '812345aae0553a6336c09b99727ac57a',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YiEexcoyTHyBdKnDqPad6fxEB18AAAAAQUIPAAAAAADEvUfAbbewvKjIf+bvQlub; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=u/O1/pm+Sz6ZaGnlc8cM/o/WDV8AAAAAQUIPAAAAAADwj4TbtmKJo2ubm/Hc8dDa; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=W//wcsR8lUxHs00xYMlkBAAAAABrp8Bu/88IQ2v2fGGMddiE; path=/; Domain=.contentful.com',
+  'nlbi_673446=3FlwRBOFYQeFNKR0KsJtVwAAAAClRVqElxvmxJ4CVXlLQ+AV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=R5+yKlXMRU/311sGPWpmA/xEB18AAAAA3y3Q0NMvQ5n3BG+z/EEJsQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3wXNR8dSjUZW5PlMOoVtA4/WDV8AAAAAUndMH/ImwCSgcU3QyxoRPA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66928488-66928497 NNNY CT(0 0 0) RT(1594311931800 31) q(0 0 0 -1) r(3 3) U5'
+  '11-13775587-13775595 NNNN CT(100 98 0) RT(1594742415437 47) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6532,8 +6532,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:30.832Z",
-    "updatedAt": "2020-07-09T16:25:32.963Z",
+    "createdAt": "2020-07-14T16:00:14.117Z",
+    "updatedAt": "2020-07-14T16:00:16.856Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6542,8 +6542,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:31.293Z",
-    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
+    "publishedAt": "2020-07-14T16:00:14.874Z",
+    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6628,9 +6628,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:32 GMT',
+  'Tue, 14 Jul 2020 16:00:16 GMT',
   'etag',
-  'W/"15361261824487259246"',
+  'W/"4762994068728274015"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6648,21 +6648,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'f70c34c7afc6dca731bcb034b49f2a6c',
+  'ea7a26c65fa4151ee7f04bfa09dd5b35',
   'Content-Length',
-  '511',
+  '510',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Z/mRMZt0TlmsLU1kSoUUgPxEB18AAAAAQUIPAAAAAAAtzQACLC5Tlz7C/udB5NfX; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=46vK9mjhR7GSshgBeX3gIpDWDV8AAAAAQUIPAAAAAADgUf49qaZicPKQcSxYJ72d; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=9LBYNi/Psn3Qq6KJYMlkBAAAAAAzZYDLedx5wSiB4NQW1tyi; path=/; Domain=.contentful.com',
+  'nlbi_673446=S7S8LvHztA4xkxjsKsJtVwAAAADcy5x/tuN2uFAV16rPAyKE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=imp/UJsUNkJb2FsGPWpmA/xEB18AAAAArJbbdxxNxfY3emorOY3xsA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=6k/LJg3fAzXq5PlMOoVtA5DWDV8AAAAAdKJKVXnnYIwAVMAjL20KCw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-13875047-13875051 NNNY CT(0 0 0) RT(1594311932224 28) q(0 0 0 -1) r(2 2) U5'
+  '5-13526433-13526437 NNNN CT(92 92 0) RT(1594742416139 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6678,8 +6678,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:30.832Z",
-    "updatedAt": "2020-07-09T16:25:33.352Z",
+    "createdAt": "2020-07-14T16:00:14.117Z",
+    "updatedAt": "2020-07-14T16:00:17.562Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6688,8 +6688,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:33.352Z",
-    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
+    "publishedAt": "2020-07-14T16:00:17.562Z",
+    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6774,9 +6774,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:33 GMT',
+  'Tue, 14 Jul 2020 16:00:17 GMT',
   'etag',
-  'W/"3405819313589139461"',
+  'W/"14583803251784325129"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6794,21 +6794,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '984b8ccf22ce2431ad229b557d307c8f',
-  'transfer-encoding',
-  'chunked',
+  '912142cc064cd46080e078a78c4e1507',
+  'Content-Length',
+  '516',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4s5/2s0cSl6BiSD6Lq9jyPxEB18AAAAAQUIPAAAAAACTHqTuukUrMz91ibf69a9/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AdHiHH0rTcOeaZA7j18HUJHWDV8AAAAAQUIPAAAAAAC+8rgieflXfyFd8x6xXbuo; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ieLTUE3Vky0TF3kFYMlkBAAAAACgJ1cUBP4ZwsvKE4pAM16I; path=/; Domain=.contentful.com',
+  'nlbi_673446=hxuVGngSnXfHLcbpKsJtVwAAAADLkzlZZoPJaxAu3sezZLda; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=sk3HbGRD0CTQ2FsGPWpmA/xEB18AAAAAcTzp/qkG5tAnyjmdDFg9jg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ejTILsyxy0V25flMOoVtA5HWDV8AAAAAY5TXX/oA1En2DxfZVlUepg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86055310-86055322 NNNY CT(0 0 0) RT(1594311932630 31) q(0 0 0 -1) r(3 3) U5'
+  '14-27000130-27000142 NNNN CT(92 93 0) RT(1594742416872 33) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6824,8 +6824,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:29.850Z",
-    "updatedAt": "2020-07-09T16:25:32.618Z",
+    "createdAt": "2020-07-14T16:00:12.848Z",
+    "updatedAt": "2020-07-14T16:00:16.138Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6834,8 +6834,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:32.618Z",
-    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
+    "publishedAt": "2020-07-14T16:00:16.138Z",
+    "firstPublishedAt": "2020-07-14T16:00:13.465Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6921,9 +6921,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:33 GMT',
+  'Tue, 14 Jul 2020 16:00:18 GMT',
   'etag',
-  'W/"12367945497557339651"',
+  'W/"7048743671037706340"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6933,29 +6933,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'ac93a389a6f11d7502ce7a1ae7fa1f64',
-  'transfer-encoding',
-  'chunked',
+  '9c4bbd3ea52bb4652f3d827405211039',
+  'Content-Length',
+  '524',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kOSlc4dMR+Caop1eztAyF/1EB18AAAAAQUIPAAAAAACsTHncDFaH+uzqjMMrVPwc; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=IoGlsfAVRhSgiv9KKBn0+5HWDV8AAAAAQUIPAAAAAADtoFYMzy3TYtM0Qo6dkDQU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=pE21HlONMRiZZX2JYMlkBAAAAAAGalXmY1EdPrPdMAmZAXUK; path=/; Domain=.contentful.com',
+  'nlbi_673446=Z0O1UlYJRmZNMpqqKsJtVwAAAADcFZUnaYPsrXe1KLcoO69i; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=crq/YvE7CgYs2VsGPWpmA/1EB18AAAAAnouxCPjgapDa8joHUIjl6Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=S5v1Bp9ecQAK5vlMOoVtA5HWDV8AAAAAZn04Wnmmvu+Yxp6AeiTctQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27144425-27144429 NNNY CT(0 0 0) RT(1594311933034 28) q(0 0 0 -1) r(2 2) U5'
+  '13-20318797-20318803 NNNN CT(94 93 0) RT(1594742417481 30) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6971,8 +6971,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:30.832Z",
-    "updatedAt": "2020-07-09T16:25:33.352Z",
+    "createdAt": "2020-07-14T16:00:14.117Z",
+    "updatedAt": "2020-07-14T16:00:17.562Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6981,8 +6981,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:33.352Z",
-    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
+    "publishedAt": "2020-07-14T16:00:17.562Z",
+    "firstPublishedAt": "2020-07-14T16:00:14.874Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -7067,9 +7067,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:34 GMT',
+  'Tue, 14 Jul 2020 16:00:18 GMT',
   'etag',
-  'W/"3405819313589139461"',
+  'W/"14583803251784325129"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7079,29 +7079,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  'bc4a4df664a3b9dba967b0d2a7d65f2c',
-  'transfer-encoding',
-  'chunked',
+  'b2ffa317593bcad6a2c0beac001a3e6a',
+  'Content-Length',
+  '516',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=pDMq78kgRlufT6T+FqPgv/1EB18AAAAAQUIPAAAAAABEAjjscaFmTAwLOeJHrFA5; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=tbfa9gVIR92nF53Az6o42pLWDV8AAAAAQUIPAAAAAACkox6V+boqwZSnQhERNDJH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=T8P5YCewp1VNNbRsYMlkBAAAAABRfZXbLwan6O2rAWLLOf9d; path=/; Domain=.contentful.com',
+  'nlbi_673446=krubaZJD4WfFgXOmKsJtVwAAAAB3s8JVRSbTBDkjR/wO7wan; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=9Xe3QrQi8yh+2VsGPWpmA/1EB18AAAAAyI+Y7tBETrKk0860LrzxYA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=et11Zac2KSGX5vlMOoVtA5LWDV8AAAAAgsMa/jDTFQT+IlZSfcvIpw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27144448-27144452 NNNY CT(0 0 0) RT(1594311933344 30) q(0 0 0 -1) r(2 2) U5'
+  '14-27000433-27000443 NNNN CT(93 93 0) RT(1594742418093 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7126,8 +7126,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "person",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:29.850Z",
-        "updatedAt": "2020-07-09T16:25:32.618Z",
+        "createdAt": "2020-07-14T16:00:12.848Z",
+        "updatedAt": "2020-07-14T16:00:16.138Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7136,8 +7136,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-09T16:25:32.618Z",
-        "firstPublishedAt": "2020-07-09T16:25:30.290Z",
+        "publishedAt": "2020-07-14T16:00:16.138Z",
+        "firstPublishedAt": "2020-07-14T16:00:13.465Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7225,9 +7225,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:34 GMT',
+  'Tue, 14 Jul 2020 16:00:19 GMT',
   'etag',
-  'W/"16334866240907286472"',
+  'W/"3162401999013364753"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7245,26 +7245,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a4947269b7cc8e118f151fafa30cbe42',
+  'c865830763402fd810e4943326864000',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=wsHV3ElTTCuyjuGE+oENXv1EB18AAAAAQUIPAAAAAADhU34Fp+6eNRRXKMvFQ/QS; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=cmT/QXc8SPSXeMDmI+O/5JPWDV8AAAAAQUIPAAAAAAD91tdhjq8CRM0+WHT/XOuj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=liNvOCiY4SJ2a/DvYMlkBAAAAABb5bnZT75oQ0tm+XTLhwQI; path=/; Domain=.contentful.com',
+  'nlbi_673446=xoWZGmt2s23To4n9KsJtVwAAAADTCveOD1SZDUTaZQQaakIm; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=c77hb+GiUxjJ2VsGPWpmA/1EB18AAAAAuLQReh4E+Wy2jK+xc6En6g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=27jcUX0eoRs95/lMOoVtA5PWDV8AAAAAeDocZ1OV+QYvyMEbO1n0RQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-42740509-42740513 NNNY CT(0 0 0) RT(1594311933650 30) q(0 0 0 -1) r(2 2) U5'
+  '14-27000579-27000592 NNNN CT(93 93 0) RT(1594742418728 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogpost', {"name":"blog post","fields":[{"name":"title","id":"title","type":"Symbol"},{"name":"category","id":"category","type":"Symbol"}]})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-09T16:25:34.705Z","updatedAt":"2020-07-09T16:25:34.705Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-14T16:00:20.040Z","updatedAt":"2020-07-14T16:00:20.040Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -7286,9 +7286,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:34 GMT',
+  'Tue, 14 Jul 2020 16:00:20 GMT',
   'etag',
-  '"8198607709353951105"',
+  '"8259321137694976203"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7306,21 +7306,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '05c9e5cc9b53994106caf4f5d9d1e792',
+  '29e5b60fc76930e61af4405eb7ed82e2',
   'Content-Length',
   '1255',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=jW3/wzCXSveqwZErnKd27f5EB18AAAAAQUIPAAAAAABVQqGxO2K9l4u+ttxbdYDP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=9Yo1ytbWSa2zyPsATu/gG5PWDV8AAAAAQUIPAAAAAACGFcorESTbPXz541JbVDNN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=0FX9Qq2RqxZlZPFFYMlkBAAAAADLKU2cVSCP/mbJYEb2jqiY; path=/; Domain=.contentful.com',
+  'nlbi_673446=SWRrSQHVCBSh5jMEKsJtVwAAAADhVHNMyfkWAwTHQRbrbvE5; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=vazlK7+IrwtC2lsGPWpmA/5EB18AAAAAoO0k6cnud4/nTpuC352qJg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=R66mIo6TiXjm5/lMOoVtA5PWDV8AAAAAosASahfamJnAO5mpj3lXwA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86055727-86055736 NNNY CT(0 0 0) RT(1594311933962 32) q(0 0 0 -1) r(3 3) U5'
+  '14-27000723-27000730 NNNN CT(90 97 0) RT(1594742419229 33) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7336,8 +7336,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogpost",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:34.705Z",
-    "updatedAt": "2020-07-09T16:25:35.188Z",
+    "createdAt": "2020-07-14T16:00:20.040Z",
+    "updatedAt": "2020-07-14T16:00:20.617Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7361,8 +7361,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:35.188Z",
-    "publishedAt": "2020-07-09T16:25:35.188Z",
+    "firstPublishedAt": "2020-07-14T16:00:20.617Z",
+    "publishedAt": "2020-07-14T16:00:20.617Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -7422,9 +7422,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:35 GMT',
+  'Tue, 14 Jul 2020 16:00:20 GMT',
   'etag',
-  'W/"10181970523647773160"',
+  'W/"10082589985409053526"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7442,21 +7442,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd8bcc3903013853ebdb62d2cb646efea',
-  'transfer-encoding',
-  'chunked',
+  '507ecd1e6e07df3b1db4bb1b7b0295ad',
+  'Content-Length',
+  '442',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=C0VTBnX9Sqmb9F1THk3Pjv5EB18AAAAAQUIPAAAAAAAUmHpDwi76rKuFEKMrZNrc; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/vi8cm9oRgKrVG7sCMV3npTWDV8AAAAAQUIPAAAAAACX/J8R6JClwqpoPx5hpBkv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=9yXhfc+p2xHwKOzeYMlkBAAAAABEDqqH/g1flNIPWgji2Veb; path=/; Domain=.contentful.com',
+  'nlbi_673446=Ld7qcXhqCBOM4ccOKsJtVwAAAABGpNJa9j3ThfGtDZgNeza3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=GCKTU0OGVjnb2lsGPWpmA/5EB18AAAAA1x2DmbDN3ZLz3+aXOu6RKg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=EOIlI2fqJxmn6PlMOoVtA5TWDV8AAAAAUSgHYye+OBk8nBV22hbVeg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55399698-55399704 NNNY CT(0 0 0) RT(1594311934467 32) q(0 1 1 -1) r(4 4) U5'
+  '13-20319435-20319443 NNNN CT(98 93 0) RT(1594742419951 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7473,10 +7473,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "4UwZKzKY3KkejAHj3cRPeQ",
+    "id": "2qjlQ6dEAo5bEW5SI1PAKv",
     "type": "Entry",
-    "createdAt": "2020-07-09T16:25:35.984Z",
-    "updatedAt": "2020-07-09T16:25:35.984Z",
+    "createdAt": "2020-07-14T16:00:21.438Z",
+    "updatedAt": "2020-07-14T16:00:21.438Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7536,9 +7536,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:36 GMT',
+  'Tue, 14 Jul 2020 16:00:21 GMT',
   'etag',
-  '"5128819315185328829"',
+  '"12179876388851723368"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7548,23 +7548,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '0558861dc2188fee7788d9ff2ad3ee52',
+  '8608cf34d658268a20f1edb9abe2ff5e',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=I1aRO2oJT8q4CE5g5+g1nv9EB18AAAAAQUIPAAAAAAATK1f1tMuryWHq23wor9NM; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=hFKfw897Q22NPI8hXGNlvJXWDV8AAAAAQUIPAAAAAACuwMsOPesuTA7dPLfvv5ZB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=cL/4PCiPK0/7gUrGYMlkBAAAAAD/QVO47CuJq5ThUtSWv6D8; path=/; Domain=.contentful.com',
+  'nlbi_673446=PKg8eJZnul1922IFKsJtVwAAAADuoocFNlgHjEZFLPmFGl9f; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=x2VGcgXQRyl921sGPWpmA/9EB18AAAAAfpYnFYbEROakOVJXn7kC0Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=iwzeXZ0Kug2A6flMOoVtA5XWDV8AAAAACoKP3Uyx1cxp6Z2XkH9/qQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7572,7 +7572,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-55399832-55399835 NNYY CT(0 0 0) RT(1594311935083 30) q(0 0 0 -1) r(4 4) U5'
+  '13-20319608-20319615 NNYN CT(86 87 0) RT(1594742420559 41) q(0 1 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7589,10 +7589,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "54GyBcsJ9GSwtZkFAXcyfs",
+    "id": "4FiuEf8CqgsbY1ZI4wBg0X",
     "type": "Entry",
-    "createdAt": "2020-07-09T16:25:36.565Z",
-    "updatedAt": "2020-07-09T16:25:36.565Z",
+    "createdAt": "2020-07-14T16:00:22.276Z",
+    "updatedAt": "2020-07-14T16:00:22.276Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7652,9 +7652,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:36 GMT',
+  'Tue, 14 Jul 2020 16:00:22 GMT',
   'etag',
-  '"4645637625467400399"',
+  '"11652420770846934910"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7672,15 +7672,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'c002a73405ea9c410312cfbb7016df3e',
+  '99ac7c3d2ef272d8201ff37376a17788',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=t2rwlKijQ42FhyK3RNHhwQBFB18AAAAAQUIPAAAAAABiU34ZceJgIok00CE3sTUP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=l/TSLR9oR7WORW/jJ6afOpbWDV8AAAAAQUIPAAAAAAAfBXqDcMkKaZXWR0AWwGIC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=84PaPidSRXrYh4OLYMlkBAAAAADqRo6xFb3gUKAYEbXOImhZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=ZfEKD3vtZ0hkiOpiKsJtVwAAAAA0x1e/NDzZ5H+xTNMEmElV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=y6dhBG9vCRYT3FsGPWpmAwBFB18AAAAAE/u18Z7SqlvnSvKG4T5Gig==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7tyaa7uPmAkj6vlMOoVtA5bWDV8AAAAAKFJ6DiUhgHqVeoPbv6W3kg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7688,7 +7688,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66929295-66929305 NNYY CT(0 0 0) RT(1594311935691 34) q(0 0 0 -1) r(4 4) U5'
+  '14-27001504-27001510 NNYN CT(95 93 0) RT(1594742421585 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7713,8 +7713,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogpost",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:34.705Z",
-        "updatedAt": "2020-07-09T16:25:35.188Z",
+        "createdAt": "2020-07-14T16:00:20.040Z",
+        "updatedAt": "2020-07-14T16:00:20.617Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7723,8 +7723,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-09T16:25:35.188Z",
-        "firstPublishedAt": "2020-07-09T16:25:35.188Z",
+        "publishedAt": "2020-07-14T16:00:20.617Z",
+        "firstPublishedAt": "2020-07-14T16:00:20.617Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7801,9 +7801,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:36 GMT',
+  'Tue, 14 Jul 2020 16:00:22 GMT',
   'etag',
-  'W/"7881515414895237677"',
+  'W/"16271660349285021501"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7821,21 +7821,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '40b9192a6ffab587b1c50e20e319f727',
-  'transfer-encoding',
-  'chunked',
+  '4e0f1768b91321ffe436665c9b1c5dd8',
+  'Content-Length',
+  '513',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=H6XTs9ihTYKqZPSh8xvhSgBFB18AAAAAQUIPAAAAAABfgS01KesZOt09hvqQRD/n; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=EGmNxaXjRtCir90iMqUp35bWDV8AAAAAQUIPAAAAAACGMCNYn8i7cVp2VCuzJH7Q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NcGxNnQJ+xJHfSFDYMlkBAAAAABwH6GC/fXFbCbHLArkHXIp; path=/; Domain=.contentful.com',
+  'nlbi_673446=2i05LQ+zuAMVym1XKsJtVwAAAAA68YVWqud0EwOz0g2iUsLc; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=okFiSrsThFBn3FsGPWpmAwBFB18AAAAAXw9XnTm2wERfD+K+SGdJJQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=djRbN8jZ3xCl6vlMOoVtA5bWDV8AAAAAzzNbfy1jV0JrCTfRitx/tQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66929412-66929422 NNNY CT(0 0 0) RT(1594311936206 27) q(0 0 0 -1) r(2 2) U5'
+  '13-20319989-20320008 NNNN CT(96 97 0) RT(1594742422200 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7861,10 +7861,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "4UwZKzKY3KkejAHj3cRPeQ",
+        "id": "2qjlQ6dEAo5bEW5SI1PAKv",
         "type": "Entry",
-        "createdAt": "2020-07-09T16:25:35.984Z",
-        "updatedAt": "2020-07-09T16:25:35.984Z",
+        "createdAt": "2020-07-14T16:00:21.438Z",
+        "updatedAt": "2020-07-14T16:00:21.438Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7914,10 +7914,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "54GyBcsJ9GSwtZkFAXcyfs",
+        "id": "4FiuEf8CqgsbY1ZI4wBg0X",
         "type": "Entry",
-        "createdAt": "2020-07-09T16:25:36.565Z",
-        "updatedAt": "2020-07-09T16:25:36.565Z",
+        "createdAt": "2020-07-14T16:00:22.276Z",
+        "updatedAt": "2020-07-14T16:00:22.276Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7981,9 +7981,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:37 GMT',
+  'Tue, 14 Jul 2020 16:00:23 GMT',
   'etag',
-  'W/"14291565929482659107"',
+  'W/"15682920442187095777"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8001,21 +8001,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a0ed72087e55cc46547b3dd635a19d44',
-  'transfer-encoding',
-  'chunked',
+  '9bd30e17cd926e6c97c87915bbbcb821',
+  'Content-Length',
+  '480',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mwHTDqKCSp6JYMp6/+8IMgBFB18AAAAAQUIPAAAAAACjzXVJdRPtfzX749Z4VObC; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=1zv9t5FQTn+Q4nDivGs23JfWDV8AAAAAQUIPAAAAAADNv1RND3igPJNiLAih4U/D; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=97dAX/dGh1X8ZxtlYMlkBAAAAAAq2m/lVc/ugh11FePVf3nC; path=/; Domain=.contentful.com',
+  'nlbi_673446=MbQDSAC8EG4gxxDiKsJtVwAAAAA7l5K6SNGIFhC+civsUIje; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=vBlrCaUYWCXY3FsGPWpmAwBFB18AAAAAHEImRaNafkal6Q4ZJGaGeA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=2UzSR98WWQ8L6/lMOoVtA5fWDV8AAAAArISDhwAqwKr3umMCuxo+Gw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41052284-41052296 NNNY CT(0 0 0) RT(1594311936520 35) q(0 0 0 -1) r(2 2) U5'
+  '12-17403377-17403384 NNNN CT(91 91 0) RT(1594742422802 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8056,15 +8056,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -8076,27 +8076,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:37 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:23 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -8109,23 +8109,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'f8e523c9c5bc6f9e89d118d412cbe4fc',
-  'X-Download-Options',
+  '87497f5eae995c7049637bc6915000b5',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4hnSPyYHRAaVOFUSyRK01QBFB18AAAAAQUIPAAAAAACHJ+nOLGXq49XyLB6LN9G9; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=XbhF9m3KQKG5V+PEie9tKpfWDV8AAAAAQUIPAAAAAADxJEvg+c7EIo2PiiR/yeWA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Y57GO97KYE9HV8B1YMlkBAAAAADGuZmOC7BhvycXMcb2JhJx; path=/; Domain=.contentful.com',
+  'nlbi_673446=+BjiHLVBIiv2T16wKsJtVwAAAADK30NbV+VH81bZrbmLIfHw; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=ygARZNiMNQkP3VsGPWpmAwBFB18AAAAA1X5IZiKkr7HG+2NdElVMdQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Kf3fJj0kkxJi6/lMOoVtA5fWDV8AAAAAys3SuUL9RIyrbqYgvNX7Gw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8133,11 +8133,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-26742059-26742063 NNYY CT(0 0 0) RT(1594311936776 32) q(0 0 0 -1) r(1 1) U5'
+  '13-20320282-20320292 NNYN CT(92 93 0) RT(1594742423323 27) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4UwZKzKY3KkejAHj3cRPeQ', {"sys":{"id":"4UwZKzKY3KkejAHj3cRPeQ","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/2qjlQ6dEAo5bEW5SI1PAKv', {"sys":{"id":"2qjlQ6dEAo5bEW5SI1PAKv","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8150,10 +8150,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "4UwZKzKY3KkejAHj3cRPeQ",
+    "id": "2qjlQ6dEAo5bEW5SI1PAKv",
     "type": "Entry",
-    "createdAt": "2020-07-09T16:25:35.984Z",
-    "updatedAt": "2020-07-09T16:25:37.875Z",
+    "createdAt": "2020-07-14T16:00:21.438Z",
+    "updatedAt": "2020-07-14T16:00:25.435Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8218,9 +8218,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:37 GMT',
+  'Tue, 14 Jul 2020 16:00:25 GMT',
   'etag',
-  'W/"11519352141687709313"',
+  'W/"14136653011521110968"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8230,33 +8230,33 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  'e75776abb84ed510b639ed3c4d20f91e',
+  '0c80431b6a62b2e865ded6bf7443258e',
   'Content-Length',
-  '390',
+  '388',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lpfrydYQRWultUxPLPSi3AFFB18AAAAAQUIPAAAAAAAqfEXyiQ0k4YRy0dRtmxgq; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=oTStHoA8T9i7eOjydXrmYZnWDV8AAAAAQUIPAAAAAACF2VPRy5ifp6/nAtNxd8UL; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=DnfNR1Osnnc4un5IYMlkBAAAAADcIEweNfo2ItZ+VraU6VCy; path=/; Domain=.contentful.com',
+  'nlbi_673446=8qRsU9I43UxFZDbwKsJtVwAAAAA4Lh5vwVk+ZvqBgzD/ajZN; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=CriKUW/Y+Cao3VsGPWpmAwFFB18AAAAAXhsdcGbLXpB53z+oBQcs6Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Nu80exeLD04G7flMOoVtA5nWDV8AAAAA7dF6UXsr8p3uht6U1BbpWw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66929587-66929594 NNNN CT(86 87 0) RT(1594311936989 28) q(0 0 1 -1) r(3 3) U5'
+  '5-13527812-13527814 NNNN CT(88 89 0) RT(1594742424725 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4UwZKzKY3KkejAHj3cRPeQ/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/2qjlQ6dEAo5bEW5SI1PAKv/published')
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8269,10 +8269,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "4UwZKzKY3KkejAHj3cRPeQ",
+    "id": "2qjlQ6dEAo5bEW5SI1PAKv",
     "type": "Entry",
-    "createdAt": "2020-07-09T16:25:35.984Z",
-    "updatedAt": "2020-07-09T16:25:38.255Z",
+    "createdAt": "2020-07-14T16:00:21.438Z",
+    "updatedAt": "2020-07-14T16:00:25.937Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8281,8 +8281,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-09T16:25:38.255Z",
-    "firstPublishedAt": "2020-07-09T16:25:38.255Z",
+    "publishedAt": "2020-07-14T16:00:25.937Z",
+    "firstPublishedAt": "2020-07-14T16:00:25.937Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8347,128 +8347,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:38 GMT',
+  'Tue, 14 Jul 2020 16:00:26 GMT',
   'etag',
-  'W/"12592086046620630163"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '1bfbdc17235b8230ab8c39d069e7471d',
-  'Content-Length',
-  '419',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=D5bW8bk2TGOeVIbKTmUnTQFFB18AAAAAQUIPAAAAAAB5aYGvCwjL7nRStmVvyPzV; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=HP/gRmeBtgxmBh+RYMlkBAAAAADYshcBFR5BDCSSjMYjD2Mb; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=1SemFjBar0hM3lsGPWpmAwFFB18AAAAAzUiM6NDz9x0+/J7YGR0UBA==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '14-86056725-86056736 NNNY CT(0 0 0) RT(1594311937539 30) q(0 0 0 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/54GyBcsJ9GSwtZkFAXcyfs', {"sys":{"id":"54GyBcsJ9GSwtZkFAXcyfs","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
-  .reply(200, {
-  "metadata": {
-    "tags": []
-  },
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "54GyBcsJ9GSwtZkFAXcyfs",
-    "type": "Entry",
-    "createdAt": "2020-07-09T16:25:36.565Z",
-    "updatedAt": "2020-07-09T16:25:39.055Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 0,
-    "version": 2,
-    "contentType": {
-      "sys": {
-        "type": "Link",
-        "linkType": "ContentType",
-        "id": "blogpost"
-      }
-    }
-  },
-  "fields": {
-    "title": {
-      "en-US": "hello!"
-    },
-    "category": {
-      "en-US": "hello!"
-    }
-  }
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Thu, 09 Jul 2020 16:25:39 GMT',
-  'etag',
-  'W/"2850861518525753052"',
+  'W/"17433361460839943386"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8486,25 +8367,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '435168a404170ec378dd3ef02eb96800',
-  'Content-Length',
-  '387',
+  'de193f6889634667eb4fbee7910fa2e2',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=s7p1yyukSbCrs7392FPHuQJFB18AAAAAQUIPAAAAAACn4RECK0cDtC4kixbPpASP; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vWm3EeYnTDOW/L4R9BSB15nWDV8AAAAAQUIPAAAAAAAHPUw/sQobSItBOvWpUQkR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=2qPtRbnnu1dyd1luYMlkBAAAAAAEaONMfBVzPNxl/hOujo6D; path=/; Domain=.contentful.com',
+  'nlbi_673446=BK2yQZsntHqdp8qmKsJtVwAAAADGau+rX/ekoPWN6ejVG6J1; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=H+mmY6ew8zXY3lsGPWpmAwJFB18AAAAAJOmqfVtkT/QLuQ+7R51owA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=uAKqYjoJxHWb7flMOoVtA5nWDV8AAAAA3riaz6+ICDAOUAizUVIJzA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26742200-26742210 NNNN CT(86 87 0) RT(1594311938156 34) q(0 0 2 -1) r(4 4) U5'
+  '12-17403866-17403871 NNNN CT(87 88 0) RT(1594742425275 40) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/54GyBcsJ9GSwtZkFAXcyfs/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4FiuEf8CqgsbY1ZI4wBg0X', {"sys":{"id":"4FiuEf8CqgsbY1ZI4wBg0X","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8517,10 +8398,129 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "54GyBcsJ9GSwtZkFAXcyfs",
+    "id": "4FiuEf8CqgsbY1ZI4wBg0X",
     "type": "Entry",
-    "createdAt": "2020-07-09T16:25:36.565Z",
-    "updatedAt": "2020-07-09T16:25:39.477Z",
+    "createdAt": "2020-07-14T16:00:22.276Z",
+    "updatedAt": "2020-07-14T16:00:26.581Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 0,
+    "version": 2,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "blogpost"
+      }
+    }
+  },
+  "fields": {
+    "title": {
+      "en-US": "hello!"
+    },
+    "category": {
+      "en-US": "hello!"
+    }
+  }
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 16:00:26 GMT',
+  'etag',
+  'W/"18207385812785737405"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'b646ad90e571e8b1e5b1cbb51b293226',
+  'Content-Length',
+  '388',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=LbikgXKqRMecMscsno2dMprWDV8AAAAAQUIPAAAAAABqP1obzHERyQrJt/hqS5Ol; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=atkAViFUkAfG5LAqKsJtVwAAAACPM40uQetAlM6H5SrCOESL; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=gg45FpI6CiUs7vlMOoVtA5rWDV8AAAAAHJZQthT6NeH/IlDQZbjMBw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '6-4140346-4140349 NNNN CT(94 94 0) RT(1594742425886 34) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4FiuEf8CqgsbY1ZI4wBg0X/published')
+  .reply(200, {
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "4FiuEf8CqgsbY1ZI4wBg0X",
+    "type": "Entry",
+    "createdAt": "2020-07-14T16:00:22.276Z",
+    "updatedAt": "2020-07-14T16:00:27.168Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8529,8 +8529,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-09T16:25:39.477Z",
-    "firstPublishedAt": "2020-07-09T16:25:39.477Z",
+    "publishedAt": "2020-07-14T16:00:27.168Z",
+    "firstPublishedAt": "2020-07-14T16:00:27.168Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8595,9 +8595,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:39 GMT',
+  'Tue, 14 Jul 2020 16:00:27 GMT',
   'etag',
-  'W/"4955621065309646556"',
+  'W/"16244480329112468108"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8615,21 +8615,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '7a230b11c27c22f43688645bff7367c2',
+  'b804595fe31d40f3c3fb1d9b160c41f0',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FYI2SlZ2Rt6jkmVYxs9PGANFB18AAAAAQUIPAAAAAADk57nxAfkAZI7VWtPGgcet; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=VHXrfMKGQsWZftSMjTm8jZrWDV8AAAAAQUIPAAAAAABExbX9oUDGgRPkDfY+NVv7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ED40ECpV4XV1HYSvYMlkBAAAAAB80plhg/xXBZHvvehfScWk; path=/; Domain=.contentful.com',
+  'nlbi_673446=ZyNoDQGnOXCOlK8ZKsJtVwAAAAAa5ZJH2jIeNM7AA4dSDb/Y; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=W2TmDVYfMHNC31sGPWpmAwNFB18AAAAAIUvhOMlBgUg3iwEyTbaouA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3RrdDlGY5gTv7vlMOoVtA5rWDV8AAAAA1RzzSIdKl9eYAvzdyaE8Hg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-42741314-42741317 NNNY CT(0 0 0) RT(1594311938772 30) q(0 0 0 -1) r(2 2) U5'
+  '6-4140409-4140417 NNNN CT(93 94 0) RT(1594742426494 36) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8655,10 +8655,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "54GyBcsJ9GSwtZkFAXcyfs",
+        "id": "4FiuEf8CqgsbY1ZI4wBg0X",
         "type": "Entry",
-        "createdAt": "2020-07-09T16:25:36.565Z",
-        "updatedAt": "2020-07-09T16:25:39.477Z",
+        "createdAt": "2020-07-14T16:00:22.276Z",
+        "updatedAt": "2020-07-14T16:00:27.168Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8667,8 +8667,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-09T16:25:39.477Z",
-        "firstPublishedAt": "2020-07-09T16:25:39.477Z",
+        "publishedAt": "2020-07-14T16:00:27.168Z",
+        "firstPublishedAt": "2020-07-14T16:00:27.168Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8721,10 +8721,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "4UwZKzKY3KkejAHj3cRPeQ",
+        "id": "2qjlQ6dEAo5bEW5SI1PAKv",
         "type": "Entry",
-        "createdAt": "2020-07-09T16:25:35.984Z",
-        "updatedAt": "2020-07-09T16:25:38.255Z",
+        "createdAt": "2020-07-14T16:00:21.438Z",
+        "updatedAt": "2020-07-14T16:00:25.937Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8733,8 +8733,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-09T16:25:38.255Z",
-        "firstPublishedAt": "2020-07-09T16:25:38.255Z",
+        "publishedAt": "2020-07-14T16:00:25.937Z",
+        "firstPublishedAt": "2020-07-14T16:00:25.937Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8801,9 +8801,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:40 GMT',
+  'Tue, 14 Jul 2020 16:00:27 GMT',
   'etag',
-  'W/"4179381182970640430"',
+  'W/"12336269207667690128"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8813,29 +8813,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'd8e8294086e83fbcabb0b04a74d1b7a3',
+  '16ba8cf930617e25968f8d0a5c780949',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+MZgESQBSCeYiKuUhHqUzwNFB18AAAAAQUIPAAAAAAAciGHjiATzQBESvd7UPMkI; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=bmye7nzuQdae9KN3UYTec5vWDV8AAAAAQUIPAAAAAADKZuf24gdDkfuJ5+QCb1Fr; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WZIePZchXm/Kdj4UYMlkBAAAAAAuMpCfAlhQEh1h6vedtxMV; path=/; Domain=.contentful.com',
+  'nlbi_673446=puwRIeuiRQN3USAFKsJtVwAAAAAfrn3dtstLlEcr/Rl2XBXc; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=P5uxZLcejlzY31sGPWpmAwNFB18AAAAAVXzad718xgFtXEoqwLCptg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TCprP1SUF21V7/lMOoVtA5vWDV8AAAAAoyWY9HSGQHFjLqsiDR83pA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41052640-41052648 NNNN CT(93 93 0) RT(1594311939286 32) q(0 0 2 -1) r(3 3) U5'
+  '2-3148973-3148974 NNNN CT(93 95 0) RT(1594742427110 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8872,7 +8872,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:40 GMT',
+  'Tue, 14 Jul 2020 16:00:28 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -8884,23 +8884,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '68c4928e033b8ff5c386e767b65f6187',
+  '902cbc61fd10f77cf11d5bf2689e0d5d',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=EDwSMu/IQxu07ggFFiarXANFB18AAAAAQUIPAAAAAABNDwfng9i7+byRu9y2GTJY; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Mfe98czcQl+MJeT1PiuAyJzWDV8AAAAAQUIPAAAAAADrK8GcM1Fasyua5ljJqlUA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Uf3eLv3UJRJ+TOFJYMlkBAAAAACgwAjNWw4N+ggzZydmyKJ0; path=/; Domain=.contentful.com',
+  'nlbi_673446=c5P4SQWVNC1s+3WNKsJtVwAAAADDUxDyrQHCBGyqBfIZX6fn; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=zY8BaTMuuEIR4FsGPWpmAwNFB18AAAAALGvZHaSsso3ng+DDo4Ke8A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/0NqRRYYwjzB7/lMOoVtA5zWDV8AAAAAcWPVSBTKcETMKlJ/lGv+LA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8908,7 +8908,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66930350-66930356 NNYY CT(0 0 0) RT(1594311939800 30) q(0 0 0 -1) r(1 1) U5'
+  '13-20321262-20321274 NNYN CT(95 87 0) RT(1594742427631 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8925,7 +8925,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "c4a642654a66bbe0cfdd13da3b99be37"
+  "requestId": "0050b204b4a09ee50189f93e52f60a67"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -8949,9 +8949,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:40 GMT',
+  'Tue, 14 Jul 2020 16:00:28 GMT',
   'etag',
-  '"14226196473492830399"',
+  '"10792275763360566336"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8961,23 +8961,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  'c4a642654a66bbe0cfdd13da3b99be37',
+  '0050b204b4a09ee50189f93e52f60a67',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4YBP+s67SrSdHdahLlwzfgRFB18AAAAAQUIPAAAAAAAlUzzJQy3w0pIrTo8EiPzp; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fGKLT+7HSQ2mv+NljeSWapzWDV8AAAAAQUIPAAAAAACo2Cox9gryCwCddRFLF01U; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=wwK8KW1qhm6gZijmYMlkBAAAAACAeGsrSnDBY0IUIWOO98IP; path=/; Domain=.contentful.com',
+  'nlbi_673446=pqg7cFtfmjEUCHxdKsJtVwAAAACm7fCcVOAs7Hk3AduLEqCs; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=QYSEXw6RYmtM4FsGPWpmAwRFB18AAAAA1u7QZZGMPZP7p/gGtDMmwg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=AxwWPhzpojQ38PlMOoVtA5zWDV8AAAAAJadFZynPrwyR+quZFZ6Spg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8985,7 +8985,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-26742398-26742401 NNYY CT(0 0 0) RT(1594311940092 33) q(0 0 0 -1) r(1 1) U5'
+  '10-8162607-8162617 NNYN CT(97 101 0) RT(1594742428131 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9026,15 +9026,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -9046,27 +9046,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:41 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:29 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -9079,23 +9079,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e3622ae9d590bb08f67d9aeb260e423b',
-  'X-Download-Options',
+  '14915318fc930a5866139fb2e7efb138',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FIh8edipT2q5Hgoidyh3PwRFB18AAAAAQUIPAAAAAAC06Hs/PrdBP16N2xIs43P/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=xyPnZJpjQxCRwT4tagHZvp3WDV8AAAAAQUIPAAAAAAC3n8HbgGeMlMLlMNoI1udq; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=6q//ZGShLnypdTb0YMlkBAAAAABxtS6e7pIjuW426VWmYWKz; path=/; Domain=.contentful.com',
+  'nlbi_673446=p1A0Nrnpj0+niCPiKsJtVwAAAAAK2RTDgoCvKvX6RlQ/ZICV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=i9VBEdUw4jWW4FsGPWpmAwRFB18AAAAA1LHXDRIcZC2Xkz2B99tAWg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7i2fHJ08aVCv8PlMOoVtA53WDV8AAAAAEoEiZpmOd5IdLNVoqjkA+A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9103,12 +9103,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '6-13875339-13875342 NNYY CT(0 0 0) RT(1594311940408 29) q(0 0 0 -1) r(1 1) U5'
+  '3-6344394-6344397 NNYN CT(87 88 0) RT(1594742428745 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost', {"name":"Blog post","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-09T16:25:41.377Z","updatedAt":"2020-07-09T16:25:41.377Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-14T16:00:29.878Z","updatedAt":"2020-07-14T16:00:29.878Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -9130,9 +9130,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:41 GMT',
+  'Tue, 14 Jul 2020 16:00:29 GMT',
   'etag',
-  '"7948710513735787671"',
+  '"14285541248354921546"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9150,21 +9150,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'd5baedfef4857038ca8bb465032fd752',
+  '53e07a8b1e199fc1f84f4731c2809c81',
   'Content-Length',
   '1054',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3uRKILxNTtiey80Tp3wEJQRFB18AAAAAQUIPAAAAAAAhaBG7okPPJ0HdyBaqFFSK; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=jzc+GF6CRX2lvm1QRNtHu53WDV8AAAAAQUIPAAAAAAD6mdLmdnrunEQslrL/SVeK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XJ0/fNd4REVb47ZEYMlkBAAAAAAHzWVOj9NjTYaZjQtuqKQt; path=/; Domain=.contentful.com',
+  'nlbi_673446=SOsqIb7X5Rec+BLPKsJtVwAAAACWW92r+c+2tJGlSLLeUSo3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=4y39eXX+N27+4FsGPWpmAwRFB18AAAAAqvw3PhqB9oYtKKHyf/FAVw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+wImL6QERHk78flMOoVtA53WDV8AAAAAdjbHIruGocGLYHySjkUa/Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41052868-41052873 NNNY CT(0 0 0) RT(1594311940614 31) q(0 0 0 -1) r(3 3) U5'
+  '10-8162789-8162801 NNNN CT(86 87 0) RT(1594742429165 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9180,8 +9180,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:41.377Z",
-    "updatedAt": "2020-07-09T16:25:41.897Z",
+    "createdAt": "2020-07-14T16:00:29.878Z",
+    "updatedAt": "2020-07-14T16:00:30.418Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9205,8 +9205,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
-    "publishedAt": "2020-07-09T16:25:41.897Z",
+    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
+    "publishedAt": "2020-07-14T16:00:30.418Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -9256,9 +9256,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:41 GMT',
+  'Tue, 14 Jul 2020 16:00:30 GMT',
   'etag',
-  'W/"1268252573313628680"',
+  'W/"6828217408317239309"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9268,29 +9268,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  'fae62935f1bea8b4124a32e1e801fb74',
+  'fd0964184f8587396253deb701dd7e83',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Qt0RI0y6Sim/EMYWajcrAwVFB18AAAAAQUIPAAAAAAA3SAk5Raewh4dPvWHGW1gC; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=5Rwupq9XSYmANLewNIyfRJ7WDV8AAAAAQUIPAAAAAACV7viHzyyHxXsqbJa8j8dT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zuZgSgQPsFwJUJp/YMlkBAAAAABENwJN1J1PPY5prarfxT4w; path=/; Domain=.contentful.com',
+  'nlbi_673446=XgTSJOw2KV3a13UHKsJtVwAAAAArPc3QeMOMzGYzSBvuY2J0; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=dRRuI4TOO3GR4VsGPWpmAwVFB18AAAAAA9tdjVxgbA9Dz8OVcrrioQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3fGsGaS8TCvv8flMOoVtA57WDV8AAAAAh/jwcW1EidIiX7N8MlRodQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86057633-86057645 NNNN CT(97 89 0) RT(1594311940990 41) q(0 0 2 -1) r(4 4) U5'
+  '14-27003733-27003744 NNNN CT(88 88 0) RT(1594742429771 30) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9317,7 +9317,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9325,7 +9325,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:42.239Z",
+    "updatedAt": "2020-07-14T16:00:31.070Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -9373,9 +9373,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:42 GMT',
+  'Tue, 14 Jul 2020 16:00:31 GMT',
   'etag',
-  'W/"15460693560588132469"',
+  'W/"12431943504097401511"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9385,29 +9385,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'cbd637ecfb9aae7eda985b0e9e3fa182',
+  '035225c93d25c14f48124b72b0ea6cc1',
   'Content-Length',
-  '384',
+  '383',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ftkN97EORQOlnBn6Ah7JUwVFB18AAAAAQUIPAAAAAAAhq1oU+V6O5xPTBv8vkcYd; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ptOdz+bIRpu5Ob6KPLiRaZ7WDV8AAAAAQUIPAAAAAACdZa69o2wpvpZkRUwLeJ8h; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8/C6ETwat0zF+8OxYMlkBAAAAADkO/dMHhTLP2H9WKSOJE3s; path=/; Domain=.contentful.com',
+  'nlbi_673446=xzDLZYpdvHUw5JPcKsJtVwAAAABVuhxenlvViAFcJuAq0Q4F; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=5tPTR1KtzG3R4VsGPWpmAwVFB18AAAAA0evyQ5SuVG8AE+uyGPimRA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=tHI+VjxlaVZi8vlMOoVtA57WDV8AAAAAEbn8qSRweacFE0gk1fVzvw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41052965-41052969 NNNY CT(0 0 0) RT(1594311941522 27) q(0 0 0 -1) r(2 2) U5'
+  '12-17404847-17404861 NNNN CT(88 88 0) RT(1594742430391 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9424,7 +9424,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9432,7 +9432,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:42.239Z",
+    "updatedAt": "2020-07-14T16:00:31.070Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9490,9 +9490,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:42 GMT',
+  'Tue, 14 Jul 2020 16:00:31 GMT',
   'etag',
-  'W/"652615658264279945"',
+  'W/"4178674710576013527"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9502,29 +9502,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '81091d9b6248bb72672ad353abba3a24',
+  '0acebafaa9789ae827c4419e9d721c83',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=sVMp5BbjQbOTWhkBlaKFrQVFB18AAAAAQUIPAAAAAAB6RkLjoU2JCRPPSjRh2EkB; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=2wYvZepAQRigtSUz3CiFhZ/WDV8AAAAAQUIPAAAAAACggh9koRylZym4jtwJzgu/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=5xb4cS5uODMUyIlbYMlkBAAAAAAoNzs0U0FOfTHge8IJuiY/; path=/; Domain=.contentful.com',
+  'nlbi_673446=PqMLa79ukjw2MoJnKsJtVwAAAAAT70apzpx/4IliPy/C2oxk; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=rzX2SCY+ATXy4VsGPWpmAwVFB18AAAAAtR8GwkFnCAOE/aUX5CVzbA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=noFJFYAKB0Tw8vlMOoVtA5/WDV8AAAAAzhs5/Uq84wUBJYmeC3yKBA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66930815-66930816 NNNY CT(0 0 0) RT(1594311941778 30) q(0 0 0 -1) r(1 1) U5'
+  '13-20322125-20322141 NNNN CT(92 92 0) RT(1594742430999 34) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9549,8 +9549,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:41.377Z",
-        "updatedAt": "2020-07-09T16:25:41.897Z",
+        "createdAt": "2020-07-14T16:00:29.878Z",
+        "updatedAt": "2020-07-14T16:00:30.418Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -9559,8 +9559,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-09T16:25:41.897Z",
-        "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+        "publishedAt": "2020-07-14T16:00:30.418Z",
+        "firstPublishedAt": "2020-07-14T16:00:30.418Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -9627,9 +9627,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:42 GMT',
+  'Tue, 14 Jul 2020 16:00:32 GMT',
   'etag',
-  'W/"17983529376578233374"',
+  'W/"15466410452043374031"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9639,29 +9639,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  'c0a39a73c06da3512507cc5748ef7561',
+  'b9eb039e75a5eab8094d8c8a84f078d1',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=zZgYPIoeTGGO6mXG8/9d6AZFB18AAAAAQUIPAAAAAAD55Nb9qProDOh2K0EglBV+; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ScSNCA5PTjW0qrmEB+sB/KDWDV8AAAAAQUIPAAAAAAAAv6DDO7k2IGI7Rcwa9pR0; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GiX9D76xeF2XNRLGYMlkBAAAAADO1IfL+BtWIPEEKqZWWoLV; path=/; Domain=.contentful.com',
+  'nlbi_673446=QZ/IQ5pUcQgvJuAGKsJtVwAAAADuIfV712h6eqULWNFL+TR8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=E967cbdhx2Ef4lsGPWpmAwZFB18AAAAAVKMR9rChlW8x+aEe0bvAhw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+dMZI7KYeWJ98/lMOoVtA6DWDV8AAAAAC64TzCkLyG9I7Ly9Lo+6fw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66930860-66930868 NNNY CT(0 0 0) RT(1594311942032 32) q(0 0 0 -1) r(2 2) U5'
+  '5-13528833-13528840 NNNN CT(94 93 0) RT(1594742431645 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9678,7 +9678,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9686,7 +9686,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:42.239Z",
+    "updatedAt": "2020-07-14T16:00:31.070Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9744,9 +9744,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:43 GMT',
+  'Tue, 14 Jul 2020 16:00:32 GMT',
   'etag',
-  'W/"652615658264279945"',
+  'W/"4178674710576013527"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9756,29 +9756,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '032ce0edab5e83324fd71db496ddeff0',
-  'transfer-encoding',
-  'chunked',
+  '1f41fa50686c9833c2a0da84cef404ae',
+  'Content-Length',
+  '370',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4QstpQvMRNKIAmzfGMQcgAZFB18AAAAAQUIPAAAAAAA9G9LV+Y3Vbj5vQxXJ+XKi; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rovvk8E1RLG4dhLnRlSa5aDWDV8AAAAAQUIPAAAAAAAcnibvenUaF5BC9cyn6b7G; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=eySYWDX4zBJGsfy5YMlkBAAAAACngl/qEr05OKj9hkGy2SaK; path=/; Domain=.contentful.com',
+  'nlbi_673446=pAW6UGVHvEy5tqpcKsJtVwAAAACXpd7i67D1+TWj7M3nS/CR; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=zR0eeN7wWyqq4lsGPWpmAwZFB18AAAAAUh+SkbWrKPl+smeVq3nmQg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=RHlfK1XWczQA9PlMOoVtA6DWDV8AAAAAJvqAg8TpNLM2Tcf+rgX2lA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86058100-86058111 NNNN CT(95 93 0) RT(1594311942450 31) q(0 0 2 -1) r(4 4) U5'
+  '13-20322459-20322468 NNNN CT(89 89 0) RT(1594742432237 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9819,15 +9819,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -9839,56 +9839,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:43 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:33 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'e31446d5a2f1a3bb1ebe4f03113e8eb6',
-  'X-Download-Options',
+  'd944676f0205147ae93b8f0436956683',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fLf+1PJHSgeJOVAA2qOoygdFB18AAAAAQUIPAAAAAAAJWyeI8nUvke3hVljbb7nw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=jlstKOAKQIG4zNVAt5hWyKHWDV8AAAAAQUIPAAAAAACtMxIb/IZ6t3f7GjiNHVf5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4sXlbYP362b+PfChYMlkBAAAAADwiuCrlu1eCB9NH3NDvoF4; path=/; Domain=.contentful.com',
+  'nlbi_673446=NRERW0/MhGpiWOaqKsJtVwAAAACNlTLkmuPDAFXCznGP4pya; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=99fNclfX4WLj4lsGPWpmAwdFB18AAAAAPKYfWzooQhD0BxJ+ljk7yg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/8obA85aGQGR9PlMOoVtA6HWDV8AAAAATxSEHYmMAcNCRZuHRVcCtg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9896,7 +9896,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86058273-86058283 NNYY CT(0 0 0) RT(1594311942912 28) q(0 0 0 -1) r(1 1) U5'
+  '10-8163414-8163420 NNYN CT(99 100 0) RT(1594742432871 26) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9912,8 +9912,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:41.377Z",
-    "updatedAt": "2020-07-09T16:25:43.910Z",
+    "createdAt": "2020-07-14T16:00:29.878Z",
+    "updatedAt": "2020-07-14T16:00:33.981Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9922,8 +9922,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-09T16:25:41.897Z",
-    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+    "publishedAt": "2020-07-14T16:00:30.418Z",
+    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -9988,9 +9988,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:43 GMT',
+  'Tue, 14 Jul 2020 16:00:34 GMT',
   'etag',
-  'W/"12092743357779974201"',
+  'W/"854256650927920123"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10000,29 +10000,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  'afa2c0f2ac1d8afd7e59bb1a98753550',
+  '2d9236aba9250c0585499eb2f76773af',
   'Content-Length',
-  '450',
+  '454',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=6JEaPP34TZapwK6d6LRRuwdFB18AAAAAQUIPAAAAAAAkmIT5QgMFtezdrijCVaMO; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mARuKgzRS+yLnuuXl84jC6HWDV8AAAAAQUIPAAAAAABxLi4bCSmkMY8/fUBt/HSY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=vjBJOlE4Qixqu0HOYMlkBAAAAADGxcZY2ZPhFan7tfoRYiJY; path=/; Domain=.contentful.com',
+  'nlbi_673446=afHYT0U4Bx5yaxPaKsJtVwAAAADjUJAHgxoixE4lQIWfFc4K; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=+Xc+In3XT2dI41sGPWpmAwdFB18AAAAAYb5c8QQySmBgnVy17AW/+A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=GbocL2HAOi8A9flMOoVtA6HWDV8AAAAAd30TKFsKj9nXstD3vTobeA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27145049-27145051 NNNY CT(0 0 0) RT(1594311943172 33) q(0 0 0 -1) r(2 2) U5'
+  '14-27004736-27004743 NNNN CT(94 97 0) RT(1594742433281 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10038,8 +10038,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:41.377Z",
-    "updatedAt": "2020-07-09T16:25:44.209Z",
+    "createdAt": "2020-07-14T16:00:29.878Z",
+    "updatedAt": "2020-07-14T16:00:34.458Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10048,8 +10048,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:44.209Z",
-    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+    "publishedAt": "2020-07-14T16:00:34.458Z",
+    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10114,9 +10114,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:44 GMT',
+  'Tue, 14 Jul 2020 16:00:34 GMT',
   'etag',
-  'W/"10568345880193897593"',
+  'W/"17196034623532127127"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10134,26 +10134,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '3aeec2fd779994e3748059f6928276c2',
+  'dc3ede0a328f16a30f5d1480446b14b7',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YOA3MacQQLGbaOn1X0YW7AdFB18AAAAAQUIPAAAAAACdb5MO/wLwmS1yf/W4mO9T; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=zpc3NAcGSLuFvFBUa4gHTKLWDV8AAAAAQUIPAAAAAAD4XhaW0em6p8wxcFVSIehP; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CSMeel1t/VZWhBwDYMlkBAAAAAAkW1kG5zDhZYfKTSGS18y7; path=/; Domain=.contentful.com',
+  'nlbi_673446=y05NQCS/DhYTcJhBKsJtVwAAAABWTcAW+K2ncRb1jDZIfXpR; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=dqShcPi0LHjN41sGPWpmAwdFB18AAAAApgWZWmTslRwqOFd6CjAaAA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3jfbH+2kxkeB9flMOoVtA6LWDV8AAAAAufwNAjmrdgA9S4NXWXUTaQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41053287-41053289 NNNY CT(0 0 0) RT(1594311943508 30) q(0 0 0 -1) r(2 2) U5'
+  '12-17405670-17405680 NNNN CT(93 96 0) RT(1594742433793 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[]})
-  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-09T16:25:41.965Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-09T16:25:45.474Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-14T16:00:30.513Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-14T16:00:35.152Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -10175,9 +10175,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:45 GMT',
+  'Tue, 14 Jul 2020 16:00:35 GMT',
   'etag',
-  '"164470994564451341"',
+  '"15152394975435498389"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10195,26 +10195,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '77f40772d3fa0c10b296aa42120f76de',
+  'ce90bc3f77df1c46fedcc972bff09cd0',
   'Content-Length',
   '880',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=yoVnRL0NTBCq89A7opW9PQhFB18AAAAAQUIPAAAAAABDNmiIKhiLNUbbkJewVXjw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=zxR/xCXhQ7qvrNqiN9LeOKLWDV8AAAAAQUIPAAAAAACzFxgCqfjkDsjR9h2CmFq4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CsFdD4zNbWOB92ncYMlkBAAAAACT8lAr88E8Np1/2R1Pb/Ga; path=/; Domain=.contentful.com',
+  'nlbi_673446=/MSNMuKKSTdEG7S1KsJtVwAAAACAiR7PZ2OCJ17Y2KG2xqIS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=3KflSJ6EmnoN5VsGPWpmAwhFB18AAAAA95E3eKgvOFbzMnDi5nfkjQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=XDBTPx5yUDws9vlMOoVtA6LWDV8AAAAAg3rP7z0tuUoCHhmNT8rf3Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27145182-27145188 NNNY CT(0 0 0) RT(1594311944748 33) q(0 0 0 -1) r(2 2) U5'
+  '4-9014074-9014079 NNNN CT(88 88 0) RT(1594742434484 35) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}]})
-  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-09T16:25:41.965Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-09T16:25:45.782Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-14T16:00:30.513Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-14T16:00:35.801Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -10236,9 +10236,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:45 GMT',
+  'Tue, 14 Jul 2020 16:00:35 GMT',
   'etag',
-  '"15680840757178577283"',
+  '"1836674219385494909"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10256,21 +10256,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'cc67c080b19994a4f55a3e8e1dd1690d',
+  '27d61c3e66984a0f9eca111bc9cbccc4',
   'Content-Length',
   '987',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FlZtZ41vSB+QG6CtBvbYjglFB18AAAAAQUIPAAAAAAA9zXcf2B75ZeHm+3O5dnKW; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YwRD8gtqQI6J2VKehjYasaPWDV8AAAAAQUIPAAAAAAB59WVtTHKjp01CKM8jPaxW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bYghH+fcaEUua5ihYMlkBAAAAAD4gGljo9EAqBfD9DoYS7yf; path=/; Domain=.contentful.com',
+  'nlbi_673446=HESsL5fGPG4b2PKpKsJtVwAAAABcN913ue9LicqIc6TzD/Sa; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=sPAYbJIFIXtO5VsGPWpmAwlFB18AAAAAvQrHXwp6jNeK+KHks/BGUw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=cF06Wd4z2W4V9/lMOoVtA6PWDV8AAAAAO2cW4xTQzoDqVF7QNCarRg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41053522-41053528 NNNY CT(0 0 0) RT(1594311945052 36) q(0 0 0 -1) r(2 2) U5'
+  '14-27005258-27005266 NNNN CT(91 89 0) RT(1594742435098 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10287,7 +10287,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10295,7 +10295,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:45.782Z",
+    "updatedAt": "2020-07-14T16:00:35.801Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10348,9 +10348,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:46 GMT',
+  'Tue, 14 Jul 2020 16:00:36 GMT',
   'etag',
-  '"5740236003190935857"',
+  '"15837268598995971550"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10360,23 +10360,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '71ae7561764a453e34e91fb89d12dfe7',
+  '2902406d9f48ed75a4852be5bd046277',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3bgK9aBVT7a6TfKmw52diglFB18AAAAAQUIPAAAAAAA6Zu4u3c1o8nTovxxJ2KJ/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=GWUwtFVORuurx0ud4B7uhKPWDV8AAAAAQUIPAAAAAADJuB/28ppbxq6iiFvwpF9A; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=++RZHufIMwNIfg0TYMlkBAAAAACfMoahRAPOzkiode0Xh2l9; path=/; Domain=.contentful.com',
+  'nlbi_673446=L75pe12yUAFqLJyGKsJtVwAAAADwU5/Z9UoJ7yFb6bPPqGfy; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=n4raM+r9rQt15VsGPWpmAwlFB18AAAAApTPjazj/pImI5Ku12Hu9VA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=A7qeEIYdT0+L9/lMOoVtA6PWDV8AAAAALIVwtyahFABiGRBcW4OFpw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10384,7 +10384,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66931612-66931620 NNYY CT(0 0 0) RT(1594311945333 25) q(0 0 0 -1) r(2 2) U5'
+  '14-27005410-27005414 NNYN CT(95 98 0) RT(1594742435617 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10409,8 +10409,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-09T16:25:41.377Z",
-        "updatedAt": "2020-07-09T16:25:44.209Z",
+        "createdAt": "2020-07-14T16:00:29.878Z",
+        "updatedAt": "2020-07-14T16:00:34.458Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -10419,8 +10419,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-09T16:25:44.209Z",
-        "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+        "publishedAt": "2020-07-14T16:00:34.458Z",
+        "firstPublishedAt": "2020-07-14T16:00:30.418Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -10487,9 +10487,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:46 GMT',
+  'Tue, 14 Jul 2020 16:00:36 GMT',
   'etag',
-  'W/"18203384032350722570"',
+  'W/"10849270469145892691"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10499,29 +10499,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'd355086962b2bdf5b152720ae615ffe3',
-  'transfer-encoding',
-  'chunked',
+  'eda89647889b39aaabdd4ba4b92bc350',
+  'Content-Length',
+  '525',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=d0zZXfakRMKZUD97EQQjgAlFB18AAAAAQUIPAAAAAAA979DKSSr8+1u1bAR2AWOq; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=bzVklE49R0OIyr0LJWc72aTWDV8AAAAAQUIPAAAAAAB5beg/1BP/p4VQ2P7XQuAY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WJwmPQVfZ0jWmfZlYMlkBAAAAABINzktTQnX/Cm9QhzsNYa2; path=/; Domain=.contentful.com',
+  'nlbi_673446=JxkpLVc1ckMUKy0lKsJtVwAAAACt+ZFQ/gnFIZHbfAd8ePku; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=ymFnXHO4GGXq5VsGPWpmAwlFB18AAAAAcPtLE2Vdx7zxwtnYE0dzYg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1lQPDhharxEd+PlMOoVtA6TWDV8AAAAA2jXpQmeDVXsNpKGqMaz/Nw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86058997-86059018 NNNN CT(88 94 0) RT(1594311945576 36) q(0 0 1 -1) r(3 3) U5'
+  '10-8163897-8163903 NNNN CT(93 93 0) RT(1594742436131 30) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10538,7 +10538,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10546,7 +10546,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:45.782Z",
+    "updatedAt": "2020-07-14T16:00:35.801Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10599,9 +10599,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:46 GMT',
+  'Tue, 14 Jul 2020 16:00:37 GMT',
   'etag',
-  '"5740236003190935857"',
+  '"15837268598995971550"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10611,23 +10611,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'eeda4647a2aad023e1afeb1622940d9e',
+  'd73423319c549b0cab63ac95b0cb2dfd',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=a48/ZiuZRqu1UeugpyjqugpFB18AAAAAQUIPAAAAAAAWD/wwjD9p/nGGv4zqxmMw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Ob++oSnLTQSkhBDjzQA/EqXWDV8AAAAAQUIPAAAAAAAd2TppK/Bu/Tzz8DrUVCAX; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bSZMFM42wRzFtjSZYMlkBAAAAABdDJT23hQVKW2QXxHACQBp; path=/; Domain=.contentful.com',
+  'nlbi_673446=Jp+9EqK94VCWUSA+KsJtVwAAAAA1t0ni4MD90bmAJ17YuIwP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=zCsyTUPOFBwi5lsGPWpmAwpFB18AAAAA7zZBrm/rSmtxQGQxEKl/Mg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Y0XpQ5qx/D6Z+PlMOoVtA6XWDV8AAAAAUx6Lbi1oe/yGW66VlkMGiQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10635,7 +10635,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86059127-86059144 NNYY CT(0 0 0) RT(1594311946040 30) q(0 0 0 -1) r(2 2) U5'
+  '13-20323590-20323603 NNYN CT(94 98 0) RT(1594742436735 36) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10676,15 +10676,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -10696,56 +10696,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:47 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:37 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'aaaba061a492c30be8ebb1f94963ec02',
-  'X-Download-Options',
+  '707a1e6185245e4fab58c9ba7feb7521',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ddxc+GqUT0yzzy+tmn1OOQpFB18AAAAAQUIPAAAAAABH7ocNwTmuBs3BUbLViQH0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=crCXehEoQiustGcPeFpMdKXWDV8AAAAAQUIPAAAAAADZduyiG3uL7WCRXmU3WSNI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=6bfpBDG3ql3k2IocYMlkBAAAAAD2aujorJkNMVeb2ZnsI/ZG; path=/; Domain=.contentful.com',
+  'nlbi_673446=3yTbVD298zc8XeJhKsJtVwAAAAAd5kX/VLOGglcJloX4ADjq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=xslmOi25aCdG5lsGPWpmAwpFB18AAAAAI4Gjs8t5E26nUj5xTX3RcA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=DAluPA6IjRb8+PlMOoVtA6XWDV8AAAAAWPMmxEKN1ccKXvwd1pLn6A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10753,7 +10753,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86059232-86059241 NNYY CT(0 0 0) RT(1594311946348 28) q(0 0 0 -1) r(1 1) U5'
+  '11-13779077-13779080 NNYN CT(85 86 0) RT(1594742437227 26) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10769,8 +10769,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:41.377Z",
-    "updatedAt": "2020-07-09T16:25:47.401Z",
+    "createdAt": "2020-07-14T16:00:29.878Z",
+    "updatedAt": "2020-07-14T16:00:38.470Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10779,8 +10779,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-09T16:25:44.209Z",
-    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+    "publishedAt": "2020-07-14T16:00:34.458Z",
+    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10845,9 +10845,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:47 GMT',
+  'Tue, 14 Jul 2020 16:00:38 GMT',
   'etag',
-  'W/"14139904167359079263"',
+  'W/"13334694213749400769"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10857,29 +10857,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '1dea22701040cbbf02d0b135ececa946',
+  'e539ce06f55bac72820697204e67a161',
   'Content-Length',
-  '464',
+  '462',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=CGiTYgHbS9Gcqk5qIuiW6ApFB18AAAAAQUIPAAAAAABYNA84juUu2LFegxdYbEsq; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=T9er0W/bQJaTwmP8t7LQDabWDV8AAAAAQUIPAAAAAABZ3mPu43hMdUlrxBy9wDfx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=efWuFFXOh0lREdv0YMlkBAAAAAD4FrXGrnbIPxTb0gLnJ7G8; path=/; Domain=.contentful.com',
+  'nlbi_673446=IvGQF12yDHHza8HnKsJtVwAAAAA+IYTAk4uXpzuJz6WnHbqX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=skqYM5cd+BO55lsGPWpmAwpFB18AAAAAvSwYvT7lVT4VzmyzqJgf2g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=E3pWdP9pkgK4+flMOoVtA6bWDV8AAAAAXRE6LB1MJs3Vb0+rS7sxFQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41053694-41053698 NNNY CT(0 0 0) RT(1594311946654 36) q(0 0 0 -1) r(2 2) U5'
+  '12-17406609-17406615 NNNN CT(92 93 0) RT(1594742437677 24) q(0 0 1 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10895,8 +10895,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:41.377Z",
-    "updatedAt": "2020-07-09T16:25:48.040Z",
+    "createdAt": "2020-07-14T16:00:29.878Z",
+    "updatedAt": "2020-07-14T16:00:39.059Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10905,8 +10905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-09T16:25:48.040Z",
-    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+    "publishedAt": "2020-07-14T16:00:39.059Z",
+    "firstPublishedAt": "2020-07-14T16:00:30.418Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10971,9 +10971,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:48 GMT',
+  'Tue, 14 Jul 2020 16:00:39 GMT',
   'etag',
-  'W/"15968548495450935525"',
+  'W/"13656252347462647717"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10983,29 +10983,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  'dd769b87822c1d8f1b2af34d4c1b511b',
+  '2d05768074ca20815163a9e44e2d90d5',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=v6LWldsVSviSnByUmip8OwtFB18AAAAAQUIPAAAAAADRsK3js7ARrwwSiFsfl2GV; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SOcAZ6CKSUuJGrYuG+UMZKbWDV8AAAAAQUIPAAAAAABctIE/Lx74kO6NEnTgOaji; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XcYMM+oSuhbX+TmIYMlkBAAAAAApaoKtJuZgR5wwpikxVlJQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=yMDhT3duvimbq3BaKsJtVwAAAABkG9gZyW7ZaNDMzH0MvHXa; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=C/waIBKyOzWD51sGPWpmAwtFB18AAAAAXywOWu7Z1ETc3+CAFX9A2Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=qv73aPwoMUBo+vlMOoVtA6bWDV8AAAAAvKW1jdN5OkSWlxVqErLCJw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-27376821-27376825 NNNN CT(86 87 0) RT(1594311947162 26) q(0 0 2 -1) r(4 4) U5'
+  '14-27006284-27006293 NNNN CT(107 95 0) RT(1594742438382 34) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11032,7 +11032,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11040,7 +11040,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:48.396Z",
+    "updatedAt": "2020-07-14T16:00:40.068Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11088,9 +11088,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:48 GMT',
+  'Tue, 14 Jul 2020 16:00:40 GMT',
   'etag',
-  'W/"12897938895799238249"',
+  'W/"3859509757060937986"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11100,29 +11100,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '972dc895b46e376bef8bb0f83c801fd0',
-  'transfer-encoding',
-  'chunked',
+  '30c6651bb0189021329c458409022b06',
+  'Content-Length',
+  '421',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=XUs0+2bRReSX7SFzmRio2gtFB18AAAAAQUIPAAAAAAA4rYmrFINOR6Q1Su4RynH0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=On9OlifOS2OIAtLXUjK2HafWDV8AAAAAQUIPAAAAAAAvwdRa6kBiXrVPLNgnD1bJ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RT9VcZEtZRu7qjcIYMlkBAAAAACQ6SdrHoSkHaHQXOCa1bAU; path=/; Domain=.contentful.com',
+  'nlbi_673446=XLVTYNqHpV+JYcdnKsJtVwAAAACD9ew0gw+MB+pEFoIXv2eW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=B4egBrNSdG/X51sGPWpmAwtFB18AAAAA73TLQCA7H+LZIbzZdSLTXQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=2j82DjotymZQ+/lMOoVtA6fWDV8AAAAAXgw+K8DH+ZZqLwLFUL5dVw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86059650-86059659 NNNY CT(0 0 0) RT(1594311947682 27) q(0 0 0 -1) r(1 1) U5'
+  '11-13779327-13779339 NNNN CT(86 175 0) RT(1594742439191 35) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11139,7 +11139,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-09T16:25:41.965Z",
+    "createdAt": "2020-07-14T16:00:30.513Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11147,7 +11147,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:48.396Z",
+    "updatedAt": "2020-07-14T16:00:40.068Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11205,9 +11205,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:48 GMT',
+  'Tue, 14 Jul 2020 16:00:40 GMT',
   'etag',
-  'W/"11422179183294694942"',
+  'W/"6791806466301085612"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11217,29 +11217,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '436e908cd1f5f64269fe20d1b48a0961',
+  '0cb4f57e2b0bac6b2483225c28244bd1',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=2PwWjhSqT9uupD06bTc5MQxFB18AAAAAQUIPAAAAAADQlt4f9pUU2PXgAqgVvkJR; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vDHmBAB3TkigYYWRanHa/KjWDV8AAAAAQUIPAAAAAAD3OAgIxVjz0PNS+UmCTgvv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4ZOXACa6bnAzwSZOYMlkBAAAAABLQAUZanSZzNDxXQwSQxse; path=/; Domain=.contentful.com',
+  'nlbi_673446=NzwjY/jC+Esm8qpaKsJtVwAAAABH3N9wx5+9Eu1wLMPrP796; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=1m2fE/h5iTk/6FsGPWpmAwxFB18AAAAAoACXbFITLTvWirx7dxy0VA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=G2bGa5j9vjrt+/lMOoVtA6jWDV8AAAAA0WyD/o74K3vzvCJvJLcVqg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66932232-66932239 NNNY CT(0 0 0) RT(1594311947986 37) q(0 0 0 -1) r(1 1) U5'
+  '14-27006733-27006752 NNNN CT(94 95 0) RT(1594742439911 44) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11276,7 +11276,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:49 GMT',
+  'Tue, 14 Jul 2020 16:00:41 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -11288,23 +11288,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '3a30d6d8ea9b02729469a134ffd84332',
+  '7d7ae1fd6721ef698d02fbf5034c1fd5',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Sr9h+yVgR5Gj5xo+bHcDIAxFB18AAAAAQUIPAAAAAABRAYcfMs3niveA0w77vR5G; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YnFNJDrJQ+mmC9J2bQM1U6jWDV8AAAAAQUIPAAAAAACZlH7sLhesKaMIPXQXwjRy; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=y3g9R6z7vQ6DMH+1YMlkBAAAAACo6twvkAHU7e0XxMWCejYB; path=/; Domain=.contentful.com',
+  'nlbi_673446=bfOAFJGcwSe5XFhDKsJtVwAAAAAkFPJXI5c6HXDhEbU76dDO; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=srllJ/IyxkuN6FsGPWpmAwxFB18AAAAAIXyk5wj7o3eC+mmWR5r5tg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=chCODLg1+mGT/PlMOoVtA6jWDV8AAAAAOUZynaXaeXpxd47Br8axHQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11312,7 +11312,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-20702034-20702036 NNYY CT(0 0 0) RT(1594311948295 34) q(0 0 0 -1) r(1 1) U5'
+  '13-20324575-20324581 NNYN CT(98 100 0) RT(1594742440555 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11329,7 +11329,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "11db998bd87bab9772ef718e2c0d7a57"
+  "requestId": "68d305ba68ce7a4e228c7a1343716a77"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -11353,9 +11353,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:49 GMT',
+  'Tue, 14 Jul 2020 16:00:41 GMT',
   'etag',
-  '"12748295005095661981"',
+  '"8464795426721667471"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11365,23 +11365,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '11db998bd87bab9772ef718e2c0d7a57',
+  '68d305ba68ce7a4e228c7a1343716a77',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YOIwEzYgSxO7SXuzBXmfegxFB18AAAAAQUIPAAAAAAAKRMlVbYw82wm3w+6TKuUh; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FItN/2pYSNGr/KcBjQGjCqnWDV8AAAAAQUIPAAAAAACPyECBP10hLKOdHAworgtA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=UWpfSGoA/GaSee42YMlkBAAAAACJGUcAbwazgcVxy3sCLIlt; path=/; Domain=.contentful.com',
+  'nlbi_673446=nEwPP1lRYmwPyE3QKsJtVwAAAAAFuyv0x4lGq4sfnOo5UJXu; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=QP62JAGzTi3g6FsGPWpmAwxFB18AAAAAKYoRd2jTrVXNPz06Dpnbqg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=YhKAFNvBzBYa/flMOoVtA6nWDV8AAAAArK0hgtu0GGQJZpxTT1eeQw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11389,7 +11389,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '7-27376931-27376936 NNYY CT(0 0 0) RT(1594311948600 29) q(0 0 0 -1) r(1 1) U5'
+  '4-9014683-9014685 NNYN CT(88 89 0) RT(1594742441141 27) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11430,15 +11430,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -11450,56 +11450,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:49 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:42 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'b8c6e52183eb166811925687f293657e',
-  'X-Download-Options',
+  '5a8ed060348bc9cb03da373f4e1950d5',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=CZKoaI4/QpC0NuYsNkjLPQ1FB18AAAAAQUIPAAAAAAAA5+bdC4hjqNTo73Nk81c4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=z2nvAtTxSPi0JY78Z8/PtqrWDV8AAAAAQUIPAAAAAACuyxgJI8hsZAdyTcr7XYYw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4SdlWySBeCquPSh7YMlkBAAAAAAjPohrRVKjBL89YhISbFTU; path=/; Domain=.contentful.com',
+  'nlbi_673446=mQT5NyJHXFa5Ba1IKsJtVwAAAADn2srJooGptCzR0Ovf03oF; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=l7kaHz/CvAFI6VsGPWpmAw1FB18AAAAA2v1kEzQIbyeC/2aFuCQueg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=tIfeMBiED2a2/flMOoVtA6rWDV8AAAAAfP1x4gyGACKFWNdFszF9BQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11507,12 +11507,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66932423-66932430 NNYN CT(94 108 0) RT(1594311948907 32) q(0 0 2 -1) r(3 3) U5'
+  '11-13779920-13779922 NNYN CT(86 88 0) RT(1594742441787 30) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/customSidebar', {"name":"Custom sidebar","fields":[],"description":"How to add, remove and update widgets"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-09T16:25:50.343Z","updatedAt":"2020-07-09T16:25:50.343Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-14T16:00:43.116Z","updatedAt":"2020-07-14T16:00:43.116Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -11534,9 +11534,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:50 GMT',
+  'Tue, 14 Jul 2020 16:00:43 GMT',
   'etag',
-  '"16071230911097891680"',
+  '"7387142411929750360"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11546,29 +11546,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '824d39188323cd87b2087374e841fb9b',
+  'd3cd5aea114da5173dab30b20c8790bd',
   'Content-Length',
   '882',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NfstNlktTgWNMi0jbhjODw1FB18AAAAAQUIPAAAAAABVBOvvLuiJC3nqmQN8sFzH; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sTzgawnmQTWo/5bhA028q6rWDV8AAAAAQUIPAAAAAABna803mK+UDqrificw7B3H; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bmt/QZChfj17h5RQYMlkBAAAAADJsF2ACwEXloXxNnaypQbT; path=/; Domain=.contentful.com',
+  'nlbi_673446=lKrQB1hofUVuV0vOKsJtVwAAAAABrg3wHSzCErNG1dqMiH3X; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=46vmcrJCgzv16VsGPWpmAw1FB18AAAAAzwMpiNWGQ6qty8cTAJ81QA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Y0xDSXHNhw6X/vlMOoVtA6rWDV8AAAAAPtJJt5uGAi4bEJ//Kdvv4g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55402552-55402566 NNNN CT(85 86 0) RT(1594311949418 35) q(0 0 2 -1) r(4 4) U5'
+  '13-20325012-20325025 NNNN CT(86 87 0) RT(1594742442379 32) q(0 0 1 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11584,8 +11584,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "customSidebar",
     "type": "ContentType",
-    "createdAt": "2020-07-09T16:25:50.343Z",
-    "updatedAt": "2020-07-09T16:25:50.795Z",
+    "createdAt": "2020-07-14T16:00:43.116Z",
+    "updatedAt": "2020-07-14T16:00:43.752Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -11609,8 +11609,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-09T16:25:50.795Z",
-    "publishedAt": "2020-07-09T16:25:50.795Z",
+    "firstPublishedAt": "2020-07-14T16:00:43.752Z",
+    "publishedAt": "2020-07-14T16:00:43.752Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -11649,9 +11649,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:50 GMT',
+  'Tue, 14 Jul 2020 16:00:43 GMT',
   'etag',
-  'W/"15928841085311407481"',
+  'W/"10531551812988891727"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11661,29 +11661,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'a82ba50348a7df62c941bafde52a3c19',
-  'transfer-encoding',
-  'chunked',
+  'b2580325890e8241cd75c36f41d40c72',
+  'Content-Length',
+  '387',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=UPlP9SQbQcypBUef7mhpKA5FB18AAAAAQUIPAAAAAADovHmzgJTeAMYDUlhQDB7J; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=5Nj9/3XmQlGb4FkRkgFhuavWDV8AAAAAQUIPAAAAAAA0Bw2jecjpfjEgIdU84xAe; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CAavesWlGEwSU70EYMlkBAAAAACv7C0CEWhGYG0VAMAjoFBj; path=/; Domain=.contentful.com',
+  'nlbi_673446=Rt/OYrzAegfKyXGZKsJtVwAAAAAblZ4H9zG5kVGfI/WOoMfB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=yoXNWfYz2jxj6lsGPWpmAw5FB18AAAAA3HiJGDtW1WSX3PdxI9Gg5Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=qHkXBJfLfQgx//lMOoVtA6vWDV8AAAAATcE1AzqdHSxPzayvMtLcmA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86060439-86060448 NNNY CT(0 0 0) RT(1594311950028 31) q(0 0 0 -1) r(3 3) U5'
+  '3-6345453-6345454 NNNN CT(94 90 0) RT(1594742443081 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11724,7 +11724,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-09T16:25:50.869Z",
+    "createdAt": "2020-07-14T16:00:43.831Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11732,7 +11732,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:51.346Z",
+    "updatedAt": "2020-07-14T16:00:45.389Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11780,9 +11780,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:51 GMT',
+  'Tue, 14 Jul 2020 16:00:45 GMT',
   'etag',
-  'W/"3520669431517539200"',
+  'W/"2482464552590765206"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11800,21 +11800,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '15fd7617ebb27799e8534b5233758765',
+  'af312b889f8312fbe9733d2dde1e35c1',
   'Content-Length',
   '461',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=rUoB4YUyR96Kxsd7gxz4ZA5FB18AAAAAQUIPAAAAAAAQ5kI1y6fZ2WXCbxLNoWib; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fdDt6IDeR6W5uqt+cikJGq3WDV8AAAAAQUIPAAAAAAA1uRVXusTMqu6iy8Y08G1S; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=DUcuXgHzWWc6vM4pYMlkBAAAAADEKJkp9024um8cYK68YR02; path=/; Domain=.contentful.com',
+  'nlbi_673446=kuqML+yhI3BjamjUKsJtVwAAAAC9iJ3HjgivC7BwCXblqgA5; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Wm5CJ/69NhrG6lsGPWpmAw5FB18AAAAA4bzo4aMrrCtWKjcoE7J0KA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=QsuEY/W9OSfWAPpMOoVtA63WDV8AAAAA5A4Px3jFp+mgPZumd6+E4g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41054200-41054202 NNNN CT(88 95 0) RT(1594311950438 29) q(0 0 2 -1) r(4 4) U5'
+  '10-8165076-8165091 NNNN CT(93 94 0) RT(1594742444703 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11855,7 +11855,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 3,
-    "createdAt": "2020-07-09T16:25:50.869Z",
+    "createdAt": "2020-07-14T16:00:43.831Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11863,7 +11863,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:51.683Z",
+    "updatedAt": "2020-07-14T16:00:46.032Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11911,9 +11911,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:51 GMT',
+  'Tue, 14 Jul 2020 16:00:46 GMT',
   'etag',
-  'W/"17904900338714515033"',
+  'W/"7655125878187309121"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11931,21 +11931,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'c74c500ca22b2b01007c8a92b6ec907e',
-  'transfer-encoding',
-  'chunked',
+  'acafc61738a0e4e60c8d9e58c67bc12b',
+  'Content-Length',
+  '461',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=uTZ6+qE0ThWFVBfCEYvGeA9FB18AAAAAQUIPAAAAAACg5paf5/k+6hZGfmhKlnUW; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=b66eXn4oS8yzpEolIkH5AK3WDV8AAAAAQUIPAAAAAADzYuUjimzcxKc6qQLICM7F; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TqU7KygdZHJJlsFaYMlkBAAAAADE4dLyBLc4jh5SHDI0paof; path=/; Domain=.contentful.com',
+  'nlbi_673446=h8xvevImHFt6pyZ5KsJtVwAAAACqchDcgK1+orXOaOwwCzo7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=kbVpJ/qiPDAs61sGPWpmAw9FB18AAAAAuW1OvitVpBWrPVTc4ItNyw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0t62THh7KDYDAvpMOoVtA63WDV8AAAAAdTN5VXZQNWUSxr5MImHS3w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66932884-66932892 NNNY CT(0 0 0) RT(1594311950962 34) q(0 0 0 -1) r(2 2) U5'
+  '14-27008259-27008270 NNNN CT(97 97 0) RT(1594742445215 39) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11986,7 +11986,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-09T16:25:50.869Z",
+    "createdAt": "2020-07-14T16:00:43.831Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11994,7 +11994,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:52.201Z",
+    "updatedAt": "2020-07-14T16:00:46.514Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12042,9 +12042,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:52 GMT',
+  'Tue, 14 Jul 2020 16:00:46 GMT',
   'etag',
-  'W/"8991075568487977346"',
+  'W/"344986861367895499"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12062,21 +12062,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b2014fc79500d0fed8584337e20c2063',
-  'transfer-encoding',
-  'chunked',
+  '606baf6261cdbaf6d9efb3a38738ef41',
+  'Content-Length',
+  '461',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=gAKcwhKtQV+Q+sJ8QllpBw9FB18AAAAAQUIPAAAAAAAyIZMpNWOYwSw9qXbFMseS; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=aW94RbaRQiaOUfM3J9ilda7WDV8AAAAAQUIPAAAAAADXb1m9z8WjwYlQKtD5E5GY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NVIiMUtS1jLpCJPZYMlkBAAAAABC8O7InFpLmXnUjie3/BCf; path=/; Domain=.contentful.com',
+  'nlbi_673446=fsbfXt+MnxqBJbYBKsJtVwAAAACSNOp0R5SMPPEHoGe/NI8t; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=FYwyNwLcTWuy61sGPWpmAw9FB18AAAAA2oisIkOcSimcp+NKBeMgYQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=2unoSQpIw1u1AvpMOoVtA67WDV8AAAAAJRtaI2HvrLR6pnBzs9GkPg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26743437-26743438 NNNY CT(0 0 0) RT(1594311951472 30) q(0 0 0 -1) r(1 1) U5'
+  '10-8165271-8165284 NNNN CT(93 95 0) RT(1594742445837 27) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12117,7 +12117,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-09T16:25:50.869Z",
+    "createdAt": "2020-07-14T16:00:43.831Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12125,7 +12125,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:52.571Z",
+    "updatedAt": "2020-07-14T16:00:47.108Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12173,9 +12173,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:52 GMT',
+  'Tue, 14 Jul 2020 16:00:47 GMT',
   'etag',
-  'W/"8667122013226520874"',
+  'W/"6499892780095129292"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12193,21 +12193,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'c12d53c54f4e1919ce358d18ac750076',
+  '1e6ecd55ad8c9193eafc5efe873f2d01',
   'Content-Length',
-  '460',
+  '461',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=RqhVb9xWRb6zYWKYBT53jxBFB18AAAAAQUIPAAAAAAC0gao9138yaXQv1RGZd3gn; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=CFtzQI2RQlGhqSL4QoyGzK7WDV8AAAAAQUIPAAAAAAAdZWAm8d6Kv5PUXy+5kZVK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=nIWFGzihFSmuJCSBYMlkBAAAAABZZW48Se9WG+XJMrcSZb1h; path=/; Domain=.contentful.com',
+  'nlbi_673446=MmwjOoxuVzaq3D2wKsJtVwAAAABamVCXEE8Vz1UKe/B0BV7U; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=ELXgGzaATWMQ7FsGPWpmAxBFB18AAAAAlqp4QQl0M+NPhWluRKmd/Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ut93HuEz5m1ZA/pMOoVtA67WDV8AAAAAO7sjBT7G8al9/V8D9+4AxA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66933163-66933170 NNNY CT(0 0 0) RT(1594311951776 28) q(0 0 0 -1) r(2 2) U5'
+  '14-27008599-27008613 NNNN CT(86 87 0) RT(1594742446358 33) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12242,7 +12242,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-09T16:25:50.869Z",
+    "createdAt": "2020-07-14T16:00:43.831Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12250,7 +12250,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:52.990Z",
+    "updatedAt": "2020-07-14T16:00:47.669Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12298,9 +12298,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:53 GMT',
+  'Tue, 14 Jul 2020 16:00:47 GMT',
   'etag',
-  'W/"18044677227004125461"',
+  'W/"7549707802854929659"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12310,29 +12310,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '403f7baf4dc39cd6fb645776de5d10c5',
-  'transfer-encoding',
-  'chunked',
+  '49fac64db3e645b3be8d6dcb5d1c8a7f',
+  'Content-Length',
+  '449',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=y1Rup8TpScSTEAAE9DpZghBFB18AAAAAQUIPAAAAAADgZy4IQdp6bs9EYzrY4uu0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/7YyC9T+RUGISVXy7CCwQK/WDV8AAAAAQUIPAAAAAAA/WRPlIgIN/7FG0cE3RxqQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=19wAJoHccCngSMxkYMlkBAAAAADVK7ai9NoqWwnN6QVKAJ53; path=/; Domain=.contentful.com',
+  'nlbi_673446=0BucTNOROwmlRz4FKsJtVwAAAADPh6EDNinG3B71c/uX4NNk; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=M+pdacM9oSSe7FsGPWpmAxBFB18AAAAAuMkFsiNYVSaVl0Bk4PKmzQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=pKw2cIGQg3XfA/pMOoVtA6/WDV8AAAAA7bJdfm4/xwAbiV/teoQpUA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-13875815-13875818 NNNY CT(0 0 0) RT(1594311952280 30) q(0 0 0 -1) r(1 1) U5'
+  '14-27008802-27008812 NNNN CT(96 95 0) RT(1594742446992 36) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12349,7 +12349,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-09T16:25:50.869Z",
+    "createdAt": "2020-07-14T16:00:43.831Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12357,7 +12357,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:52.990Z",
+    "updatedAt": "2020-07-14T16:00:47.669Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12423,9 +12423,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:54 GMT',
+  'Tue, 14 Jul 2020 16:00:48 GMT',
   'etag',
-  'W/"10874627288313817418"',
+  'W/"12305616659862115590"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12443,21 +12443,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bb73e94b0739d2e9154d6f905452865b',
-  'Content-Length',
-  '435',
+  '0d999dd39e75a2df282b6c5f77be8ba6',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NYu4KMrlQcmx4BFtyct0ixJFB18AAAAAQUIPAAAAAAApZVPaQP4Q7qIQkDOJX7Zj; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=zIou199FQfK4YE5r9ZRWXK/WDV8AAAAAQUIPAAAAAACKgNYyCottj8IQTCxaaiB0; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=1I15QGKIqA7Bqhl5YMlkBAAAAADh127TVeDIuKk3QfYMKj25; path=/; Domain=.contentful.com',
+  'nlbi_673446=5VfAVdmwjwFG5zgOKsJtVwAAAABYn0ilXdvkTCNaIKGGzAF2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=lzeFLBmSe0eB7lsGPWpmAxJFB18AAAAAhJ+vYIY02WfeloELdnKijg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/nkYC99lfU1VBPpMOoVtA6/WDV8AAAAAIlh5L2V2zIioh3L2dCse6g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26743573-26743576 NNNY CT(0 0 0) RT(1594311952600 28) q(0 0 0 -1) r(17 17) U5'
+  '11-13780889-13780896 NNNN CT(98 99 0) RT(1594742447493 35) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12542,7 +12542,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:55 GMT',
+  'Tue, 14 Jul 2020 16:00:48 GMT',
   'etag',
   'W/"9102674631899357591"',
   'Server',
@@ -12554,29 +12554,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '988eb93f5a35970b46986cf483e6baa7',
+  '92bef8e3b0a6f59b975cba34c08c37a5',
   'Content-Length',
   '375',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=q9XOBYCXRXOb8DoZKFw0oxJFB18AAAAAQUIPAAAAAAA2MQ2bWogz+1gA3bV26Tpr; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=GoKMLXDFSvKxuGPFv1+sWbDWDV8AAAAAQUIPAAAAAAAGVS9CEdSGZXpXb9fkz+Yk; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=28e5eVZr6QqKbVHWYMlkBAAAAACFfpQpjPWQVwjA9klNeTIQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=qM2EYTD4MAuzL1bDKsJtVwAAAAD7EmxNlFdEB7h07tyOAclm; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Lb5hVnfWznbD7lsGPWpmAxJFB18AAAAALg/iT5b2sRfd/781tQZXCQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=zlOZLDkM6UHKBPpMOoVtA7DWDV8AAAAA5mHftDWO/pzVXC7UZE3v8w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-42743642-42743652 NNNY CT(0 0 0) RT(1594311954439 38) q(0 0 0 -1) r(2 2) U5'
+  '5-13531135-13531146 NNNN CT(88 87 0) RT(1594742448007 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12617,15 +12617,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -12637,56 +12637,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:55 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:49 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '37ee1db700f8d9edc76e30c4189b6964',
-  'X-Download-Options',
+  '47b814f6947c0d248062268ac41f8f4b',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=d0oOfp0USdqs+ywkAznTKxJFB18AAAAAQUIPAAAAAACjCkUxD4r+3dbPXgrakN9y; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=hpO70gvVRIufZNEpMq1ABrDWDV8AAAAAQUIPAAAAAADUp15JxwjlXyxvGbO39LUB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=QYV2NwauV1Q4z9U2YMlkBAAAAAAMXK1C9/RMRmaFvpbtv+bt; path=/; Domain=.contentful.com',
+  'nlbi_673446=qSI/JIt/nA71OcoxKsJtVwAAAADaujKPZVrXya3Ejps11mIT; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=EerPeUT1ykb07lsGPWpmAxJFB18AAAAAX+crnyYHowQFbRpr7riB9w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=RX/tKBn+tn0sBfpMOoVtA7DWDV8AAAAA31Ozf0oNLsLf64ZK7+zdhA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -12694,7 +12694,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-41054766-41054773 NNYY CT(0 0 0) RT(1594311954738 29) q(0 0 0 -1) r(1 1) U5'
+  '9-5259612-5259618 NNYN CT(100 99 0) RT(1594742448445 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12754,7 +12754,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:55.871Z",
+    "updatedAt": "2020-07-14T16:00:49.773Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12802,9 +12802,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:55 GMT',
+  'Tue, 14 Jul 2020 16:00:49 GMT',
   'etag',
-  'W/"12171348567539028359"',
+  'W/"16455332812432625297"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12814,29 +12814,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  '47bc0925fe7af7f49d0d73766522998b',
-  'transfer-encoding',
-  'chunked',
+  '9cbe2e4001f27d43c27f9e5837f8e6e2',
+  'Content-Length',
+  '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3n1xJDmiSiGlBZWncsOtHhNFB18AAAAAQUIPAAAAAADOkaCJDPQWSFYCiyl/zZHz; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vSmK3CBtSSqslBQjt+DXdbHWDV8AAAAAQUIPAAAAAAAuglF1HrfCHy9zoLvMNXAS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=MFK/RThSTBFCWBq8YMlkBAAAAAD/EEKzn9BqtSU+eKIB7Xuw; path=/; Domain=.contentful.com',
+  'nlbi_673446=AjwVFq/QPGKlnxunKsJtVwAAAACrAoX4i7t44n3wMYayhdqX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=0qd3Xh9Qyk1571sGPWpmAxNFB18AAAAAjo9bM0v0xPNl5gM4dtpUxw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=kv9Tev+xGn/QBfpMOoVtA7HWDV8AAAAASKOtANeZdy3CPpoehqRaeA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86061911-86061925 NNNY CT(0 0 0) RT(1594311955148 39) q(0 0 0 -1) r(2 2) U5'
+  '14-27009426-27009433 NNNN CT(87 179 0) RT(1594742449022 33) q(0 0 3 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12896,7 +12896,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:56.315Z",
+    "updatedAt": "2020-07-14T16:00:50.308Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12944,9 +12944,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:56 GMT',
+  'Tue, 14 Jul 2020 16:00:50 GMT',
   'etag',
-  'W/"8087280609649312617"',
+  'W/"3525807837851847895"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12964,21 +12964,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f63615b3f6bbab0298877310e342b378',
+  '85f9e3bb28cddee8bf62a33b88d3b9aa',
   'Content-Length',
   '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=DFKc6/DdSOudJnlTzRIw8RNFB18AAAAAQUIPAAAAAAA+289jRivEiysXH765RnPM; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=C38tHGtDTGy2vRDd1QBLRbLWDV8AAAAAQUIPAAAAAAAfT63sAdwryO434CKNe+aX; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=C/fYEaxk8hOr65sVYMlkBAAAAAAsJzGfVeuQlXa8tsPn8//a; path=/; Domain=.contentful.com',
+  'nlbi_673446=ayGrEejbLwGNC9yDKsJtVwAAAAB4N1dPFBjmml/50qVW1HOd; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=67bgXTvW+BLd71sGPWpmAxNFB18AAAAAPNEHtag87OaIivefTYH2pA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=vInWZ+CvE2pBBvpMOoVtA7LWDV8AAAAAtWWKzNR3IKne6FL1Gez1rw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27145819-27145822 NNNN CT(88 88 0) RT(1594311955418 31) q(0 0 2 -1) r(3 3) U5'
+  '14-27009592-27009608 NNNN CT(95 95 0) RT(1594742449631 33) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13038,7 +13038,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:59.137Z",
+    "updatedAt": "2020-07-14T16:00:51.119Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13086,9 +13086,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:59 GMT',
+  'Tue, 14 Jul 2020 16:00:51 GMT',
   'etag',
-  'W/"11334213927273169520"',
+  'W/"11550344503687094556"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13098,29 +13098,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'c460325ba19e70ec0bb4075f87f16aeb',
+  '18daa1924ddb54df1c4e43ce402d0928',
   'Content-Length',
   '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=8QV8enFHSEOJBxEFOG3EpxZFB18AAAAAQUIPAAAAAAAEKclum9lsZl1zwI52fv+M; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lyCiSGJmRuG/xVBVYWYgvrLWDV8AAAAAQUIPAAAAAAC9NbqJPzGd7cTLpmKlaf7R; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SSgRX2QM5DSCSWnFYMlkBAAAAAC9GS4R2fHLY/qWyN8oUbLF; path=/; Domain=.contentful.com',
+  'nlbi_673446=/2GEHlsvak5z0SK0KsJtVwAAAAAsmPSOyfk/pn5ojqODJFYh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=8S7wUqeI03yW8lsGPWpmAxZFB18AAAAA7SQypoWRMk/JXe7pSA9SUw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=VfhiN72bXBmOB/pMOoVtA7LWDV8AAAAA6jtvHHE+mDc0DdwygVRGSw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-20702526-20702529 NNNY CT(0 0 0) RT(1594311958418 27) q(0 0 0 -1) r(2 2) U5'
+  '13-20327131-20327141 NNNN CT(97 97 0) RT(1594742450249 33) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13180,7 +13180,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:59.578Z",
+    "updatedAt": "2020-07-14T16:00:51.727Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13228,9 +13228,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:59 GMT',
+  'Tue, 14 Jul 2020 16:00:51 GMT',
   'etag',
-  'W/"2400676016350313103"',
+  'W/"107759787027299487"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13240,29 +13240,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'e6c298cabe3867ecccfb20f24f2e8126',
-  'transfer-encoding',
-  'chunked',
+  '972abc471f40cb5a5e5fd73077394e0f',
+  'Content-Length',
+  '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=dAuN0g7RS5aIdOtn9RTYVRdFB18AAAAAQUIPAAAAAACWN1kFTPQAyOaHZQgn75FY; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Xbto6qZxRECOj2VmkoZvZ7PWDV8AAAAAQUIPAAAAAAB88rWzGGwvjYKQQN18IL5U; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zANXfae1wh9+lKylYMlkBAAAAAC5Z0HSzU6MwTennjeE4LGh; path=/; Domain=.contentful.com',
+  'nlbi_673446=udGbb7v3RFPJHAy3KsJtVwAAAAC6kfLQWyktWrlJB6NuS+2+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=+Sm2ILsF+wMN81sGPWpmAxdFB18AAAAA01JG/EasW+5TQJru6wxypA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+aSIFIeumytuCPpMOoVtA7PWDV8AAAAAixtFzInuyZGidLXwCfcA/Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-26744199-26744205 NNNY CT(0 0 0) RT(1594311958854 29) q(0 0 0 -1) r(2 2) U5'
+  '8-2536479-2536480 NNNN CT(85 86 0) RT(1594742451085 31) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13316,7 +13316,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:59.947Z",
+    "updatedAt": "2020-07-14T16:00:52.345Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13364,9 +13364,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:25:59 GMT',
+  'Tue, 14 Jul 2020 16:00:52 GMT',
   'etag',
-  'W/"4114434414238587969"',
+  'W/"10720502177319649590"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13376,29 +13376,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '706d303d82738b781e1e386597ca2e95',
+  'e0c626065cd19438f49327f41cbf9615',
   'Content-Length',
   '524',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nGbLUHTNT9uQbBigqkAEYxdFB18AAAAAQUIPAAAAAAB/BxcqeB5l78L7QH9xt/e6; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Yiq4OlLwT16DUOmGwEI0r7TWDV8AAAAAQUIPAAAAAACwDCV8FE7FzHmoQsZ0h8kU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LWnfHTMgbV94MlEeYMlkBAAAAAB1l4y9m0jfAMzLb2CFG6MW; path=/; Domain=.contentful.com',
+  'nlbi_673446=VH40CIFl5lskt5dYKsJtVwAAAACi57WNzkf1unYLQApo0Kpi; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=dVXbPs5mTlVS81sGPWpmAxdFB18AAAAAzShExcdlb/BP5ePLRQkhbQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Y5bFeCoJq3ICCfpMOoVtA7TWDV8AAAAAPsCn4YsgB4oIMzV+6ZcNiA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-66934914-66934921 NNNY CT(0 0 0) RT(1594311959224 33) q(0 0 0 -1) r(2 2) U5'
+  '3-6346023-6346026 NNNN CT(87 88 0) RT(1594742451689 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13423,7 +13423,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-09T16:25:59.947Z",
+    "updatedAt": "2020-07-14T16:00:52.345Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -13500,9 +13500,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:00 GMT',
+  'Tue, 14 Jul 2020 16:00:52 GMT',
   'etag',
-  'W/"10418961072770146335"',
+  'W/"11545231734773879195"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13512,29 +13512,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '849a870d4b3bfed5360134f1829837a8',
+  '393c4ae688b081a3697ade13c23ac845',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3GZws7RvRu+8yI1G1LfAVRdFB18AAAAAQUIPAAAAAAAYt/unTVNvk/gMxl/asMUo; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MP2Ahrs7TCWdFhLIWrwlb7TWDV8AAAAAQUIPAAAAAAAoqQLBN07ymmUqDUF12G5Q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=IXZDGKzlr1W0Zc5QYMlkBAAAAAA1nNsNQiDKaUldZHIBWczT; path=/; Domain=.contentful.com',
+  'nlbi_673446=jz5QOY1w2HoSXcDxKsJtVwAAAACaTTHPgLodJrOciN6G7rMp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=3NM+eqcaTAfO81sGPWpmAxdFB18AAAAAuBzkStpT8ZtoJfVA4JT+Bw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0T8yKhkEwSmlCfpMOoVtA7TWDV8AAAAA0ijTsON3kwvYfWwfRaVuIA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-86063284-86063296 NNNN CT(93 93 0) RT(1594311959494 32) q(0 0 2 -1) r(3 3) U5'
+  '6-4142188-4142190 NNNN CT(92 93 0) RT(1594742452293 34) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13569,7 +13569,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:00 GMT',
+  'Tue, 14 Jul 2020 16:00:53 GMT',
   'etag',
   '"9177491833369070274"',
   'Server',
@@ -13581,23 +13581,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'a9d1d1eab17024a094093b94e220dfba',
+  '6256ce44c5aab0ad4c8a7008a8c98ace',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kEwXzO48TbybEN4vRte05BhFB18AAAAAQUIPAAAAAAB6qhCzOKmZ8xyXLijKstY4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=f2+bAQBARleh9JVbCf4kyLXWDV8AAAAAQUIPAAAAAABbwpxWqHilB8ibaSHP+5pR; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bUFBKs90yX/niCAOYMlkBAAAAABa1NnESqDHeJKfsrBcfiKq; path=/; Domain=.contentful.com',
+  'nlbi_673446=2M6CC4OOuiavMGydKsJtVwAAAADlhpt63B8FHMS6ylg1IiCX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=h9srJCp+Wgsl9FsGPWpmAxhFB18AAAAAZDHtHtwtlFkltPMHKhRKmA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ysktQDCoTSQpCvpMOoVtA7XWDV8AAAAA9O+rYJZRDBtGdJQsPSzPVA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13605,7 +13605,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86063493-86063502 NNYY CT(0 0 0) RT(1594311960066 32) q(0 0 0 -1) r(2 2) U5'
+  '1-1685440-1685442 NNYN CT(93 95 0) RT(1594742452906 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13646,15 +13646,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -13666,56 +13666,56 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:00 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:54 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '50b995a713e0be601930a8bb72137599',
-  'X-Download-Options',
+  '4aa49e0a0b3de8bb10e98ddf7c6282a8',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=xo+8pvqsQaKqtPYe8t605xhFB18AAAAAQUIPAAAAAAAz68PN9uMtrJ3e53tVpI//; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=QNWWgjuZTkSa5YvAgov8mbXWDV8AAAAAQUIPAAAAAADCUTlDmTywUj1x1a6V2HvV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4siwPCGKKlfww5D2YMlkBAAAAACqA5ouwDqKKOd8sop5LbDq; path=/; Domain=.contentful.com',
+  'nlbi_673446=EQJSeZvDWDyHwUMuKsJtVwAAAADzP/+7DnAcw3ZV5Kd6HHwX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=s2YGK/gYTlhp9FsGPWpmAxhFB18AAAAAiOcOm5DY6dHooQ2kNXQcrw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=XdDRfK56ukmaCvpMOoVtA7XWDV8AAAAAtoomzapbR7nJYUryAvnbHQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13723,12 +13723,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-55404539-55404548 NNYY CT(0 0 0) RT(1594311960310 35) q(0 0 0 -1) r(1 1) U5'
+  '3-6346144-6346148 NNYN CT(94 94 0) RT(1594742453437 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":0},"name":"marketing"})
-  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-09T16:26:01.234Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-09T16:26:01.234Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
+  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-14T16:00:54.593Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-14T16:00:54.593Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -13750,9 +13750,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:01 GMT',
+  'Tue, 14 Jul 2020 16:00:54 GMT',
   'etag',
-  '"13236965944598722177"',
+  '"5757577779022189902"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13762,29 +13762,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'f11f4848e50730ae907423f1f41faa33',
+  '99e8557b70d0a66cbaa8511a62167f99',
   'Content-Length',
   '740',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Jn1sirpaQWabO+EVK3XOFhhFB18AAAAAQUIPAAAAAABI4CGAnNAIxB6tqUw4gu57; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=+3YR17zkRN+8nRJQNa6cOrbWDV8AAAAAQUIPAAAAAABJqqdupzsHC6ZmRmb5VMkq; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=jW5McE74R1yI0ePxYMlkBAAAAACIhlLkzm1x6V72MvNzTsey; path=/; Domain=.contentful.com',
+  'nlbi_673446=yZ/AI0ykfWNfXtdIKsJtVwAAAABz9FOrz0cNMMW+7aDBn+Nw; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=gS2Bfgz4QF6u9FsGPWpmAxhFB18AAAAAMotTYF43iL3IJVoAJzI+ng==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=GaHNdTAfcmMPC/pMOoVtA7bWDV8AAAAA2UdBE6e+R1YHY5JL6OwGNg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-41055457-41055459 NNNY CT(0 0 0) RT(1594311960516 28) q(0 0 0 -1) r(2 2) U5'
+  '5-13532020-13532025 NNNN CT(87 88 0) RT(1594742453945 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13821,8 +13821,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-09T16:26:01.234Z",
-    "updatedAt": "2020-07-09T16:26:01.234Z",
+    "createdAt": "2020-07-14T16:00:54.593Z",
+    "updatedAt": "2020-07-14T16:00:54.593Z",
     "version": 1
   },
   "name": "marketing"
@@ -13849,9 +13849,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:01 GMT',
+  'Tue, 14 Jul 2020 16:00:55 GMT',
   'etag',
-  '"9835733008416165370"',
+  '"4053287262629635354"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13861,23 +13861,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'ea927dd8db75bbd267fd616238879e6c',
+  '5889a1845e37c956085ef9a01345ea0d',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=G8v+TOQuQWi/eYhqFRiTyxlFB18AAAAAQUIPAAAAAAD4afRQKRpOo9oDfXDwYu0y; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=asNiN9qORx6sQXmIRGIyhrbWDV8AAAAAQUIPAAAAAABCtjt8sJBBLcPwejojjjl5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Tsr4AcPFNX9QjWQ5YMlkBAAAAACgNnj2utU99hwWP1SimsT5; path=/; Domain=.contentful.com',
+  'nlbi_673446=a5qANjYlkmvGuqoIKsJtVwAAAABkA0XvR3bIWdyseT45K6AB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=jdTwIyfBhA8h9VsGPWpmAxlFB18AAAAAxq6udxgKp8hh+YLspNWlDg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=iXRKfjD8pVyaC/pMOoVtA7bWDV8AAAAAxT7tiyBExViey6SENP4b4g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13885,7 +13885,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66935267-66935275 NNYN CT(85 86 0) RT(1594311960892 30) q(0 0 1 -1) r(3 3) U5'
+  '9-5259881-5259882 NNYN CT(93 94 0) RT(1594742454401 26) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13929,8 +13929,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-09T16:26:01.234Z",
-        "updatedAt": "2020-07-09T16:26:01.234Z",
+        "createdAt": "2020-07-14T16:00:54.593Z",
+        "updatedAt": "2020-07-14T16:00:54.593Z",
         "version": 1
       },
       "name": "marketing"
@@ -13959,9 +13959,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:02 GMT',
+  'Tue, 14 Jul 2020 16:00:55 GMT',
   'etag',
-  '"1064381601898507789"',
+  '"14463358499897617033"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13971,23 +13971,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  '7d356ef7bfb49b2c86302a30185acb4c',
+  '76008b1ff6485fef4b4dde11b92c4db0',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ZLfz7tEFR/KWuFXgKrfUYRlFB18AAAAAQUIPAAAAAAB5mPm7rvP5qb/NZPKvfe/Y; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lRy5wnckRKCaoIXhkMh0qrfWDV8AAAAAQUIPAAAAAABw3491D+1lAHCzomPeFgqI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=MQb9OegQqDubCSbQYMlkBAAAAAA72l4lXP4m+TwxoG+1rKZj; path=/; Domain=.contentful.com',
+  'nlbi_673446=bWh6fdM+NXQK2XNbKsJtVwAAAABmdFzto1CQLOlgqnJV5bw4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=UAwoL0IqOVKB9VsGPWpmAxlFB18AAAAAafhAG5wOhp8x7ohYbGDHvA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0TrGUCxjcz4lDPpMOoVtA7fWDV8AAAAA338nxRcJCh6XJCd6mJjN1w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13995,7 +13995,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-66935366-66935370 NNYY CT(0 0 0) RT(1594311961322 28) q(0 0 0 -1) r(1 1) U5'
+  '4-9016182-9016189 NNYN CT(93 93 0) RT(1594742454968 38) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14036,15 +14036,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-09T16:25:00Z",
-        "updatedAt":"2020-07-09T16:25:00Z"
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
       }
     }
   ]
 }
 
 , [
-  'Accept-Ranges',
+  'accept-ranges',
   'bytes',
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -14056,27 +14056,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
+  'cache-control',
   'max-age=0',
-  'CF-Organization-Id',
+  'cf-organization-id',
   '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:02 GMT',
-  'ETag',
-  'W/"9db5145faafd31cb9e80b0cd866c7368"',
-  'Referrer-Policy',
+  'Tue, 14 Jul 2020 16:00:56 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
   'max-age=15768000',
-  'X-Content-Type-Options',
+  'x-content-type-options',
   'nosniff',
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
@@ -14089,23 +14089,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '8015aacb681b75bca4556fa8515fff47',
-  'X-Download-Options',
+  '8df42ad93ee56e3723012761d6c8fb65',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=dcB4fTPlR/W6C69rfSl+qRlFB18AAAAAQUIPAAAAAAAF72pMwk2H4i3PiqY0PP0U; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=yb0AyFZ1TP2eO543foe1xLfWDV8AAAAAQUIPAAAAAAAI5d2CxCQy+qMHVw14u93u; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=rIxHP06lLGw7Z4l3YMlkBAAAAAD7jTL1rJG+VF15qVPsyjeM; path=/; Domain=.contentful.com',
+  'nlbi_673446=7Mg5JZwzliV053eZKsJtVwAAAADqy3Ce7KAJC2/7iUVw5/Pu; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=qrFPa1WT0yjM9VsGPWpmAxlFB18AAAAAGcWlNEMXNJNCNKEFJrsMaw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=q/0GOyOMI0m6DPpMOoVtA7fWDV8AAAAALRC6+FPkIZGxrUUEWPhLQw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14113,12 +14113,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-86063959-86063969 NNYY CT(0 0 0) RT(1594311961616 34) q(0 0 0 -1) r(1 1) U5'
+  '13-20328637-20328648 NNYN CT(87 87 0) RT(1594742455574 33) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":1},"name":"better marketing"})
-  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-09T16:26:01.234Z","updatedAt":"2020-07-09T16:26:02.848Z","version":2},"name":"better marketing"}, [
+  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-14T16:00:54.593Z","updatedAt":"2020-07-14T16:00:56.672Z","version":2},"name":"better marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -14140,9 +14140,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:02 GMT',
+  'Tue, 14 Jul 2020 16:00:56 GMT',
   'etag',
-  '"12844811058257837964"',
+  '"17387467672040922824"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14160,21 +14160,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '2a56ad100e19b9fb2bb444f994704c04',
+  '195b6ee5a5e6ee204f350ce78f5489af',
   'Content-Length',
   '747',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Q29s/RzDQVekZeGxzM7/vxpFB18AAAAAQUIPAAAAAAA8ML+eYPkzY6DPIQbf1vTU; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Y9YyQWp7S2apz9xidpAITbjWDV8AAAAAQUIPAAAAAACY/5sjemPVj3HAE5G1Vsyk; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=3V9zW9zL6X8WsGZhYMlkBAAAAADCoI61eQTOdOpWOx9DHReu; path=/; Domain=.contentful.com',
+  'nlbi_673446=8oj6WrL1IyYRudjNKsJtVwAAAADLd/FdRLn6TGPH4+MbWEuM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=PGd/ClSvdA9r9lsGPWpmAxpFB18AAAAA/B/7EMcTmHPJepxLP3O+JA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=A/9rGd6WczooDfpMOoVtA7jWDV8AAAAA3WfUJ6JR9wtCudzP0mgWwA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-27146213-27146216 NNNN CT(93 94 0) RT(1594311961820 32) q(0 0 2 -1) r(6 6) U5'
+  '14-27011475-27011492 NNNN CT(99 103 0) RT(1594742455995 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14211,8 +14211,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-09T16:26:01.234Z",
-    "updatedAt": "2020-07-09T16:26:02.848Z",
+    "createdAt": "2020-07-14T16:00:54.593Z",
+    "updatedAt": "2020-07-14T16:00:56.672Z",
     "version": 2
   },
   "name": "better marketing"
@@ -14239,9 +14239,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:03 GMT',
+  'Tue, 14 Jul 2020 16:00:57 GMT',
   'etag',
-  '"12844811058257837964"',
+  '"17387467672040922824"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14259,15 +14259,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '23e6a105f06cf5d9f87dfe583a0525c3',
+  '96310ea522d2f052a225eb5aff7989e5',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=pMD1cw0rSg+D0AMWlxNOZRtFB18AAAAAQUIPAAAAAACS/NyKx7kj2SbY8yel1Fu4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=eNPUAkvkT2+u0DmuJ38xxLnWDV8AAAAAQUIPAAAAAAAUNf0+Lwx9NRDzKwttym3a; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GrJ3RCLB0i7zE8TgYMlkBAAAAADk3rt6axKoyYeMC7nix1Sw; path=/; Domain=.contentful.com',
+  'nlbi_673446=CCwRMBmy3TOVH/BaKsJtVwAAAABBS9Z09bnED4ihiwbRl6G0; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=bDHkLXh9dHQV91sGPWpmAxtFB18AAAAAtCpqx7BUe90s6pP9CUljJw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ybLnFBdJOC6mDfpMOoVtA7nWDV8AAAAAeN+6UXyhPJKxvCdaDcjizQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14275,12 +14275,59 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '2-9266366-9266369 NNYN CT(86 86 0) RT(1594311962720 29) q(0 0 2 -1) r(3 3) U5'
+  '2-3149832-3149835 NNYN CT(89 96 0) RT(1594742456595 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .delete('/spaces/bohepdihyxin/environments/env-integration')
-  .reply(204, "", [
+  .get('/spaces/bohepdihyxin/environments/env-integration/tags')
+  .query({"limit":"100","order":"sys.createdAt","skip":"0"})
+  .reply(200, {
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "items": [
+    {
+      "sys": {
+        "type": "Tag",
+        "id": "sampletag",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "bohepdihyxin"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "env-integration",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "createdAt": "2020-07-14T16:00:54.593Z",
+        "updatedAt": "2020-07-14T16:00:56.672Z",
+        "version": 2
+      },
+      "name": "better marketing"
+    }
+  ]
+}
+, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -14291,18 +14338,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'Cache-Control',
-  'max-age=0',
-  'CF-Organization-Id',
-  '3ubGFD1MWA6VgVYbIwSBg8',
-  'CF-Space-Id',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
   'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Thu, 09 Jul 2020 16:26:04 GMT',
-  'Referrer-Policy',
-  'strict-origin-when-cross-origin',
+  'Tue, 14 Jul 2020 16:00:57 GMT',
+  'etag',
+  '"17120536850921208281"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14320,25 +14369,338 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '574a04ae36776afe066c7eb1efbd32a9',
-  'X-Download-Options',
+  'fac4edf1cd90965fff630b236da40b99',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=tBU3uTCqR2ykL4KHZ2pqA7nWDV8AAAAAQUIPAAAAAACMzed+ujSBKbpaJfYX/mb8; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=WI4KQgUUnz6TGVUsKsJtVwAAAAA8GzodjQPv1c4Y88Bgxc3v; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=4XfCXajwTFBLDvpMOoVtA7nWDV8AAAAA68AdyPMdGbWxsol8gW629Q==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '5-13532562-13532569 NNYN CT(113 93 0) RT(1594742457217 32) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/locales')
+  .query({"limit":"100","order":"sys.createdAt","skip":"0"})
+  .reply(200, {
+  "total":1,
+  "limit":100,
+  "skip":0,
+  "sys":{
+    "type":"Array"
+  },
+  "items":[
+    {
+      "name":"U.S. English",
+      "internal_code":"en-US",
+      "code":"en-US",
+      "fallbackCode":null,
+      "default":true,
+      "contentManagementApi":true,
+      "contentDeliveryApi":true,
+      "optional":false,
+      "sys":{
+        "type":"Locale",
+        "id":"0zK7OynpqVdcSetOBfe5P8",
+        "version":1,
+        "space":{
+          "sys":{
+            "type":"Link",
+            "linkType":"Space",
+            "id":"bohepdihyxin"
+          }
+        },
+        "environment":{
+          "sys":{
+            "type":"Link",
+            "linkType":"Environment",
+            "id":"env-integration"
+          }
+        },
+        "createdAt":"2020-07-14T15:59:32Z",
+        "updatedAt":"2020-07-14T15:59:32Z"
+      }
+    }
+  ]
+}
+
+, [
+  'accept-ranges',
+  'bytes',
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cache-control',
+  'max-age=0',
+  'cf-organization-id',
+  '3ubGFD1MWA6VgVYbIwSBg8',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 16:00:58 GMT',
+  'etag',
+  'W/"f22cb9b177121e851327f03346d48b93"',
+  'referrer-policy',
+  'strict-origin-when-cross-origin',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'x-content-type-options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'f02ae2401ea2dfd7fb699fd7150ac655',
+  'x-download-options',
   'noopen',
-  'X-Frame-Options',
+  'x-frame-options',
   'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
+  'x-permitted-cross-domain-policies',
   'none',
-  'X-XSS-Protection',
+  'x-xss-protection',
   '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/Z/BUdQKS2ucYHpTmqA5zxxFB18AAAAAQUIPAAAAAAAI15Fi3zqWpXJB7P4pjJvr; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=47cQT+PZTZSgLeLndDuLFrrWDV8AAAAAQUIPAAAAAAB2tX8UN9VFOCvOhM7dLCmg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SY/FA3/FZH22p09PYMlkBAAAAADF08YRZGivl4IrOyPcasCd; path=/; Domain=.contentful.com',
+  'nlbi_673446=AD5qHjm1F3YekBfcKsJtVwAAAABakQor/742E1Cbwx9jj5Vd; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=fhKRO1hKiGEO+FsGPWpmAxxFB18AAAAAEZ6eb9ttartvTwZILJYPAw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=18NbdX1G9S6eDvpMOoVtA7rWDV8AAAAAU8kTM8YfPIlaTjkzJBZpEw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '14-27011931-27011943 NNYN CT(93 93 0) RT(1594742457693 31) q(0 0 2 -1) r(3 3) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .delete('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":2},"name":"better marketing"})
+  .reply(204, "", [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 16:00:58 GMT',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  'a6bb1391ca251e7857c67ed0f666e50e',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=aTGj1L6KSQKyEJaX+aeKErrWDV8AAAAAQUIPAAAAAACuppY3ZQDescn0yY4qpU72; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=eIP4IfqoumEy7s4MKsJtVwAAAADUDMEHbFqUKOj3SZ5oxT9W; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=okWvVOwCInEuD/pMOoVtA7rWDV8AAAAAyPzsyygulO0/rRJHNsjIwg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-55405065-55405069 NNNY CT(0 0 0) RT(1594311963142 31) q(0 0 0 -1) r(9 9) U5'
+  '9-5260112-5260117 NNNN CT(88 89 0) RT(1594742458241 57) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag')
+  .reply(404, {
+  "sys": {
+    "type": "Error",
+    "id": "NotFound"
+  },
+  "message": "The resource could not be found.",
+  "details": {
+    "type": "Tag",
+    "id": "sampletag",
+    "environment": "env-integration",
+    "space": "bohepdihyxin"
+  },
+  "requestId": "6fe00046935559ccd9213ac4bf591acd"
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 16:00:59 GMT',
+  'etag',
+  '"6451860625274420159"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '6fe00046935559ccd9213ac4bf591acd',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=DULghJTrQaeHLg772dqudLvWDV8AAAAAQUIPAAAAAAAo/6AkxJnaTBKMYe0Vc5XZ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=KkIqHoz9j3ZQ3xZRKsJtVwAAAABvN9t76xcndICy2i6p57D2; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=yS+3GvPnNlO9D/pMOoVtA7vWDV8AAAAAUuti997LJXSB9ouVobWR+A==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '6-4142610-4142611 NNYN CT(87 87 0) RT(1594742458860 31) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .delete('/spaces/bohepdihyxin/environments/env-integration')
+  .reply(204, "", [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cache-control',
+  'max-age=0',
+  'cf-organization-id',
+  '3ubGFD1MWA6VgVYbIwSBg8',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Tue, 14 Jul 2020 16:01:00 GMT',
+  'referrer-policy',
+  'strict-origin-when-cross-origin',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'x-content-type-options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  '1c5595c56d33e78c0c9f3c34530186e7',
+  'x-download-options',
+  'noopen',
+  'x-frame-options',
+  'ALLOWALL',
+  'x-permitted-cross-domain-policies',
+  'none',
+  'x-xss-protection',
+  '1; mode=block',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=XJ1aGDjZQky6kc/JvHtxYbzWDV8AAAAAQUIPAAAAAABuSSC0AR8CzLSwklnv4j2n; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=j9o8dqKOKTOunMhhKsJtVwAAAAAQ5zPyKnyrLV4liJsazJwG; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=vwvxDPtO9FM+EfpMOoVtA7zWDV8AAAAAbGUqwAUc8dC2RQi+YC5OoQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '2-3149926-3149927 NNNN CT(92 93 0) RT(1594742459369 37) q(0 0 1 -1) r(10 10) U5'
 ]);

--- a/test/fixtures/contentful-migration-integration.js
+++ b/test/fixtures/contentful-migration-integration.js
@@ -58,7 +58,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:32 GMT',
+  'Thu, 09 Jul 2020 16:24:59 GMT',
   'ETag',
   'W/"9f8886bb475af980f12a1a32fbc74d55"',
   'Referrer-Policy',
@@ -80,7 +80,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bfb9be832d5a9ac740ab03017fe1ea04',
+  '4b4e0f89ae8497d34a7965908860e0f0',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -92,11 +92,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=i9hXkoy0S6mdT4xxzJLVAb+RBV8AAAAAQUIPAAAAAABaa/aCLntGOBGyhstw4Hq/; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FfxqWwtUQbqT8qqaeZp+U9pEB18AAAAAQUIPAAAAAABfgLKDFLTy0c2A5c0lhafi; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=uw53IOdeeWL1u3QDYMlkBAAAAAD1isQ0Sf997kfzJOEltx+Y; path=/; Domain=.contentful.com',
+  'nlbi_673446=SPVTEzwBAgUi9ysWYMlkBAAAAABpH1VOJj5njzZqidjNQgZa; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=1sqFby7l1lyt7U0EPWpmA7+RBV8AAAAA0lfi4uvnIQFURO9c20vx+A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=m+c9aLa07yG1s1sGPWpmA9pEB18AAAAAFa/9Eg7I4pC7XUZF0g7LwQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -104,12 +104,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49170468-49170483 NNYY CT(0 0 0) RT(1594200511744 37) q(0 0 0 -1) r(2 2) U5'
+  '4-26738708-26738710 NNYY CT(0 0 0) RT(1594311898322 34) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration', {"name":"env-integration"})
-  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-08T09:28:33Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-08T09:28:33Z"}}, [
+  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-09T16:25:00Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-09T16:25:00Z"}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -131,9 +131,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:33 GMT',
+  'Thu, 09 Jul 2020 16:25:00 GMT',
   'ETag',
-  'W/"9f34ab922b18b26b14cfbc521335d926"',
+  'W/"7054f2d88f6e69c2b9dbfff1f540c20f"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -145,15 +145,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '0928c9d4a42b1dffcc1c673c0be4bcc4',
+  '735e7c9e6db10324fa705c53715830ca',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -167,15 +167,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=OVDfTjaySIOSABui+nrKAMGRBV8AAAAAQUIPAAAAAACBkRddNtXzsWZfzOTBW3r7; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=VM+Z+PJ2SlKAxhKOsN7o7ttEB18AAAAAQUIPAAAAAADrwxTpIZgvJhCnraASFFtf; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gpUwQRJfQ0o+F5N3YMlkBAAAAABnEmjdDxUl4+r+cJlBGrEi; path=/; Domain=.contentful.com',
+  'nlbi_673446=NNq1PmNs3zi5jXAeYMlkBAAAAACFjdSQQXyq7VC6VXDzr/iQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=6XKQcp4t0EPh7k0EPWpmA8GRBV8AAAAAQqZNRuily+Fi+D68ec173w==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=aEk+LMpdQWWstFsGPWpmA9tEB18AAAAAhnP5BuxkWAz5A4lAwyNCwg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31543211-31543217 NNNY CT(0 0 0) RT(1594200512077 31) q(0 0 0 -1) r(10 10) U5'
+  '12-55392486-55392490 NNNY CT(0 0 0) RT(1594311898650 26) q(0 0 0 -1) r(10 10) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -207,7 +207,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt":"2020-07-08T09:28:33Z",
+    "createdAt":"2020-07-09T16:25:00Z",
     "updatedBy":{
       "sys":{
         "type":"Link",
@@ -215,7 +215,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "updatedAt":"2020-07-08T09:28:33Z"
+    "updatedAt":"2020-07-09T16:25:00Z"
   }
 }
 
@@ -243,9 +243,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:34 GMT',
+  'Thu, 09 Jul 2020 16:25:01 GMT',
   'ETag',
-  'W/"08d8e5956848c70ff8f150b994749617"',
+  'W/"75ff57ac5f5bc26336602224480791f8"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -265,7 +265,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5b5c90c2995cf20388600d7ab64cc072',
+  'e8367b10870c1d6ec1dad13d3aa3253a',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -277,11 +277,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=RymYkyEEQ3Cfueryi4ml6cKRBV8AAAAAQUIPAAAAAABFNdhkyaWRvQxkdC8Ar1dn; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=poeUVy6vQ6i8Tc55swdtXtxEB18AAAAAQUIPAAAAAAAV2QDMJJSvY9LRtXck3e4v; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ydGVCRfx3TnZ+SuUYMlkBAAAAACBU7qnLiFZBWGvAFx3Jto8; path=/; Domain=.contentful.com',
+  'nlbi_673446=RviyYUWBQzYyKMY/YMlkBAAAAACaXKvJTQcIpjTVK19OexZU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Sv45HRV4imMh8E0EPWpmA8KRBV8AAAAAJBozqM6tZ7XeRTzc8BBCLA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=6vUBFrblCAC0tVsGPWpmA9xEB18AAAAAn5/VFFozlHjywLjOO5hHNg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -289,7 +289,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '5-25298532-25298537 NNYY CT(0 0 0) RT(1594200513287 24) q(0 0 0 -1) r(7 7) U5'
+  '14-86045821-86045832 NNYY CT(0 0 0) RT(1594311899863 24) q(0 0 0 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -315,19 +315,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:35 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:01 GMT',
+  'etag',
   '"10440568906820546102"',
   'Server',
   'Contentful',
@@ -346,15 +346,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '805bf6a2bbeefa9040749c7baebedbf0',
+  '7fe682109d0518440db10c22bc77e243',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nqe+un6nSJmmI9lI8C3EmMORBV8AAAAAQUIPAAAAAAB4h4RMQmNvJ2p6XERGfVup; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=TiS+CGMrSHqh60+X/XIu9N1EB18AAAAAQUIPAAAAAADAfFo/wFCUuL77jgEJFJX+; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Uw8zM6QN4XhbH+8jYMlkBAAAAACUTijPFMfyjk5ELuyRG2Bk; path=/; Domain=.contentful.com',
+  'nlbi_673446=cwvdV5yxCWWmXdELYMlkBAAAAABENANfJDSxQS4JbhZ2hi4o; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=7GsaaBNtnSY/8U0EPWpmA8ORBV8AAAAATiz9wStebxjzbI2+OD1jAg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=JxsaEdXyiHePtlsGPWpmA91EB18AAAAA3wxn/Rj23PnHVY2tRlSdjA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -362,7 +362,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '5-25298728-25298735 NNYN CT(93 93 0) RT(1594200514231 32) q(0 0 2 -1) r(9 9) U5'
+  '13-66921432-66921442 NNYN CT(93 93 0) RT(1594311900702 38) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -403,8 +403,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -434,9 +434,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:36 GMT',
+  'Thu, 09 Jul 2020 16:25:02 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -456,7 +456,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'da336ff707624683cc92f86d397289c0',
+  '2351574da06cc2f959a8d9acce51992e',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -468,11 +468,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=RwGTj/fQRp++Kr0WdHQlc8SRBV8AAAAAQUIPAAAAAACuL32Zk7xuhVeRJgZ8KT2g; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lot0CMoWQI6Uu/QdMGiYSt5EB18AAAAAQUIPAAAAAADTMmW4BQHiYg0wpOdn2TDD; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=6TVAVfAvq0/ttviVYMlkBAAAAADS3Z10zB0WnS463nrACtZj; path=/; Domain=.contentful.com',
+  'nlbi_673446=a2f6HjQB5k3xIKi2YMlkBAAAAABofbqhO4doj6PX/cj6C3gP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=hcFbQmr/7mcG8k0EPWpmA8SRBV8AAAAAk4u720cRH0QOpuTkHtStew==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=Gycxe97RDRCut1sGPWpmA95EB18AAAAAGNhysbpKY6vvEPnVEoITXg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -480,12 +480,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-38152777-38152783 NNYY CT(0 0 0) RT(1594200515347 38) q(0 0 0 -1) r(7 7) U5'
+  '2-9264447-9264449 NNYY CT(0 0 0) RT(1594311901530 34) q(0 0 0 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog', {"name":"angry dog","fields":[{"id":"woofs","name":"woof woof","type":"Number","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-08T09:28:38.462Z","updatedAt":"2020-07-08T09:28:38.462Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-09T16:25:03.323Z","updatedAt":"2020-07-09T16:25:03.323Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -496,20 +496,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:38 GMT',
-  'ETag',
-  '"2254202747247994809"',
+  'Thu, 09 Jul 2020 16:25:03 GMT',
+  'etag',
+  '"10692450299847994942"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -527,21 +527,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '30529f3d46d9537b718f8c27ad2aa821',
+  '32fc331b2cf8dc5be5b64a64fb3c311f',
   'Content-Length',
   '1051',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fmGzyP8xTBiJYZcuLakeesaRBV8AAAAAQUIPAAAAAADuEJu1L2tWUc+F4sTMt87/; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ieJ0GaOhTNWXDczD7vNRJt5EB18AAAAAQUIPAAAAAADcM9d8RrcETfmfXbnuhe4L; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=A/HeLPiIWC059NaAYMlkBAAAAADcpHLGcb9zOqu7M84oMiSv; path=/; Domain=.contentful.com',
+  'nlbi_673446=kloCRK+NN1c59I8PYMlkBAAAAABOxoqor6eVHvrCgHAfoPqT; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=hspYELYqdBRu9E0EPWpmA8aRBV8AAAAAHULzQ34DSQuwsivDjsXpwA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=Qh95MVr2nTE4uFsGPWpmA95EB18AAAAAQdghOLPdAtdJk5wgLaIgKw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-16015086-16015092 NNNN CT(86 176 0) RT(1594200517079 33) q(0 0 2 -1) r(11 11) U5'
+  '14-86046549-86046562 NNNY CT(0 0 0) RT(1594311902430 33) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -557,8 +557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:39.439Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:03.794Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -582,8 +582,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
-    "publishedAt": "2020-07-08T09:28:39.439Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "publishedAt": "2020-07-09T16:25:03.794Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -620,11 +620,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -633,9 +633,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:39 GMT',
-  'ETag',
-  'W/"16388129176758471477"',
+  'Thu, 09 Jul 2020 16:25:04 GMT',
+  'etag',
+  'W/"10718090535463505466"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -645,29 +645,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '0159fbdfc1848718770b41e0305c05fb',
-  'Content-Length',
-  '442',
+  '453c84ec912266108e54dbbb85565ce8',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=F8Ck5zAFQBaobF6pEYIhjseRBV8AAAAAQUIPAAAAAABfUVsvcVFf7mRLOs6YcVmw; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=q0g6uvIkTYOXG5ZZqa0AZd9EB18AAAAAQUIPAAAAAABGfTjJLYbfaedcSjJFXvCk; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xJ3uAcd68mNqzg9FYMlkBAAAAADqpNmV7YraeukB2QdOQtyo; path=/; Domain=.contentful.com',
+  'nlbi_673446=hqjKTyyAoB3CJxMyYMlkBAAAAACc6xQDseBKmqiDIMJyOLo2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=HBTkQjyAyR6I9U0EPWpmA8eRBV8AAAAAf3JRWMCU5xbhfc8kU3TRDw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=yTBbed0yCUftuFsGPWpmA99EB18AAAAAsox0Wxa146V9xdm+//u0qQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15104160-15104176 NNNY CT(0 0 0) RT(1594200518437 34) q(0 0 0 -1) r(8 8) U5'
+  '10-27141785-27141786 NNNY CT(0 0 0) RT(1594311902926 30) q(0 0 0 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -683,8 +683,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:39.439Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:03.794Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -693,8 +693,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:28:39.439Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:03.794Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -746,11 +746,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -759,9 +759,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:40 GMT',
-  'ETag',
-  'W/"2984781584108253073"',
+  'Thu, 09 Jul 2020 16:25:04 GMT',
+  'etag',
+  'W/"2679592502292985425"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -779,21 +779,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '49b3e2143cd6e59c35d64e3273aa0651',
+  'a7f6a593151d58d3ee0698eb7d50ec8e',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kwXZFoDYQ+C1C1isLL6gc8eRBV8AAAAAQUIPAAAAAACSGTH8z15ziPSpPnNRmoVy; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=8qNyjtKaSZ+efY9om+hCtuBEB18AAAAAQUIPAAAAAACX09gx3s8Dwle3xAO7VKAL; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4TAbZa2bB3+nLGPJYMlkBAAAAAD6CbhIQVLzd8m1mlhqYcVg; path=/; Domain=.contentful.com',
+  'nlbi_673446=NZeBIwxrW2WWV2AxYMlkBAAAAABio+9LdBbls1wQYtspjhpa; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=LwF2QoK2USQ39k0EPWpmA8eRBV8AAAAApCFz6jnJ3bNLirHNuMORTQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=2EvvY82VohKsuVsGPWpmA+BEB18AAAAAq1StiAghPosTs/O/CWfCWA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38153951-38153958 NNNY CT(0 0 0) RT(1594200519441 30) q(0 0 0 -1) r(3 3) U5'
+  '13-66922145-66922153 NNNY CT(0 0 0) RT(1594311903753 28) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -818,8 +818,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:28:38.462Z",
-        "updatedAt": "2020-07-08T09:28:39.439Z",
+        "createdAt": "2020-07-09T16:25:03.323Z",
+        "updatedAt": "2020-07-09T16:25:03.794Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -828,8 +828,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-08T09:28:39.439Z",
-        "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+        "publishedAt": "2020-07-09T16:25:03.794Z",
+        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -883,11 +883,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -896,9 +896,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:45 GMT',
-  'ETag',
-  'W/"15813039308470308699"',
+  'Thu, 09 Jul 2020 16:25:10 GMT',
+  'etag',
+  'W/"3726170834583369418"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -916,21 +916,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '6346df008ecedd1aed14351f334482b3',
+  'dda40b62e1d08bace6cbc93fcd7a6bd5',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Zjsngmf2RYC985MUuLoC8M2RBV8AAAAAQUIPAAAAAADlg/c1Dwcr2o9kKbSdHXGr; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=0qVgcPfdS62e4CXCXKJPuOVEB18AAAAAQUIPAAAAAABTg7AbZmQltKEATr2PbmH3; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PgnfFyayKUIkfFo0YMlkBAAAAABtLfsUtgkTMlJQlqwSailo; path=/; Domain=.contentful.com',
+  'nlbi_673446=itjXdzlN7U6cFiFQYMlkBAAAAACGxKkiFsRx/M+JXn1UmM7+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=z3prU2QjQkf4+00EPWpmA82RBV8AAAAA1JPlx+813E5jyJaQIohBLg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=dhaHT++U7i6lv1sGPWpmA+VEB18AAAAARzttJAv/ninNQpOZDUYxVQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-11762506-11762508 NNNY CT(0 0 0) RT(1594200525055 29) q(0 0 0 -1) r(2 2) U5'
+  '14-86048480-86048488 NNNY CT(0 0 0) RT(1594311909270 35) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -971,8 +971,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -1002,9 +1002,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:46 GMT',
+  'Thu, 09 Jul 2020 16:25:10 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -1024,7 +1024,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b31b7e1456d6dc84043f5a52aae7357f',
+  '53db55e6bf5a01211e0de9b5524e6cdc',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -1036,11 +1036,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=QYzp19RARXyijYBGOujb1c6RBV8AAAAAQUIPAAAAAAAKoTFlev6VtIEEzCVG8/Ki; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=gu+QVH8FRw6OC9qsb9A7i+ZEB18AAAAAQUIPAAAAAACvX7aJLJwMfctcYh8W7oG4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WXVKPZkupSsGjOiOYMlkBAAAAAAK4nXRqf9+W0J2EoXlwtAK; path=/; Domain=.contentful.com',
+  'nlbi_673446=ttsLLprm32oRK4nJYMlkBAAAAABqBBR3IpGpm90/NVwPGlKp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=GpF1Cew3qRNG/U0EPWpmA86RBV8AAAAAhJdrQ4Wh/qlzt4CHqInIfQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=tz7JKObQG3O5wFsGPWpmA+ZEB18AAAAAr0poM66aDkC4eTF6EE8+Pw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1048,7 +1048,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49174520-49174544 NNYY CT(0 0 0) RT(1594200525387 35) q(0 0 0 -1) r(6 6) U5'
+  '14-86048596-86048609 NNYY CT(0 0 0) RT(1594311909696 31) q(0 0 0 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1064,8 +1064,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:47.017Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:11.460Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1074,8 +1074,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:28:39.439Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:03.794Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1127,11 +1127,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -1140,9 +1140,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:47 GMT',
-  'ETag',
-  'W/"2640800182493493323"',
+  'Thu, 09 Jul 2020 16:25:11 GMT',
+  'etag',
+  'W/"5226526402958839353"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1152,29 +1152,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '224986d27c8e7f88b6e9215a50aff57d',
+  '55ce45d0c37902929a6e218a48d576d9',
   'Content-Length',
-  '448',
+  '446',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=8NVN30gTSXK5cjSXKQnw7c6RBV8AAAAAQUIPAAAAAACybpisUePnoO4zdv0nBCTW; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=T4r39nnvTiu2DnCmV55NtOZEB18AAAAAQUIPAAAAAACYMtDMc1ZnG7k2w4mHNjTw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ZUgZZJtXXkYQQsNjYMlkBAAAAABLXsUzYKweFpAQnILsDlJt; path=/; Domain=.contentful.com',
+  'nlbi_673446=xTAsOW0A6RpcCcfsYMlkBAAAAADM8aKIVHJKF3HcHlc9+N2z; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=x4fDNyKWryDc/U0EPWpmA86RBV8AAAAAdbVnCpIVAlmEd6Y9cFmeYg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=aTjAN32VdR5KwVsGPWpmA+ZEB18AAAAAvz5PQ4dgsZH2D/JkpUS4MQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38156203-38156219 NNNY CT(0 0 0) RT(1594200526207 33) q(0 0 0 -1) r(3 3) U5'
+  '12-55394887-55394892 NNNY CT(0 0 0) RT(1594311910706 30) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1190,8 +1190,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:47.411Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:11.848Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1200,8 +1200,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:28:47.411Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:11.848Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1253,11 +1253,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -1266,9 +1266,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:47 GMT',
-  'ETag',
-  'W/"3598165922300205710"',
+  'Thu, 09 Jul 2020 16:25:12 GMT',
+  'etag',
+  'W/"232822418921518007"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1278,29 +1278,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '74e9809d96f8a2b47a136da72bb56bba',
+  'e32bf1876a569ba1c1c93857ea686756',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=DxrgXWd4RgqhOl3SlTqvic6RBV8AAAAAQUIPAAAAAADrCzSaXlxtbPUJIkOmXv7F; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mW8hZUteTsWPYHjY5ueSm+dEB18AAAAAQUIPAAAAAAAMDzI26oDvHIImI1koIp/1; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ep6/XydORG0cP/K+YMlkBAAAAABKcTbtTbtTvxLPWf1eWFm5; path=/; Domain=.contentful.com',
+  'nlbi_673446=SLgTM6X7fhXI5I24YMlkBAAAAAAMbvtcdwseOhX5GnCYcEdX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=AnV7S+MCIVF5/k0EPWpmA86RBV8AAAAABvsUARTPR9JrxkZaQl7F1Q==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=RHHxLV5lVXLXwVsGPWpmA+dEB18AAAAA85q+1RHJTyDHQipNOGL2fQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15950273-15950278 NNNY CT(0 0 0) RT(1594200526593 30) q(0 0 0 -1) r(3 3) U5'
+  '13-66923847-66923851 NNNY CT(0 0 0) RT(1594311911118 32) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1316,8 +1316,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:48.047Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:12.485Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1326,8 +1326,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:28:47.411Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:11.848Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1368,11 +1368,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -1381,9 +1381,124 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:48 GMT',
-  'ETag',
-  'W/"4095598730009028750"',
+  'Thu, 09 Jul 2020 16:25:12 GMT',
+  'etag',
+  'W/"2927921332069189198"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '40eb4540dd1ee7fda7b53a35c460bc79',
+  'Content-Length',
+  '375',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=IBtGrwKeT0iMBh8xn1zp7edEB18AAAAAQUIPAAAAAACCc2aJ1XuyxubRJ2ydnqeP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=G8cGC/IPnEgvrhjqYMlkBAAAAAB4kHHIplfkf44XCImHuNAq; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=91VpT8olIEBOwlsGPWpmA+dEB18AAAAAVLHt69bjere5z5XwfV7S0g==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '14-86049189-86049200 NNNY CT(0 0 0) RT(1594311911738 32) q(0 0 0 -1) r(2 2) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:13.052Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 5,
+    "publishedAt": "2020-07-09T16:25:13.052Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 3,
+    "version": 6,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "angry dog",
+  "description": "super angry",
+  "fields": []
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:13 GMT',
+  'etag',
+  'W/"15997666040028119424"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1401,136 +1516,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '4021b833e95b8b971f286a8f57831944',
+  '14c777a1b03daf7c988a2d731b007ebf',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4ZXI91o7S4OGULfgvt5c2M+RBV8AAAAAQUIPAAAAAADGwb2314J4Y1YqGq50LBJH; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=U5tHeu29TgaTaDbWdke70+hEB18AAAAAQUIPAAAAAAAOTwWMQ/XvpeutkBohcCZr; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=UBouaCgjFVgwrynaYMlkBAAAAAB6KFoRP9z48fP8kOQZnATB; path=/; Domain=.contentful.com',
+  'nlbi_673446=RgO2XzAp3TkOZRD4YMlkBAAAAACYX8jWdQOf39dAinangBeS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Ak7WHfWsyVk2/00EPWpmA8+RBV8AAAAA+fTDmWVVsTf0kRSHv/M/Sg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=qcewAj+mhRcrw1sGPWpmA+hEB18AAAAAFphhevC+e8iaz6IpZ9rz9w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38156547-38156573 NNNY CT(0 0 0) RT(1594200527213 31) q(0 0 0 -1) r(3 3) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:48.644Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 5,
-    "publishedAt": "2020-07-08T09:28:48.644Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 3,
-    "version": 6,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "angry dog",
-  "description": "super angry",
-  "fields": []
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:28:48 GMT',
-  'ETag',
-  'W/"5059323763109913719"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'ee02dff22d45208621367ce9d75a6030',
-  'Content-Length',
-  '371',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=B0FpOmYHQLyd3RKq1JiLcNCRBV8AAAAAQUIPAAAAAAAwY49xsV8/pFKz6pdl/ryC; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=OEb1c3RWsiEa6nUdYMlkBAAAAABQNAjzB6yMWsanKl/OXWPD; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=KAKSPuXcnjEOAE4EPWpmA9CRBV8AAAAAgGyTxmQRtyUKxBfQiYcWxQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '12-31547155-31547165 NNNY CT(0 0 0) RT(1594200527833 33) q(0 0 0 -1) r(4 4) U5'
+  '4-26739772-26739775 NNNN CT(94 94 0) RT(1594311912144 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1546,8 +1546,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:48.644Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:13.052Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1556,8 +1556,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-08T09:28:48.644Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:13.052Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1598,11 +1598,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -1611,9 +1611,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:49 GMT',
-  'ETag',
-  'W/"5059323763109913719"',
+  'Thu, 09 Jul 2020 16:25:13 GMT',
+  'etag',
+  'W/"15997666040028119424"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1631,21 +1631,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'effc296d057044c4f86529890b526119',
+  '1a7fff22c179e0a8c81507b60492c055',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MNvppclwQqasmXQP92e2etCRBV8AAAAAQUIPAAAAAABIAGVYzmH5cbYIik4zY77+; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SJZ1kJ0PT+G/E9fsVP4wRulEB18AAAAAQUIPAAAAAACeVkHW1FkLI3OTTCTrSsZX; expires=Fri, 09 Jul 2021 11:06:46 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=2fZTXDQHck+NFQiTYMlkBAAAAACb3GzhdSH9/LRbhkodQZdZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=cluuZwrYQSazXYYLYMlkBAAAAADq2yf7vHxjXDveqHncQCW4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=kOyJDUKQWFStAE4EPWpmA9CRBV8AAAAAuyYdjECmcxyV3wfKyRvuQg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=y2W9N3gHpmPww1sGPWpmA+lEB18AAAAAIkArQ1z07+YfHCF2oQdDng==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-8162756-8162758 NNNY CT(0 0 0) RT(1594200528453 34) q(0 0 0 -1) r(3 3) U5'
+  '0-2794462-2794465 NNNY CT(0 0 0) RT(1594311912965 31) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1670,8 +1670,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:28:38.462Z",
-        "updatedAt": "2020-07-08T09:28:48.644Z",
+        "createdAt": "2020-07-09T16:25:03.323Z",
+        "updatedAt": "2020-07-09T16:25:13.052Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -1680,8 +1680,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 5,
-        "publishedAt": "2020-07-08T09:28:48.644Z",
-        "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+        "publishedAt": "2020-07-09T16:25:13.052Z",
+        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -1724,11 +1724,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -1737,9 +1737,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:49 GMT',
-  'ETag',
-  'W/"910227165766382286"',
+  'Thu, 09 Jul 2020 16:25:14 GMT',
+  'etag',
+  'W/"14910209425744553100"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1749,29 +1749,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'c070f6b8822dc480f6593eddc90e4db4',
-  'transfer-encoding',
-  'chunked',
+  'e2f7cfcd54ce32fc9616b2e33190c3e2',
+  'Content-Length',
+  '435',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Cqe0VJrOQwmPb3Pi9hxsrtGRBV8AAAAAQUIPAAAAAABAhxUGjM42yk2W3CTe6e7M; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=8RJw4UOBQhuxXSP8M+HRvulEB18AAAAAQUIPAAAAAADNgwWVxkDaDjV5bTz4s0D+; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=V9IXeX3Z9ERH5gS9YMlkBAAAAAD7q0clej2G0OWRGjUbepUn; path=/; Domain=.contentful.com',
+  'nlbi_673446=SRIfQybY6wPvDqM7YMlkBAAAAAAWCEZpdg66hTHLW3ngWxiX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=eaR6VKmzaBJIAU4EPWpmA9GRBV8AAAAA/HpDzDBXR6+7zDVLIbbr1g==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=JoRAd1jERGFqxFsGPWpmA+lEB18AAAAAm4foj8oyJaZLJWuy0Jcm5Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-12936853-12936856 NNNY CT(0 0 0) RT(1594200529063 28) q(0 0 0 -1) r(2 2) U5'
+  '3-21639669-21639674 NNNY CT(0 0 0) RT(1594311913576 33) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1812,8 +1812,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -1843,9 +1843,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:50 GMT',
+  'Thu, 09 Jul 2020 16:25:15 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -1857,15 +1857,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '792096a9b71d260ca3983cc32e30647a',
+  '17d2e2194a38b47e410b2d199eaea49f',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -1877,11 +1877,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=GW12dTCZSDGgItB++M97j9KRBV8AAAAAQUIPAAAAAACRU8A6H6JiYWeTu4B8X5vt; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Bw6Qx5ssSoOwLIhbxH/5cOpEB18AAAAAQUIPAAAAAAAu425Mghshr5FMaEMborvo; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JVzrWHKLyVjik/U2YMlkBAAAAABPBy27vfCflXv2R95/WyQr; path=/; Domain=.contentful.com',
+  'nlbi_673446=wjVjcI3ARBmpr+9WYMlkBAAAAAD9uuIk4OUaIMBXSTcQvs2l; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=qJBpAihLImUvAk4EPWpmA9KRBV8AAAAAcyjrvB2xMxbGd/6CnEkykg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=vnv3UHCLelBRxVsGPWpmA+pEB18AAAAATSwxTD4UycP5gn1mP7GYBg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1889,7 +1889,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-23191353-23191364 NNYY CT(0 0 0) RT(1594200529367 30) q(0 0 0 -1) r(7 7) U5'
+  '14-86049826-86049834 NNYY CT(0 0 0) RT(1594311913882 25) q(0 0 0 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1905,8 +1905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:51.141Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:15.735Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1915,8 +1915,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-08T09:28:48.644Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:13.052Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1968,11 +1968,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -1981,9 +1981,261 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:51 GMT',
-  'ETag',
-  'W/"18327019666517323153"',
+  'Thu, 09 Jul 2020 16:25:15 GMT',
+  'etag',
+  'W/"7638184034428287910"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'e3b4e783a7294c0b9b1b84eb6a9c5748',
+  'Content-Length',
+  '496',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=G7P5smf4RkKFPm0eipLSn+tEB18AAAAAQUIPAAAAAADeHus5s/JxgMcYuoinkmZh; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=CZzGBCerEV/+9msgYMlkBAAAAAAJW38jMVRxHPQ9lrwbcjFg; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=9+9Vfp5xfiL5xVsGPWpmA+tEB18AAAAA/i1229oRfWbbExDokJqC1Q==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '12-55395660-55395668 NNNN CT(87 88 0) RT(1594311914806 28) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:16.143Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 7,
+    "publishedAt": "2020-07-09T16:25:16.143Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 4,
+    "version": 8,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "goodboys",
+      "name": "number of times he has been called a good boy",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:16 GMT',
+  'etag',
+  'W/"1162459728137802232"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'a12d6171e9e8030f76af111a140e50bb',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=KyqUkMAzTI2bWqtQqoU47+tEB18AAAAAQUIPAAAAAAAGq+mn9mhFhWzqmJViyZwy; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=XE50BKt8dHp6ASkfYMlkBAAAAAD7166lkQud4FHLE7rky4+B; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=ww9xZ9sYRG9ixlsGPWpmA+tEB18AAAAAQFQQXFRHmQt/U+cCWaZuJQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '14-86050253-86050262 NNNY CT(0 0 0) RT(1594311915432 32) q(0 0 0 -1) r(2 2) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:16.143Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 7,
+    "publishedAt": "2020-07-09T16:25:16.143Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 4,
+    "version": 8,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "goodboys",
+      "name": "number of times he has been called a good boy",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:16 GMT',
+  'etag',
+  'W/"1162459728137802232"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2001,273 +2253,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '1c2416441d819737193fb7756e0e4ebd',
-  'Content-Length',
-  '498',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=hWkqYqLbS9KvCjPm0bEGF9KRBV8AAAAAQUIPAAAAAACq6j2IRM6gsyK6nd5j4WgT; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=Mx1eQrrpxQQb85OLYMlkBAAAAAC7m9h8qerS/4EzvDw4x6i+; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=DSD3B2TiyHu2Ak4EPWpmA9KRBV8AAAAATfeD2R5geEey9uhzRett9Q==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '13-38157504-38157514 NNNY CT(0 0 0) RT(1594200530285 29) q(0 0 0 -1) r(3 3) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:51.832Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 7,
-    "publishedAt": "2020-07-08T09:28:51.832Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 4,
-    "version": 8,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "goodboys",
-      "name": "number of times he has been called a good boy",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:28:51 GMT',
-  'ETag',
-  'W/"3851015708028788060"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'f9779aa8fd5f2ee338b43169e14bc6c7',
+  'c41b508d7525d87394e3ca47d8875859',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=STkcWnq2Qned8ctjeECU0tORBV8AAAAAQUIPAAAAAADbvKs6MzCKeQio8fzuQ4Er; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=bKIyblDNTfufmF4sKUiJUOtEB18AAAAAQUIPAAAAAABFNtuLLo0GeilP9RGBUrDE; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FVA2WrCkBxCdMnlqYMlkBAAAAACIN7e6HI7IywmBupKV4bHB; path=/; Domain=.contentful.com',
+  'nlbi_673446=fvXTeJvb0CI7D9rHYMlkBAAAAADaH1uRnYnjCnOYi81jXQ2D; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=XsXELTBvjBKeA04EPWpmA9ORBV8AAAAAdkNAcNpSSWAtY9IvBX2Xzw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=QuMAfsEfESKjxlsGPWpmA+tEB18AAAAACB737vkuSR3vSF+sxUrCDQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-25301281-25301288 NNNN CT(93 87 0) RT(1594200530903 31) q(0 0 2 -1) r(5 5) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:51.832Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 7,
-    "publishedAt": "2020-07-08T09:28:51.832Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 4,
-    "version": 8,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "goodboys",
-      "name": "number of times he has been called a good boy",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:28:52 GMT',
-  'ETag',
-  'W/"3851015708028788060"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'a534708ad975bb4eebc4e1b7f29da60a',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=OZsIybVFSwCNZ4UeQ4i6W9ORBV8AAAAAQUIPAAAAAABPPPxm+oLeF3Yl7umIkNbi; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=B92cXxyKFHLof7qVYMlkBAAAAAC6tz1qnOLrxQYZqjux6tMn; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=3X7zcqOia0zjA04EPWpmA9ORBV8AAAAALmV5bcQ56fmQqpgV8AjVyQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '14-49176580-49176591 NNNY CT(0 0 0) RT(1594200531519 31) q(0 0 0 -1) r(2 2) U5'
+  '11-41049037-41049045 NNNY CT(0 0 0) RT(1594311915750 39) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2292,8 +2292,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:28:38.462Z",
-        "updatedAt": "2020-07-08T09:28:51.832Z",
+        "createdAt": "2020-07-09T16:25:03.323Z",
+        "updatedAt": "2020-07-09T16:25:16.143Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -2302,8 +2302,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 7,
-        "publishedAt": "2020-07-08T09:28:51.832Z",
-        "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+        "publishedAt": "2020-07-09T16:25:16.143Z",
+        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -2357,11 +2357,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -2370,9 +2370,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:52 GMT',
-  'ETag',
-  'W/"14724765763972732364"',
+  'Thu, 09 Jul 2020 16:25:16 GMT',
+  'etag',
+  'W/"7046238294136992912"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2382,29 +2382,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  'c5f049823ba9081a46f5a042d69aaff8',
+  'dabdb72181ddb17eba74dd6e0de519e8',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=U57y/FJiRBeu642WSbvbQdSRBV8AAAAAQUIPAAAAAAC8FhxwCtpeWZJtRoGiof7C; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=V2H3LZhXRBueWldVSBcSv+xEB18AAAAAQUIPAAAAAAD2vE2Vdp2wFnMVLDpbFtHT; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xm4CTIEsPBfTPhyfYMlkBAAAAABkZLdUKlURDA+0x7aBVGIR; path=/; Domain=.contentful.com',
+  'nlbi_673446=ok9ibZUA2AcYdmgeYMlkBAAAAADRIRRc6QGOoKrB3JoqMwj7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=AUKvJHHstyVFBE4EPWpmA9SRBV8AAAAAsMQ6TnEVzkZhV/2eVf/sxg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=N2gfdBl+6XzsxlsGPWpmA+xEB18AAAAAgwwR9sX9ISMAP6grPTC2vQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49176685-49176696 NNNY CT(0 0 0) RT(1594200531825 28) q(0 0 0 -1) r(2 2) U5'
+  '5-42737992-42737994 NNNY CT(0 0 0) RT(1594311916038 26) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2421,7 +2421,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-08T09:28:39.811Z",
+    "createdAt": "2020-07-09T16:25:03.987Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2429,7 +2429,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:28:51.945Z",
+    "updatedAt": "2020-07-09T16:25:16.209Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2469,20 +2469,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:52 GMT',
-  'ETag',
-  '"6584607252561165157"',
+  'Thu, 09 Jul 2020 16:25:17 GMT',
+  'etag',
+  '"8848235822135652323"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2492,23 +2492,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  'f7b894d8cd440653066dff4bb155c7d1',
+  '1635f1037eb84dc41d42212d6d1ef839',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=dCKRdI6cRlmYfJlljDsBm9SRBV8AAAAAQUIPAAAAAACfL34vpIyEtUweyq62RCf6; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SZ7CQXVlQcO3tRxF6nirxexEB18AAAAAQUIPAAAAAACo0iPqjGqj68ktIEmiERYn; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=drBtQVFxXHO0xesDYMlkBAAAAADsnpNazpB1LGvu1MbkPnQX; path=/; Domain=.contentful.com',
+  'nlbi_673446=AkJfTbttBxlG0oAyYMlkBAAAAACm1xr4BuAw4thAhtfiJ5EK; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=qrBDLRPG1GKABE4EPWpmA9SRBV8AAAAAVFzzukjbWvMqcNQWl+kxOQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=cS5nPoIeoj5jx1sGPWpmA+xEB18AAAAAKNY7/zaZtn7ezXxMzzMIUA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2516,7 +2516,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-38158095-38158104 NNYY CT(0 0 0) RT(1594200532121 28) q(0 0 0 -1) r(1 1) U5'
+  '6-13874432-13874435 NNYN CT(86 87 0) RT(1594311916302 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2557,8 +2557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -2588,9 +2588,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:53 GMT',
+  'Thu, 09 Jul 2020 16:25:18 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -2602,15 +2602,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '393991c645d98077225ab710d58578c3',
+  'd8cdc591025040290edf9b56f23041e1',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -2622,11 +2622,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FTgpSMaOSBapPaeYhSpIodSRBV8AAAAAQUIPAAAAAADrRkQtocmyKSD/XTqE8M3N; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=enqdYb0DQOykxBVF8fT25O1EB18AAAAAQUIPAAAAAAC8HKhVd9ZjALyPccXSASD4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=9SDVe5mLPjPquaYfYMlkBAAAAAD3zMk6Dj6edF9oS8rEpDa9; path=/; Domain=.contentful.com',
+  'nlbi_673446=C2y2PpdSJz5Cfx95YMlkBAAAAACW7sGGgsTb+6V9ba3JwosE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=sFAZDsq5uT7ZBE4EPWpmA9SRBV8AAAAAqYte8UbCO/HPPFK85E/Mpg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=rzOTdLHoli+jyFsGPWpmA+1EB18AAAAAGgYAQiMaCDEtk1gNr83A3A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2634,7 +2634,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49176934-49176946 NNYY CT(0 0 0) RT(1594200532541 30) q(0 0 0 -1) r(1 1) U5'
+  '7-27374452-27374456 NNYN CT(93 93 0) RT(1594311916766 20) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2650,8 +2650,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:53.723Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:18.597Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2660,8 +2660,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-08T09:28:51.832Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:16.143Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2713,11 +2713,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -2726,9 +2726,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:53 GMT',
-  'ETag',
-  'W/"16592373564337195577"',
+  'Thu, 09 Jul 2020 16:25:18 GMT',
+  'etag',
+  'W/"3211865957038243333"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2738,29 +2738,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '37fc1b733e3d702faf74709bf5e8491a',
-  'Content-Length',
-  '503',
+  '44387c67cd24d76ae6eda5645387c6d5',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/bbtmzrlTgS5bwFxFQqLM9WRBV8AAAAAQUIPAAAAAAAKlUEDPqqkb8cppVru1nRR; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=12e3QsJ+Rx2CWuIUm0xxO+5EB18AAAAAQUIPAAAAAADWt+6cOX9vkKkD6t2ieUj8; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4uxnfDTtugBrwQ39YMlkBAAAAADCQBqD0bMei12XyWsTpDQv; path=/; Domain=.contentful.com',
+  'nlbi_673446=TKmXWrrsaE1jDEQiYMlkBAAAAAC1Eej80cW4MoCUrggYATYP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=7FhFTw5M/EVnBU4EPWpmA9WRBV8AAAAAXXMUCRjynx4Ef87ltXdVeQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=XrzMes5wIzkdyVsGPWpmA+5EB18AAAAABLEFopG7X1cmzU4rD0rXMQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-16016706-16016711 NNNN CT(93 94 0) RT(1594200532759 32) q(0 0 2 -1) r(5 5) U5'
+  '12-55396381-55396387 NNNY CT(0 0 0) RT(1594311917878 31) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2776,8 +2776,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:54.231Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:18.902Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2786,8 +2786,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-08T09:28:54.231Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:18.902Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2839,11 +2839,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -2852,70 +2852,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:54 GMT',
-  'ETag',
-  'W/"234253625784123604"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'c3a75962c089a102b11078d74cc1e5b0',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=YPrUhTkvQh+xQMMKMLHbndWRBV8AAAAAQUIPAAAAAABXER7sfM9Oh6L2gY5jc27L; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=bg0vV5rGpVCd0uQiYMlkBAAAAADe36tG5KZBNWgkHVyKQPi2; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=gu+bdOV5CjwiBk4EPWpmA9WRBV8AAAAAu/DENRzTmgvpiSd4qZu13A==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '10-15106511-15106516 NNNN CT(86 87 0) RT(1594200533353 34) q(0 0 2 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/editor_interface', {"controls":[{"fieldId":"aDifferentId"}]})
-  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-08T09:28:39.811Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-08T09:28:54.893Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:28:54 GMT',
-  'ETag',
-  '"103371693709989453"',
+  'Thu, 09 Jul 2020 16:25:18 GMT',
+  'etag',
+  'W/"14506092796344775312"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2933,21 +2872,82 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'c989ba6a8d440c8b041f950c4c72483b',
+  '013d2150a9d95378cce395b819b23406',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=cV8QLBx2TqmFZaFBOl886O5EB18AAAAAQUIPAAAAAADSxplyOmBrX7YZFwabEN4G; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=agqvMZqCdVN22RGLYMlkBAAAAACcbUWz44lDNRX1h7lctuu3; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=GSUMaBla2BeDyVsGPWpmA+5EB18AAAAA7ssZNxIjWjKOto7WeZtCTQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '5-42738298-42738301 NNNY CT(0 0 0) RT(1594311918191 20) q(0 0 0 -1) r(2 2) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/editor_interface', {"controls":[{"fieldId":"aDifferentId"}]})
+  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-09T16:25:03.987Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-09T16:25:19.246Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:19 GMT',
+  'etag',
+  '"9617718487684677262"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '5242e79c38fd3480fd8ed077e46c2852',
   'Content-Length',
   '922',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=hI1LBGqtRXWS74Pcz0yEXdaRBV8AAAAAQUIPAAAAAAABwSB/edtlCIaEEjG81CFE; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=pKFnIyvpS7GGkmy42b6Ka+5EB18AAAAAQUIPAAAAAABtq56Pc6m8V9xUX/r7YhxV; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JdkgAMu4KXKmZp38YMlkBAAAAAB4/OjL28m9Fi1ajZTmF0Xt; path=/; Domain=.contentful.com',
+  'nlbi_673446=fn0ncXJEpwL3DrOoYMlkBAAAAACexr30SOxtbT2IgMy9UFww; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=UlGPR6ILlyIbB04EPWpmA9aRBV8AAAAA6j6cigWkwueBzKhxB/lddA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=bAxPLYr+fETnyVsGPWpmA+5EB18AAAAApVFm8djlnjsUJyfe9uLMtA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31548608-31548617 NNNN CT(86 86 0) RT(1594200533972 37) q(0 0 1 -1) r(6 6) U5'
+  '4-26740384-26740386 NNNY CT(0 0 0) RT(1594311918524 29) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2963,8 +2963,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:55.601Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:19.576Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2973,8 +2973,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-08T09:28:54.231Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:18.902Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3026,11 +3026,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -3039,135 +3039,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:55 GMT',
-  'ETag',
-  'W/"969487790986713381"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '82fdf3f1a9e2ac67aa872a7aea7d3df7',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=swpTQ5dYT9ieTR8jJ88/zNeRBV8AAAAAQUIPAAAAAACUSFPOpYF6d8Ma0g/JXRnc; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=5zHMBxWW3yr0ixgmYMlkBAAAAAAgZJvQu+46EjnAcSuYnyN1; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=CzVhYwtcF32YB04EPWpmA9eRBV8AAAAAnqiaEF562EPgicBeSiY3KA==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '2-5589110-5589114 NNNY CT(0 0 0) RT(1594200534803 31) q(0 0 0 -1) r(2 2) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:55.919Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 11,
-    "publishedAt": "2020-07-08T09:28:55.919Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 6,
-    "version": 12,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "Friendly dog",
-  "description": "Who's a good boy? He is!",
-  "fields": [
-    {
-      "id": "aDifferentId",
-      "name": "ID switching is fun!",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:28:56 GMT',
-  'ETag',
-  'W/"303047498072662263"',
+  'Thu, 09 Jul 2020 16:25:19 GMT',
+  'etag',
+  'W/"4301013271912430813"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3185,25 +3059,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '7fac27c4e1cf983438d2092740ce5130',
-  'transfer-encoding',
-  'chunked',
+  'e912e66a1016bc14dcc65b5b0cddeac9',
+  'Content-Length',
+  '495',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+vZpTGJrTYGzLWkCQXjXq9eRBV8AAAAAQUIPAAAAAAAr5XGPIDKNxqfuvqoCk6tQ; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AE5Sr80rSmmkbkPWVZWzye9EB18AAAAAQUIPAAAAAAAvLVQwG3w7NwcmEUYdBVF9; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LeQZOgOcrA7k6WcOYMlkBAAAAAASZxG6noVRzMEPG+qYsrd5; path=/; Domain=.contentful.com',
+  'nlbi_673446=eB7nJpb25gRyUx1cYMlkBAAAAABvMEBD+E3dXiIzClHcAbpR; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=39drPmUh3zcKCE4EPWpmA9eRBV8AAAAAzJ6YRCV+ZN2/Kw7BMMzaEQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=kJRSanvURzhgylsGPWpmA+9EB18AAAAAn6OtzsknSRMBsn4Or5K+eA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38158901-38158910 NNNY CT(0 0 0) RT(1594200535209 27) q(0 0 0 -1) r(3 3) U5'
+  '5-42738391-42738399 NNNY CT(0 0 0) RT(1594311918810 31) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
   .reply(200, {
   "sys": {
     "space": {
@@ -3215,8 +3089,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:55.919Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:20.044Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3225,8 +3099,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 11,
-    "publishedAt": "2020-07-08T09:28:55.919Z",
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "publishedAt": "2020-07-09T16:25:20.044Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3278,11 +3152,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -3291,9 +3165,135 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:56 GMT',
-  'ETag',
-  'W/"303047498072662263"',
+  'Thu, 09 Jul 2020 16:25:20 GMT',
+  'etag',
+  'W/"5070260442711112897"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35997',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '7',
+  'X-Contentful-Request-Id',
+  'b6e4c412d6ee047b49ad6f7a7fe1885a',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=B86wXjiESNCvOQO/wlQV9u9EB18AAAAAQUIPAAAAAACSo6My0TS3T0Ebwe4tfKqb; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=CFW3fd153UoOwvRyYMlkBAAAAAAuoj4hXEmh2kNR19inXB6m; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=wKr/cQ+KxDvnylsGPWpmA+9EB18AAAAAHf89ao/yIclpnac9CitW/w==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '4-26740463-26740467 NNNY CT(0 0 0) RT(1594311919312 33) q(0 0 0 -1) r(3 3) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:20.044Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 11,
+    "publishedAt": "2020-07-09T16:25:20.044Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 6,
+    "version": 12,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "Friendly dog",
+  "description": "Who's a good boy? He is!",
+  "fields": [
+    {
+      "id": "aDifferentId",
+      "name": "ID switching is fun!",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:20 GMT',
+  'etag',
+  'W/"5070260442711112897"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3311,21 +3311,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '48bf3b2e76282b85ff2c1c4cc747f5c3',
-  'transfer-encoding',
-  'chunked',
+  'cdddf4d764a37b546cbfa31e6923b6f4',
+  'Content-Length',
+  '490',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=gntWjOPmQx2biE0YryH8cteRBV8AAAAAQUIPAAAAAADlwPzLO9EUUrZ2ryFKOK/o; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=bEmAZAQDSwe9mhzQ6G1qR+9EB18AAAAAQUIPAAAAAAAGZEpRD2L7B78aQzS3lkkR; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4DPUFyZoDnXSvdekYMlkBAAAAABqAYDwaGn3kd162h3XORBg; path=/; Domain=.contentful.com',
+  'nlbi_673446=2fWLLnvvNFw9eUcpYMlkBAAAAACh0qHJ2kLwmmU3oKjG9cPy; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=AkBjEHIw3WRhCE4EPWpmA9eRBV8AAAAAj6gRSWeq86EXvhznNf8VXg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=JdenOjWeOEFDy1sGPWpmA+9EB18AAAAAd3CzMI7CS6vAJHBuIHnang==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31548945-31548948 NNNY CT(0 0 0) RT(1594200535613 33) q(0 0 0 -1) r(2 2) U5'
+  '14-86051568-86051573 NNNY CT(0 0 0) RT(1594311919722 43) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3350,8 +3350,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:28:38.462Z",
-        "updatedAt": "2020-07-08T09:28:55.919Z",
+        "createdAt": "2020-07-09T16:25:03.323Z",
+        "updatedAt": "2020-07-09T16:25:20.044Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -3360,8 +3360,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 11,
-        "publishedAt": "2020-07-08T09:28:55.919Z",
-        "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+        "publishedAt": "2020-07-09T16:25:20.044Z",
+        "firstPublishedAt": "2020-07-09T16:25:03.794Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -3415,11 +3415,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -3428,9 +3428,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:56 GMT',
-  'ETag',
-  'W/"10703430495555291407"',
+  'Thu, 09 Jul 2020 16:25:20 GMT',
+  'etag',
+  'W/"13244042601259833950"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3448,21 +3448,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'baec40e8c71a955a0913357c067eb7e1',
+  '2f4a11dbf49565db95b053208985f349',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Xvg6YWZ3QySjNN6diPaMfNiRBV8AAAAAQUIPAAAAAAD3CTJu4zqsQT1vMCf68Xhq; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=N/4IeJCPQuKde85zXo4/6PBEB18AAAAAQUIPAAAAAAAfbuIOjs2a9nvccuiwugLo; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=lnn+Lb/sYk5VCJwSYMlkBAAAAADsin32GTHEgZUlgrpjgTYF; path=/; Domain=.contentful.com',
+  'nlbi_673446=xWXBRYz/RTVK0BfuYMlkBAAAAACUiZaLfMWdnw9mk8mM1s5Y; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=BRW7C+hxswINCU4EPWpmA9iRBV8AAAAA01zAYetPmHowyRN38xTUeg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=JulIec8lYwOBy1sGPWpmA/BEB18AAAAABlQe5CPkuuAKAAGXf480qQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15951170-15951172 NNNN CT(88 89 0) RT(1594200535936 31) q(0 0 2 -1) r(4 4) U5'
+  '7-27374664-27374666 NNNY CT(0 0 0) RT(1594311920014 33) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3488,19 +3488,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:57 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:21 GMT',
+  'etag',
   '"10440568906820546102"',
   'Server',
   'Contentful',
@@ -3511,23 +3511,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '7',
   'X-Contentful-Request-Id',
-  'c3e818a98475ed152e427fafb6332905',
+  '2ca963d392b9bcfe43b3358cbad92647',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=GppvambdSQmPKD0k/fVzitiRBV8AAAAAQUIPAAAAAAAOxCoL+eCFtfrzaLvzraot; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=slx9vRglTKWMqzJfaAD9FvBEB18AAAAAQUIPAAAAAABgUTvPdVnlJjE1tx8Tq3Ik; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=iVNeS0da1jy1oPo7YMlkBAAAAADLYNFiTLBp87fjZ7a2NW9x; path=/; Domain=.contentful.com',
+  'nlbi_673446=8A21eJR1fGzadpFkYMlkBAAAAABzsCYkODGh5BHs9BwewU+9; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=cid9NlYNCTyrCU4EPWpmA9iRBV8AAAAAKU2CbDON/9KZra+rvjzcew==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=v422CYe83hYezFsGPWpmA/BEB18AAAAAXYZ+YcPwm236mUVMpX9uOA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3535,7 +3535,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-23193042-23193049 NNYY CT(0 0 0) RT(1594200536653 32) q(0 0 0 -1) r(3 3) U5'
+  '14-86051720-86051726 NNYY CT(0 0 0) RT(1594311920336 28) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3576,8 +3576,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -3607,9 +3607,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:57 GMT',
+  'Thu, 09 Jul 2020 16:25:21 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -3621,15 +3621,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '1dd295653cd477717f9e671e9341b7d1',
+  'af523484fa2085489163fdf0e2223ddd',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -3641,11 +3641,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Sz2v35KkTkqx2zHoL1b0ldmRBV8AAAAAQUIPAAAAAABwOP5bLKipCC4RrJE32lQS; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ycN+D8OGSYCvQ2Y6bSVKPPBEB18AAAAAQUIPAAAAAAD4KP1DQsbbUEJPsXPH8LwP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FZ8IDxjKD1qi8a3TYMlkBAAAAAANG+m4B/0sI1LNhpIvcoQA; path=/; Domain=.contentful.com',
+  'nlbi_673446=zbcTRBr1SVs1yk8ZYMlkBAAAAAACsnkfT6yZ/BnP7Bsxlp/7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=bAhFM1y5nxMXCk4EPWpmA9mRBV8AAAAAttMKxLyUKMiCkQbcs44mgg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=jx3XQ2+vdBNwzFsGPWpmA/BEB18AAAAAGFeqF94I9k/VEfX2GSDpQw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3653,7 +3653,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-15107073-15107080 NNYY CT(0 0 0) RT(1594200537249 30) q(0 0 0 -1) r(1 1) U5'
+  '13-66926019-66926027 NNYY CT(0 0 0) RT(1594311920834 26) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3669,8 +3669,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:28:38.462Z",
-    "updatedAt": "2020-07-08T09:28:58.561Z",
+    "createdAt": "2020-07-09T16:25:03.323Z",
+    "updatedAt": "2020-07-09T16:25:21.756Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3678,7 +3678,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "Environment"
       }
     },
-    "firstPublishedAt": "2020-07-08T09:28:39.439Z",
+    "firstPublishedAt": "2020-07-09T16:25:03.794Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3723,11 +3723,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -3736,68 +3736,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:58 GMT',
-  'ETag',
-  'W/"15969911792016186163"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'bd49fb835f5df75d8d66c67e59a5a8ba',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=G2faZnPKT/ms2yz8AYYZ+tqRBV8AAAAAQUIPAAAAAABlOgnzrIEvkWr4GloZiu23; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=Q/dCLgnK6Whf9tXyYMlkBAAAAADQ8BbPuc+26Jstfhjt2lGf; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=DsJVXs1+WH7ECk4EPWpmA9qRBV8AAAAA6Ip46+agobKr6erdX6x/iw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '4-15951425-15951428 NNNY CT(0 0 0) RT(1594200537775 33) q(0 0 0 -1) r(2 2) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .delete('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(204, "", [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:28:59 GMT',
+  'Thu, 09 Jul 2020 16:25:21 GMT',
+  'etag',
+  'W/"3288684190985338390"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3815,38 +3756,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'f2c03ede215f84e90c9c86cb75d36f00',
+  '04ee4eec2ac25aac79569f1166675f94',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mIFFxS93SvOiezcve5AzEdqRBV8AAAAAQUIPAAAAAADxUkWbz1qPt+7lYUdmD/i1; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=+8qi2VLhRQ2FMLCmhYdAQ/FEB18AAAAAQUIPAAAAAACHQCkRK2A42Xb+OFn2bfmH; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=OVwEccSOK3/gILaWYMlkBAAAAACo/bJteRjy8UgWKV/214hB; path=/; Domain=.contentful.com',
+  'nlbi_673446=02/tT8F1RFzeGTDYYMlkBAAAAABVT/r+78O9swQF5GkO1TvQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=y24fIfMR7mEeC04EPWpmA9qRBV8AAAAAJaQkfPtXRvLwDk4+wecWxQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=oYpHfbFsDmO/zFsGPWpmA/FEB18AAAAAf4b2k2gBO4hJEIDv4SyEmg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31549598-31549601 NNNY CT(0 0 0) RT(1594200538225 32) q(0 0 0 -1) r(2 2) U5'
+  '7-27374762-27374764 NNNY CT(0 0 0) RT(1594311921034 28) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
-  .reply(404, {
-  "sys": {
-    "type": "Error",
-    "id": "NotFound"
-  },
-  "message": "The resource could not be found.",
-  "details": {
-    "type": "ContentType",
-    "id": "dog",
-    "environment": "env-integration",
-    "space": "bohepdihyxin"
-  },
-  "requestId": "841b158cf173f64d03390f912b68dcf6"
-}
-, [
+  .delete('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(204, "", [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -3857,20 +3786,18 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:59 GMT',
-  'ETag',
-  '"106939959205791809"',
+  'Thu, 09 Jul 2020 16:25:22 GMT',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3888,15 +3815,88 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '841b158cf173f64d03390f912b68dcf6',
+  'a16133d2d7acd857be6d55f38b65e886',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=m8Z9SlxyRVWFcft+jb1R/NqRBV8AAAAAQUIPAAAAAACsabAO4ntOqqKQIU+MStiV; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=gLbEBVv/RBet5c14Tg/8zfFEB18AAAAAQUIPAAAAAADHhHtpmphOKfONQKTSI08L; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SVM5QRcmbS5ZqjVQYMlkBAAAAAAOtzcNttP9zSeps9URsK26; path=/; Domain=.contentful.com',
+  'nlbi_673446=NPKNV0VZo0B8F8wjYMlkBAAAAACUPQLY2oDNS5FBZWUGkmk5; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=N+sDYyEYFwuLC04EPWpmA9qRBV8AAAAAOOXAhf7gid6N1LraAJNDdQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=aaTpchY1nhsGzVsGPWpmA/FEB18AAAAAWov97nhFiTEHVJwhEpEqkw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '4-26740639-26740644 NNNY CT(0 0 0) RT(1594311921364 30) q(0 0 0 -1) r(3 3) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/dog')
+  .reply(404, {
+  "sys": {
+    "type": "Error",
+    "id": "NotFound"
+  },
+  "message": "The resource could not be found.",
+  "details": {
+    "type": "ContentType",
+    "id": "dog",
+    "environment": "env-integration",
+    "space": "bohepdihyxin"
+  },
+  "requestId": "2a6181a793aabadf90f800c454834744"
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:22 GMT',
+  'etag',
+  '"17118622069612008956"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  '2a6181a793aabadf90f800c454834744',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=aJgaryYTSkmSxvTC7WV3kfFEB18AAAAAQUIPAAAAAAA3mQZa2WmDqLJpnYJ9/vV1; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=YBfKPKJKPVqZeQf/YMlkBAAAAABIt+DhZ1U/iNnUjHQvWp4i; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=yI20bsOgiU9MzVsGPWpmA/FEB18AAAAA6EOKDnCzQbiNEZkCE7/gtw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3904,7 +3904,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49179036-49179049 NNYY CT(0 0 0) RT(1594200538680 31) q(0 0 0 -1) r(1 1) U5'
+  '12-55397095-55397101 NNYY CT(0 0 0) RT(1594311921680 34) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3930,19 +3930,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:28:59 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:22 GMT',
+  'etag',
   '"10440568906820546102"',
   'Server',
   'Contentful',
@@ -3953,23 +3953,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '3c7b7f003b5cc5e32879b719a5d316ba',
+  '0dd9999f6f2ecb1da79380c25121c51e',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BkDt5Pn/T02s1XTNSoolcNuRBV8AAAAAQUIPAAAAAAA6KeM2s0phUg5YzwZ986QR; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/LizykGpTLy+kMGTn3pFEfJEB18AAAAAQUIPAAAAAAC3JmD7fFtkYNRmOx2rY3LS; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=1NhFKd80a1TF+wsIYMlkBAAAAACmx3PvTeTlfCrPkaWnNUPj; path=/; Domain=.contentful.com',
+  'nlbi_673446=0dS7DxTLkCXTOWaTYMlkBAAAAADw8eScdtrwVDgvvSXa8uLz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=u/iXWzrJRGsZDE4EPWpmA9uRBV8AAAAAoJAtxbl1HpfXKBL02uGGXA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=CH9DPfeZliP0zVsGPWpmA/JEB18AAAAAerxkJsvTRhzeMP4ltT3LfA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3977,7 +3977,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-23193439-23193443 NNYY CT(0 0 0) RT(1594200539149 31) q(0 0 0 -1) r(3 3) U5'
+  '2-9265144-9265145 NNYN CT(93 93 0) RT(1594311922082 27) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4018,8 +4018,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -4049,9 +4049,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:00 GMT',
+  'Thu, 09 Jul 2020 16:25:23 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -4071,7 +4071,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd8b72a2d06acb15abdc9c3a9392d1017',
+  'beeadb3e3299c7b866b262037a1f6de9',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -4083,11 +4083,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Zipj6NDaTTy48/ovLqKLetyRBV8AAAAAQUIPAAAAAAAVg5MclMVi8OHlhgoSm+2x; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=DxUsaNSSRCioRbT5kKO1dPJEB18AAAAAQUIPAAAAAAA3x6sDvrHKG/fhy8pfAIb3; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=z8JEJhZwKiwDspOjYMlkBAAAAABASEcHY4dc6su9+LGdZUcH; path=/; Domain=.contentful.com',
+  'nlbi_673446=ZDw3UG1c6zO2Bn/DYMlkBAAAAAAmf6ifzmezGzHMVmZPzX9X; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=mnv1S3BGzS/eDE4EPWpmA9yRBV8AAAAAQAeSyWAJJdc9BE3+n+O9Qw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=zqz0PI6uQzc+zlsGPWpmA/JEB18AAAAA0H/sKrizWP+bIgrLcf8N5Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4095,12 +4095,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '1-2744311-2744312 NNYY CT(0 0 0) RT(1594200539495 27) q(0 0 0 -1) r(6 6) U5'
+  '13-66926432-66926442 NNYY CT(0 0 0) RT(1594311922592 33) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dieatary-food', {"name":"Dieatary Food","fields":[{"id":"name","type":"Symbol","name":"name of the food","validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}]},{"id":"calories","type":"Link","linkType":"Asset","name":"amount of calories the food contains","validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}]}],"description":"Food with up to 500 calories"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-08T09:29:01.228Z","updatedAt":"2020-07-08T09:29:01.228Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-09T16:25:23.756Z","updatedAt":"2020-07-09T16:25:23.756Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4111,20 +4111,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:01 GMT',
-  'ETag',
-  '"123399840763186970"',
+  'Thu, 09 Jul 2020 16:25:23 GMT',
+  'etag',
+  '"10647023984675792264"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4142,21 +4142,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'b6c289bd369f7e96eeb5cc2596e4e2ab',
+  '050679a06c1fc0dfd9bb6154938bd66c',
   'Content-Length',
   '1783',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=gyP4xGPwSg66RsNJKsdSvNyRBV8AAAAAQUIPAAAAAAAkunVjrQCUUxQc/S4s1NmX; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=OnOq0BlzRS6gx2YirtrE4vNEB18AAAAAQUIPAAAAAABV4f43XPOY4FSk8F9KJN64; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=HoFoQklsBQi+U3inYMlkBAAAAADnIn5vvIBLaX77vhb9mcID; path=/; Domain=.contentful.com',
+  'nlbi_673446=52c7CXpIcBGFaJ6jYMlkBAAAAABtSzzbsfk58qUOS/QKEki/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=9yDWMJODn0J5DU4EPWpmA9yRBV8AAAAAY/DgJnOxe8zskfYNZTUBXA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=RpocaVlFZ1bazlsGPWpmA/NEB18AAAAAlMUpVmo+Hd+sCMBTlJjbXw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '2-5589348-5589349 NNNY CT(0 0 0) RT(1594200540327 29) q(0 0 0 -1) r(5 5) U5'
+  '13-66926489-66926499 NNNY CT(0 0 0) RT(1594311922898 25) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4172,8 +4172,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:01.228Z",
-    "updatedAt": "2020-07-08T09:29:01.694Z",
+    "createdAt": "2020-07-09T16:25:23.756Z",
+    "updatedAt": "2020-07-09T16:25:24.097Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4197,8 +4197,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:01.694Z",
-    "publishedAt": "2020-07-08T09:29:01.694Z",
+    "firstPublishedAt": "2020-07-09T16:25:24.097Z",
+    "publishedAt": "2020-07-09T16:25:24.097Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4269,11 +4269,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -4282,9 +4282,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:01 GMT',
-  'ETag',
-  'W/"7016253029570906987"',
+  'Thu, 09 Jul 2020 16:25:24 GMT',
+  'etag',
+  'W/"6050121518920068446"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4302,21 +4302,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '0df788a4bf924943b81043ebb5cb577b',
+  '162bf50edf5d1525ff825088b8c6ef88',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=96v4lgo1SAG7G1Qt6ds0A92RBV8AAAAAQUIPAAAAAAC/qww2YG3aLUlR/3XCN6DI; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=LD/SGZBuRNOLpWj2OKyeQ/NEB18AAAAAQUIPAAAAAAA+Upi8+SyWQVG0DBl9BMvE; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=i2lJYegVZD1Uqr13YMlkBAAAAABZIgKKO1LjtlVJVXd35JBx; path=/; Domain=.contentful.com',
+  'nlbi_673446=qQnyJgerl3iSd+skYMlkBAAAAACiqC4BRzCnvCHxIRTIE7bQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=G40zeP6xwncJDk4EPWpmA92RBV8AAAAAO8bMjp8Isc9dp3Czpuj+XA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=febQS740TjRLz1sGPWpmA/NEB18AAAAANJSJEFATLtH6gCNIY0lEfw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-23193835-23193846 NNNY CT(0 0 0) RT(1594200540933 36) q(0 0 0 -1) r(4 4) U5'
+  '2-9265189-9265191 NNNY CT(0 0 0) RT(1594311923366 32) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4332,8 +4332,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:01.228Z",
-    "updatedAt": "2020-07-08T09:29:01.694Z",
+    "createdAt": "2020-07-09T16:25:23.756Z",
+    "updatedAt": "2020-07-09T16:25:24.097Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4342,8 +4342,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:29:01.694Z",
-    "firstPublishedAt": "2020-07-08T09:29:01.694Z",
+    "publishedAt": "2020-07-09T16:25:24.097Z",
+    "firstPublishedAt": "2020-07-09T16:25:24.097Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -4429,11 +4429,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -4442,9 +4442,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:02 GMT',
-  'ETag',
-  'W/"5710019624164312603"',
+  'Thu, 09 Jul 2020 16:25:24 GMT',
+  'etag',
+  'W/"16242354007701607109"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4454,29 +4454,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '056904c3b22c04f04e9557aacf53d379',
-  'Content-Length',
-  '652',
+  'e8983262210c20de8700ca3118756ece',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+HQjGM87TuaTbZ0rtRO4it2RBV8AAAAAQUIPAAAAAABAPUhpC3MHlnlrdmThfY+D; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=5zh9HPEgRCqFt22WZoJPYPREB18AAAAAQUIPAAAAAADAuy+7N01jq3F5ps8j+OeH; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JCrEWGI3Tya/Sxj1YMlkBAAAAADKtiVB4EYrzHGRJ1HnmuhL; path=/; Domain=.contentful.com',
+  'nlbi_673446=NrXvNnOwm1hFPir4YMlkBAAAAACk8SElkUTMm7dCa/kY2Lwg; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=tRR8MTPCs1OVDk4EPWpmA92RBV8AAAAAUprquA1UuL9DtYTNtvhbJw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=PHA1EfO5pSjqz1sGPWpmA/REB18AAAAA+osfDcFbm7zYvG/fZYQb5w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-11764015-11764020 NNNY CT(0 0 0) RT(1594200541561 27) q(0 0 0 -1) r(2 2) U5'
+  '11-41050466-41050475 NNNN CT(94 96 0) RT(1594311923814 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4502,19 +4502,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:02 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:25 GMT',
+  'etag',
   '"10440568906820546102"',
   'Server',
   'Contentful',
@@ -4525,23 +4525,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '68fe1d0c30865a0106dc5d80f6c941cb',
+  'd175043cd5b1b6c2565f7b1a36b11919',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=bTxUCchOQ9ared2K5i90Ld6RBV8AAAAAQUIPAAAAAAC1OsDsYXUMRJ2SNUOZU2/7; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ZO5p1mJ6SsmGLxxdqIk0wPREB18AAAAAQUIPAAAAAADEOxMj2kIlwlTllakOpJEP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=YUwQPiYnmzvI64GOYMlkBAAAAAA9YpTb3MSu506MR3FG+gdY; path=/; Domain=.contentful.com',
+  'nlbi_673446=EIJZN14TmV650HtDYMlkBAAAAABwWVJO1qnjQRxP6cVyyjTU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=pBO7e7arPEkHD04EPWpmA96RBV8AAAAAx3HAN8KlIwnMizbve4TvvQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=ifJpWQ+hSWlp0FsGPWpmA/REB18AAAAA/O3yal1gwo4CQx9Gbv2mzQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4549,7 +4549,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49180173-49180188 NNYY CT(0 0 0) RT(1594200541977 34) q(0 0 0 -1) r(2 2) U5'
+  '14-86052949-86052962 NNYY CT(0 0 0) RT(1594311924432 34) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4590,8 +4590,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -4621,82 +4621,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:03 GMT',
+  'Thu, 09 Jul 2020 16:25:25 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '5f4bf2c5199b7ecb628b58ed917a7964',
-  'X-Download-Options',
-  'noopen',
-  'X-Frame-Options',
-  'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
-  'none',
-  'X-XSS-Protection',
-  '1; mode=block',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=FBWhZcBQRlmO4HW/+NHTXt6RBV8AAAAAQUIPAAAAAADW+siVhwt9o6hWZLwaKsgc; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=5N9pFBKUD3OficXuYMlkBAAAAACZYMO8nXM7C0HNPJ863uvD; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=c/MuarOyJGZXD04EPWpmA96RBV8AAAAAwDzDrvSh9Pw7Ge/Sgan0Yw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
-  'X-Iinfo',
-  '10-15107781-15107793 NNYY CT(0 0 0) RT(1594200542373 34) q(0 0 0 -1) r(1 1) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food', {"name":"foooood","displayField":"taste","fields":[{"id":"taste","type":"Symbol","name":"what it tastes like"}],"description":" well, food"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-08T09:29:03.541Z","updatedAt":"2020-07-08T09:29:03.541Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:03 GMT',
-  'ETag',
-  '"10293719736612681056"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4714,21 +4643,92 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '4386986efe0de6d7d1a42ea66dee64e1',
+  '0d1480069f5d018878a72e9bfe47074a',
+  'X-Download-Options',
+  'noopen',
+  'X-Frame-Options',
+  'ALLOWALL',
+  'X-Permitted-Cross-Domain-Policies',
+  'none',
+  'X-XSS-Protection',
+  '1; mode=block',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=3kBu7MDjRoS0LKaTnglE1fREB18AAAAAQUIPAAAAAADvc4uOy55B70kclzy5rsIT; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=GXeSJMiwfU5baWX0YMlkBAAAAAAvV0SfGXnIpluZST3BOyx3; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=WM2Uf5nrdB+q0FsGPWpmA/REB18AAAAAqmjOKfqdNWItzoVN+tx57Q==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '12-55397707-55397720 NNYY CT(0 0 0) RT(1594311924738 25) q(0 0 0 -1) r(1 1) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food', {"name":"foooood","displayField":"taste","fields":[{"id":"taste","type":"Symbol","name":"what it tastes like"}],"description":" well, food"})
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-09T16:25:25.909Z","updatedAt":"2020-07-09T16:25:25.909Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:25 GMT',
+  'etag',
+  '"13935677294334095123"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35997',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '7',
+  'X-Contentful-Request-Id',
+  '83aba324d2f63a1299d989fa0c3ef148',
   'Content-Length',
   '1064',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=HDyjHSfkRdSVnHuOX7UKxN+RBV8AAAAAQUIPAAAAAABIO7UzfNDg603VUhI94Umd; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=xbC0kjQ2QY277iyBU+pMSfVEB18AAAAAQUIPAAAAAAClUjWpDGiTS5yn8UIO2yC0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FGXWM82HnQaXkGs5YMlkBAAAAADmJBe8U93EMCnAWlvV1Z2s; path=/; Domain=.contentful.com',
+  'nlbi_673446=owIceMsJGCXV4eWaYMlkBAAAAACqyK9KwB9nZbdPh0nD3zmA; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=RN3nOYBfgBLsD04EPWpmA9+RBV8AAAAA6G/xFv/B5hpRrjWOm02dZQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=C+A7e3U3AQI70VsGPWpmA/VEB18AAAAAniaQzWw3tsd8EgA/nI/QQQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-4769021-4769025 NNNY CT(0 0 0) RT(1594200542579 39) q(0 0 0 -1) r(5 5) U5'
+  '11-41050691-41050695 NNNY CT(0 0 0) RT(1594311925050 28) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4744,8 +4744,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:03.541Z",
-    "updatedAt": "2020-07-08T09:29:03.948Z",
+    "createdAt": "2020-07-09T16:25:25.909Z",
+    "updatedAt": "2020-07-09T16:25:26.577Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4769,8 +4769,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:03.948Z",
-    "publishedAt": "2020-07-08T09:29:03.948Z",
+    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
+    "publishedAt": "2020-07-09T16:25:26.577Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4807,11 +4807,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -4820,9 +4820,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:04 GMT',
-  'ETag',
-  'W/"3565378225074659424"',
+  'Thu, 09 Jul 2020 16:25:26 GMT',
+  'etag',
+  'W/"14647378867660032396"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4832,29 +4832,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '9e2cabc9edc74f3de8b1467730b107b2',
+  'e4f485951098e70057ce049e97d53e18',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=cr/108n6Tw2pfTwHbkBxXd+RBV8AAAAAQUIPAAAAAACCt3j92/OMR1PZMiE7fBKy; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=u9ZLGwJLTWGbJARwOI9ge/ZEB18AAAAAQUIPAAAAAABSK6ENEASYCETn2/g9l6ES; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PJ+Sax/qoH6IImZUYMlkBAAAAAD8DBwsA+WexgfejCpi4lbq; path=/; Domain=.contentful.com',
+  'nlbi_673446=MrQEVdpj4hpC6+vrYMlkBAAAAABwTtqmt/c0jgt6PVwbidMZ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=T3YHZEpxn2ZYEE4EPWpmA9+RBV8AAAAACw01SxzTnFX9t4oQr7rbMw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=tSyndTJ1AG7d0VsGPWpmA/ZEB18AAAAA7tGJslD0A381M6mCXaizUg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-4769052-4769053 NNNY CT(0 0 0) RT(1594200543203 33) q(0 0 0 -1) r(3 3) U5'
+  '14-86053253-86053268 NNNN CT(86 87 0) RT(1594311925672 40) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4879,8 +4879,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "food",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:29:03.541Z",
-        "updatedAt": "2020-07-08T09:29:03.948Z",
+        "createdAt": "2020-07-09T16:25:25.909Z",
+        "updatedAt": "2020-07-09T16:25:26.577Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -4889,8 +4889,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-08T09:29:03.948Z",
-        "firstPublishedAt": "2020-07-08T09:29:03.948Z",
+        "publishedAt": "2020-07-09T16:25:26.577Z",
+        "firstPublishedAt": "2020-07-09T16:25:26.577Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -4944,11 +4944,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -4957,9 +4957,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:04 GMT',
-  'ETag',
-  'W/"18200018803838434741"',
+  'Thu, 09 Jul 2020 16:25:27 GMT',
+  'etag',
+  'W/"17090761978903646731"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4969,29 +4969,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'ba3c92f28651f56d5627035d10f5e9fb',
-  'Content-Length',
-  '513',
+  '74f18f1479b1907210e5022ef699906e',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4z4/P5M8Qm+qPRGlsU6v9N+RBV8AAAAAQUIPAAAAAABi4WEMwGJamzjq14zvdou+; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=KB5MAszLTZqtj2LvVmr25PZEB18AAAAAQUIPAAAAAABobhNDz9Fm40sIMoIYFoYQ; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CAZdfz2rW2GLEbyDYMlkBAAAAAAQ9HlXcoyElv8l7FBQ5mjw; path=/; Domain=.contentful.com',
+  'nlbi_673446=BcbJN0dPTypr7SefYMlkBAAAAAC6MlEDNm/FoCQ3QqWrOUOU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=cxr0XWRVgFe1EE4EPWpmA9+RBV8AAAAAENBxefzjV39lt9m7SWfF6A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=UcGcBt+fxzdz0lsGPWpmA/ZEB18AAAAAB6I7KQU4Kgwg93sekKQH6A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49180731-49180741 NNNY CT(0 0 0) RT(1594200543610 38) q(0 0 0 -1) r(2 2) U5'
+  '9-20701113-20701118 NNNY CT(0 0 0) RT(1594311926280 30) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5032,8 +5032,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -5063,9 +5063,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:04 GMT',
+  'Thu, 09 Jul 2020 16:25:27 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -5077,15 +5077,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'bbd5bbf8f799fe21b846b6aed1e6acad',
+  '5586d8ddbf4ca71ba78131398b8fb478',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -5097,11 +5097,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=w8REf19IRmKuom4YtqtVVOCRBV8AAAAAQUIPAAAAAAAr6XtTSbsY6LFwDPPQrF1w; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=XxQCkhM+RXKoy32CribtBvdEB18AAAAAQUIPAAAAAACoAqM9BvE5SrxMvisdwe2I; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ZhfXafoyGUiNFACHYMlkBAAAAADndvvJjcr0ohTZRLpWs90q; path=/; Domain=.contentful.com',
+  'nlbi_673446=OSfMDe65wTGddrLcYMlkBAAAAAD2DnngUgjTnMw5LWbSbgYV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=MkKtQr016BgREU4EPWpmA+CRBV8AAAAAmDt8YCNHlgHpawZ99XasvA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=ZfthH+zQ7ke00lsGPWpmA/dEB18AAAAApcvgjt+shwHgc/Rh7MDifg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5109,7 +5109,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-11764248-11764252 NNYY CT(0 0 0) RT(1594200543912 22) q(0 0 0 -1) r(1 1) U5'
+  '4-26741145-26741148 NNYY CT(0 0 0) RT(1594311926892 33) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5125,8 +5125,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:03.541Z",
-    "updatedAt": "2020-07-08T09:29:05.264Z",
+    "createdAt": "2020-07-09T16:25:25.909Z",
+    "updatedAt": "2020-07-09T16:25:27.862Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5135,8 +5135,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:29:03.948Z",
-    "firstPublishedAt": "2020-07-08T09:29:03.948Z",
+    "publishedAt": "2020-07-09T16:25:26.577Z",
+    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5238,11 +5238,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -5251,185 +5251,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:05 GMT',
-  'ETag',
-  'W/"11489265861695420639"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'f333f3f6d017f3c4888d1a20dbcb0862',
-  'Content-Length',
-  '591',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=CC/fsA8ISsWN0EtTzfI8a+CRBV8AAAAAQUIPAAAAAAB2IQkaygK5xP05v6h79q7l; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=mazBFFuPSzrIow3gYMlkBAAAAADG0+KjGlmHN1MWkyPzWcTI; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=EuFRI/GaglLOEU4EPWpmA+CRBV8AAAAAlZaoEwZ6lym3OKdLuSlaiA==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '12-31551201-31551210 NNNN CT(94 93 0) RT(1594200544321 31) q(0 0 2 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "food",
-    "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:03.541Z",
-    "updatedAt": "2020-07-08T09:29:05.793Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:05.793Z",
-    "firstPublishedAt": "2020-07-08T09:29:03.948Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 2,
-    "version": 4,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": "taste",
-  "name": "foooood",
-  "description": " well, food",
-  "fields": [
-    {
-      "id": "calories",
-      "name": "How many calories does it have?",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "taste",
-      "name": "what it tastes like",
-      "type": "Symbol",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "producer",
-      "name": "Food producer",
-      "type": "Symbol",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "vegan",
-      "name": "Vegan friendly",
-      "type": "Boolean",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "gmo",
-      "name": "Genetically modified food",
-      "type": "Boolean",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    },
-    {
-      "id": "sugar",
-      "name": "Amount of sugar",
-      "type": "Number",
-      "localized": false,
-      "required": false,
-      "validations": [],
-      "disabled": false,
-      "omitted": false
-    }
-  ]
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:05 GMT',
-  'ETag',
-  'W/"7205505111305197625"',
+  'Thu, 09 Jul 2020 16:25:27 GMT',
+  'etag',
+  'W/"15616522819024614663"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5447,25 +5271,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '30215810cc9a0737c418dbeee2a98127',
-  'transfer-encoding',
-  'chunked',
+  'f4481a88a61373a776cad9cf61bbf952',
+  'Content-Length',
+  '591',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Ui3TW38bQXaY4W3Lt6Cq/+GRBV8AAAAAQUIPAAAAAACVI4GPO29t/KgR/Y7PLFfw; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=K9rizgzSQpOl7Q0rvmf8SPdEB18AAAAAQUIPAAAAAABar2V4MIbb3cxRVz73gWV3; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=torpUbrsA0xodL3UYMlkBAAAAADzQt39Q8NcIzW5RmQ+TFG9; path=/; Domain=.contentful.com',
+  'nlbi_673446=B4UkJRTtiCDj3vkuYMlkBAAAAAAsPnZy558m2lD0vrz9XVta; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=GZn9B0MW4E95Ek4EPWpmA+GRBV8AAAAAwQb8jZZUyH1lNDdg4uhMEQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=PPtzOf9vEBcE01sGPWpmA/dEB18AAAAAb1F/scsbczKuzdri9AcKYQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-23194689-23194698 NNNY CT(0 0 0) RT(1594200545029 47) q(0 0 0 -1) r(4 4) U5'
+  '11-41050979-41050986 NNNY CT(0 0 0) RT(1594311927096 37) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/food')
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food/published')
   .reply(200, {
   "sys": {
     "space": {
@@ -5477,8 +5301,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:03.541Z",
-    "updatedAt": "2020-07-08T09:29:05.793Z",
+    "createdAt": "2020-07-09T16:25:25.909Z",
+    "updatedAt": "2020-07-09T16:25:28.232Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5487,8 +5311,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:05.793Z",
-    "firstPublishedAt": "2020-07-08T09:29:03.948Z",
+    "publishedAt": "2020-07-09T16:25:28.232Z",
+    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5590,11 +5414,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -5603,9 +5427,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:06 GMT',
-  'ETag',
-  'W/"7205505111305197625"',
+  'Thu, 09 Jul 2020 16:25:28 GMT',
+  'etag',
+  'W/"6623412258601009463"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5623,21 +5447,197 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'dc471c3efd5684cb74371640330b433a',
+  'bfee7c632b5b84aced32201626b94d3f',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vD0BsZmLSfq5FtZqTUisguGRBV8AAAAAQUIPAAAAAADoxi9xdnwE7GmDIiWwSLb3; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=oJOqHdJaT5SwfOlVQkvjlPdEB18AAAAAQUIPAAAAAAC8lMBqlcGn1PvayOEVox58; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qs1zXWLMgho9Rf1rYMlkBAAAAACSXMrgvTISQKqi8Q4UlXm/; path=/; Domain=.contentful.com',
+  'nlbi_673446=CtTzBFZ3XCaCesqdYMlkBAAAAACrjnkl0FEoT1ngOETtjNED; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=oXhpBpQMGWbJEk4EPWpmA+GRBV8AAAAAdOYwcUaMQfhWkUO40csv+w==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=kQhGSYvRSmtk01sGPWpmA/dEB18AAAAA8kE7s3loWoH6ci71rmffZg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49181367-49181394 NNNY CT(0 0 0) RT(1594200545477 37) q(0 0 0 -1) r(2 2) U5'
+  '14-86053824-86053845 NNNY CT(0 0 0) RT(1594311927508 29) q(0 0 0 -1) r(2 2) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/food')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "food",
+    "type": "ContentType",
+    "createdAt": "2020-07-09T16:25:25.909Z",
+    "updatedAt": "2020-07-09T16:25:28.232Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 3,
+    "publishedAt": "2020-07-09T16:25:28.232Z",
+    "firstPublishedAt": "2020-07-09T16:25:26.577Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 2,
+    "version": 4,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": "taste",
+  "name": "foooood",
+  "description": " well, food",
+  "fields": [
+    {
+      "id": "calories",
+      "name": "How many calories does it have?",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "taste",
+      "name": "what it tastes like",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "producer",
+      "name": "Food producer",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "vegan",
+      "name": "Vegan friendly",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "gmo",
+      "name": "Genetically modified food",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "sugar",
+      "name": "Amount of sugar",
+      "type": "Number",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:28 GMT',
+  'etag',
+  'W/"6623412258601009463"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  'bf7432123a653941ce0b0375bacb04d7',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=pYjES1WATJarQiKkv9FCmPhEB18AAAAAQUIPAAAAAABHLQUQ4ekeq4z4rBkPIMB/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=rQIlO3+ru0mSx9DKYMlkBAAAAABBJVl+hbet4zhC/qGiRfJB; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=v92XaTSLVR2401sGPWpmA/hEB18AAAAAOULFLYmEqh6y7u9vR4PV/Q==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '12-55398425-55398435 NNNY CT(0 0 0) RT(1594311927908 34) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5663,19 +5663,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:06 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:28 GMT',
+  'etag',
   '"10440568906820546102"',
   'Server',
   'Contentful',
@@ -5686,23 +5686,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '1d02a28075edbaf2828f83458eaefa24',
+  '25785b6c75e555705b9f39fde3e31156',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=WyFTaAKbRlqwAodEzextBOKRBV8AAAAAQUIPAAAAAADiMFzeQu1vUlscmdUhHhtT; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/P2jHGDnRl6cchqVT/e/0fhEB18AAAAAQUIPAAAAAADa5xQQ8uaH+5gvDlpyLN1J; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=yja5W0KQHW9eBB8vYMlkBAAAAAA0SWgO0BenPd1hmw4fsddc; path=/; Domain=.contentful.com',
+  'nlbi_673446=+1T+XLnSYxCwrPOaYMlkBAAAAAAEfiiCfR0CgDO8GaImXIDe; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=XW4kecKZrlFCE04EPWpmA+KRBV8AAAAANAUIbVw2rltuMg0D/8em8Q==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=vc+eCAkVlwMi1FsGPWpmA/hEB18AAAAAXhN3p6bWTwKbEfW+OTM6lQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5710,7 +5710,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-15108282-15108286 NNYN CT(88 89 0) RT(1594200545839 32) q(0 0 2 -1) r(4 4) U5'
+  '9-20701189-20701192 NNYY CT(0 0 0) RT(1594311928234 28) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5751,8 +5751,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -5782,9 +5782,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:07 GMT',
+  'Thu, 09 Jul 2020 16:25:29 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -5804,7 +5804,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5aeef349d68c81176028c8a1ddd9e638',
+  'eb108f0095ddbf3236997dafd8123d74',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -5816,11 +5816,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nOuk7Vx9QY+8OpBMiA/JbeORBV8AAAAAQUIPAAAAAADxVECG7hp/aGW9zoW+hOV1; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=HeqisWPBSFeue8/NBQfqpvhEB18AAAAAQUIPAAAAAAA4uvB/TRs3xVuiHBHCekOO; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=E6TmUtiSGxbm2kJnYMlkBAAAAACDPn3tzeaiRmc8i+4yz9Y4; path=/; Domain=.contentful.com',
+  'nlbi_673446=Y9jEbrpU92xrGqDQYMlkBAAAAABJ8pDqOQzPRUq0fSck+xck; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=tLtoP3u5Xl1AFE4EPWpmA+ORBV8AAAAABLhS+nEbBx7Wo4zvubFWOg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=57nrV4Kdk1qN1FsGPWpmA/hEB18AAAAAFvY4u1KmROcQ/dGX8P5auA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5828,12 +5828,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49181763-49181782 NNYY CT(0 0 0) RT(1594200546351 26) q(0 0 0 -1) r(7 7) U5'
+  '12-55398572-55398578 NNYN CT(88 86 0) RT(1594311928524 24) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/person', {"name":"Person","fields":[{"id":"age","name":"Age","type":"Number","required":true},{"id":"fullName","name":"Full name","type":"Symbol","required":true,"localized":true}],"description":"A content type for a person"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-08T09:29:07.970Z","updatedAt":"2020-07-08T09:29:07.970Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-09T16:25:29.850Z","updatedAt":"2020-07-09T16:25:29.850Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -5844,20 +5844,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:08 GMT',
-  'ETag',
-  '"10381638622458611232"',
+  'Thu, 09 Jul 2020 16:25:29 GMT',
+  'etag',
+  '"7332829308841050924"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5875,21 +5875,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '12885093fbfe9edb2ce351a7018db762',
+  '8a4f6b4e701926ba6362f88b8c15af5c',
   'Content-Length',
   '1269',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=LyvBWo19QbGM0Leyn4PqI+ORBV8AAAAAQUIPAAAAAABFWyYK80F/ksDQOIxnfhKa; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=5qLbnO6xR5mo+VEghqF1pflEB18AAAAAQUIPAAAAAABbc1n5fDRuVsb4etL9N4ih; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gYrgBQFXzCu4U6vvYMlkBAAAAACWSHZmYAbN2ZAE5uoPjF7b; path=/; Domain=.contentful.com',
+  'nlbi_673446=DJQ/e8u8S3KJNpGpYMlkBAAAAAAYTHqx6YvqjoEmuhSHhGQ2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=wLraSPz8NUmeFE4EPWpmA+ORBV8AAAAAduqTDHr/Yd1sPmhlXQC/HA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=iEzoYrQetHsy1VsGPWpmA/lEB18AAAAAV7+T2ZDcsCdDhryg16mjKQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-12938179-12938183 NNNY CT(0 0 0) RT(1594200547191 30) q(0 0 0 -1) r(3 3) U5'
+  '6-13874925-13874928 NNNN CT(93 94 0) RT(1594311928898 26) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5905,8 +5905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:07.970Z",
-    "updatedAt": "2020-07-08T09:29:08.494Z",
+    "createdAt": "2020-07-09T16:25:29.850Z",
+    "updatedAt": "2020-07-09T16:25:30.290Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5930,8 +5930,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:08.494Z",
-    "publishedAt": "2020-07-08T09:29:08.494Z",
+    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
+    "publishedAt": "2020-07-09T16:25:30.290Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -5978,11 +5978,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -5991,9 +5991,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:08 GMT',
-  'ETag',
-  'W/"2102942112223528472"',
+  'Thu, 09 Jul 2020 16:25:30 GMT',
+  'etag',
+  'W/"15637892669674338975"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6011,26 +6011,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a8b9b7969eeaa8f068c35ca2d195a714',
+  '7de7ee70bafb8eabf92a694078288fd3',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=aYVOUnaAQ0K0qhLjPB1Jo+SRBV8AAAAAQUIPAAAAAACvEc6xo7HTqRGiR0VBmlo1; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/2Hnx/jbSJaq7FhZ7SmcSflEB18AAAAAQUIPAAAAAABulahYgDrDO3JKkWv7SoZQ; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=OL51WJwf7hFifdQmYMlkBAAAAAC9L0nHITTeNUddh3myva5F; path=/; Domain=.contentful.com',
+  'nlbi_673446=8XRyHLucnmp0voskYMlkBAAAAACfmzIzV9tt3jqOM12BJWa3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=p+1iVjavvxYaFU4EPWpmA+SRBV8AAAAAOvWq1S7Wp3JnWKzJhYlWYQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=P661bCkvNwWR1VsGPWpmA/lEB18AAAAAJyYbme2YqHDp3Jo0kNOqNQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-16018303-16018310 NNNY CT(0 0 0) RT(1594200547700 36) q(0 0 0 -1) r(3 3) U5'
+  '14-86054470-86054485 NNNY CT(0 0 0) RT(1594311929562 33) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/animal', {"name":"Animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","required":true},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","required":false}],"description":"An animal"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-08T09:29:09.123Z","updatedAt":"2020-07-08T09:29:09.123Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-09T16:25:30.832Z","updatedAt":"2020-07-09T16:25:30.832Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -6041,20 +6041,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:09 GMT',
-  'ETag',
-  '"8827901835266500259"',
+  'Thu, 09 Jul 2020 16:25:30 GMT',
+  'etag',
+  '"17989775881492960242"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6072,21 +6072,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '0203b60e583a1c6a4fb2b1bc07a55c57',
+  '3f5415468a108e2c50761abfc6cb5bf1',
   'Content-Length',
   '1292',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=TOkYHSrdQMShTRKlvlRw+uSRBV8AAAAAQUIPAAAAAAD5YDWcSdJurq9tvXIW8GSK; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=0Db7T4DPRpqDYoxB07y/5fpEB18AAAAAQUIPAAAAAAAOawt6z5br+DBHEyODm8KK; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ymvkZyfsWBq82x/BYMlkBAAAAABS02ygY2mNO2ThbVzD9yNf; path=/; Domain=.contentful.com',
+  'nlbi_673446=DkH4UggDADUB1/QSYMlkBAAAAAD9Wx8FUFUfvZO1Jh1vSACB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Ma+0f+zVzm+rFU4EPWpmA+SRBV8AAAAA+tAaVLq8X3tfW8M3nxpv7A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=rD6gZTEzeE4N1lsGPWpmA/pEB18AAAAA19gD9jgCElmOuMtAaFYmtQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-23195454-23195466 NNNY CT(0 0 0) RT(1594200548311 31) q(0 0 0 -1) r(3 3) U5'
+  '14-86054602-86054604 NNNY CT(0 0 0) RT(1594311929958 26) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6102,8 +6102,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:09.123Z",
-    "updatedAt": "2020-07-08T09:29:10.011Z",
+    "createdAt": "2020-07-09T16:25:30.832Z",
+    "updatedAt": "2020-07-09T16:25:31.293Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6127,8 +6127,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:10.011Z",
-    "publishedAt": "2020-07-08T09:29:10.011Z",
+    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
+    "publishedAt": "2020-07-09T16:25:31.293Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -6175,11 +6175,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -6188,9 +6188,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:10 GMT',
-  'ETag',
-  'W/"1577060652133499911"',
+  'Thu, 09 Jul 2020 16:25:31 GMT',
+  'etag',
+  'W/"12219047309239319921"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6208,21 +6208,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '14282404919498e2140085b045ad2767',
+  'd61f2b32ac0df6cc9545fa79602aa08c',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=CrSTwqa5S8G0NCmUgZQBauWRBV8AAAAAQUIPAAAAAADeQLlThLYbl2EL18pIzQAc; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=j7U11CcuQZ6kj0VYAdrkG/pEB18AAAAAQUIPAAAAAACcLqZ2b9IGJsKD4HGq2NQI; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gjNQBU2JFwRN4sL8YMlkBAAAAACDDKovgcu4BF3rHrKRGUuS; path=/; Domain=.contentful.com',
+  'nlbi_673446=KAQIV3522THR3yEXYMlkBAAAAACMR0kf6FLu94iYjXxIi3ai; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=oU6oTgYxpza6Fk4EPWpmA+WRBV8AAAAA0Swfs6cDlsWwfB/WHzFFlw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=3KvOTwHxTQSW1lsGPWpmA/pEB18AAAAAJbYzWKwrGEp8sRLQK9jeig==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-12938296-12938297 NNNN CT(87 88 0) RT(1594200548927 31) q(0 0 2 -1) r(7 7) U5'
+  '3-21640961-21640966 NNNY CT(0 0 0) RT(1594311930569 26) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6238,8 +6238,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:07.970Z",
-    "updatedAt": "2020-07-08T09:29:10.636Z",
+    "createdAt": "2020-07-09T16:25:29.850Z",
+    "updatedAt": "2020-07-09T16:25:32.040Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6248,8 +6248,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:29:08.494Z",
-    "firstPublishedAt": "2020-07-08T09:29:08.494Z",
+    "publishedAt": "2020-07-09T16:25:30.290Z",
+    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6322,11 +6322,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -6335,9 +6335,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:10 GMT',
-  'ETag',
-  'W/"5494925589567692190"',
+  'Thu, 09 Jul 2020 16:25:32 GMT',
+  'etag',
+  'W/"11088506612956257108"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6347,29 +6347,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '70fd15a32d18d1d19dab41a338d20e6a',
+  'ddbf87d4d1e38274494031d20658d6af',
   'Content-Length',
-  '520',
+  '519',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=TT3RIuD3SmCCAK3I+ShS/uaRBV8AAAAAQUIPAAAAAABsycMAV89KttgVcaTs2P9a; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=C4sG0MKTQB2+0rxwlW5GJ/tEB18AAAAAQUIPAAAAAACO3Wp+KSWpXC7JYYMD6EdS; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hudgKxhHaEgc7uW2YMlkBAAAAABXdusLc81SsOkVXzdwlhqd; path=/; Domain=.contentful.com',
+  'nlbi_673446=XNrXZVsiIRBBCbXSYMlkBAAAAACSkMJUJrXZGr6B4Vph9YTg; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=PIXQK/poDkJBF04EPWpmA+aRBV8AAAAASfGCaBmF32Ztcq3eRgaLNw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=TQQ7JylAIRdJ11sGPWpmA/tEB18AAAAAcj+Z3IJSJjAgB55utuJrJQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49183092-49183107 NNNY CT(0 0 0) RT(1594200549839 45) q(0 0 0 -1) r(3 3) U5'
+  '10-27144207-27144209 NNNN CT(93 93 0) RT(1594311930988 35) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6385,8 +6385,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:07.970Z",
-    "updatedAt": "2020-07-08T09:29:11.133Z",
+    "createdAt": "2020-07-09T16:25:29.850Z",
+    "updatedAt": "2020-07-09T16:25:32.618Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6395,8 +6395,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:11.133Z",
-    "firstPublishedAt": "2020-07-08T09:29:08.494Z",
+    "publishedAt": "2020-07-09T16:25:32.618Z",
+    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6469,11 +6469,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -6482,9 +6482,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:11 GMT',
-  'ETag',
-  'W/"2083079281209736772"',
+  'Thu, 09 Jul 2020 16:25:32 GMT',
+  'etag',
+  'W/"12367945497557339651"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6502,21 +6502,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '034d4b695c10508aa5531ff8dd3bd7ae',
+  'c0e8ad337a47427234e90a35f874b279',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YUwrnXylTgmcm6DBysQ/F+aRBV8AAAAAQUIPAAAAAAB8AAgF9NbVD86ZxF5lGsDF; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YiEexcoyTHyBdKnDqPad6fxEB18AAAAAQUIPAAAAAADEvUfAbbewvKjIf+bvQlub; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PKoVe9iQnRvHODqCYMlkBAAAAAAqxmMgZwORKVXCAY5PjjW3; path=/; Domain=.contentful.com',
+  'nlbi_673446=W//wcsR8lUxHs00xYMlkBAAAAABrp8Bu/88IQ2v2fGGMddiE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=9a9TNp1hzEvPF04EPWpmA+aRBV8AAAAANt9jUzWCIhLaDEquB0xUTw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=R5+yKlXMRU/311sGPWpmA/xEB18AAAAA3y3Q0NMvQ5n3BG+z/EEJsQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15108918-15108920 NNNN CT(86 86 0) RT(1594200550205 28) q(0 0 2 -1) r(5 5) U5'
+  '13-66928488-66928497 NNNY CT(0 0 0) RT(1594311931800 31) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6532,8 +6532,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:09.123Z",
-    "updatedAt": "2020-07-08T09:29:11.940Z",
+    "createdAt": "2020-07-09T16:25:30.832Z",
+    "updatedAt": "2020-07-09T16:25:32.963Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6542,8 +6542,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:29:10.011Z",
-    "firstPublishedAt": "2020-07-08T09:29:10.011Z",
+    "publishedAt": "2020-07-09T16:25:31.293Z",
+    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6615,11 +6615,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -6628,9 +6628,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:11 GMT',
-  'ETag',
-  'W/"17592018158465654195"',
+  'Thu, 09 Jul 2020 16:25:32 GMT',
+  'etag',
+  'W/"15361261824487259246"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6648,21 +6648,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '06d0ceb8ea87cb79eaff12a0eddb85d5',
-  'transfer-encoding',
-  'chunked',
+  'f70c34c7afc6dca731bcb034b49f2a6c',
+  'Content-Length',
+  '511',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=XQVH6bg1SVWB4pYc5QMQL+eRBV8AAAAAQUIPAAAAAAARwVakTOyNcPRcssNSVNif; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Z/mRMZt0TlmsLU1kSoUUgPxEB18AAAAAQUIPAAAAAAAtzQACLC5Tlz7C/udB5NfX; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=QgIrPieYqj6ER6UqYMlkBAAAAAAPjrCRVXdN7Tr2OQQoU6/Y; path=/; Domain=.contentful.com',
+  'nlbi_673446=9LBYNi/Psn3Qq6KJYMlkBAAAAAAzZYDLedx5wSiB4NQW1tyi; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Ld8ZdejMB3GdGE4EPWpmA+eRBV8AAAAA4hSHzZdHRKVV1DRs183Czg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=imp/UJsUNkJb2FsGPWpmA/xEB18AAAAArJbbdxxNxfY3emorOY3xsA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-4769244-4769246 NNNY CT(0 0 0) RT(1594200550975 32) q(0 0 0 -1) r(4 4) U5'
+  '6-13875047-13875051 NNNY CT(0 0 0) RT(1594311932224 28) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6678,8 +6678,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:09.123Z",
-    "updatedAt": "2020-07-08T09:29:12.355Z",
+    "createdAt": "2020-07-09T16:25:30.832Z",
+    "updatedAt": "2020-07-09T16:25:33.352Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6688,8 +6688,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:12.355Z",
-    "firstPublishedAt": "2020-07-08T09:29:10.011Z",
+    "publishedAt": "2020-07-09T16:25:33.352Z",
+    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6761,11 +6761,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -6774,9 +6774,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:12 GMT',
-  'ETag',
-  'W/"300933915263834668"',
+  'Thu, 09 Jul 2020 16:25:33 GMT',
+  'etag',
+  'W/"3405819313589139461"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6794,21 +6794,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f1e179eb7765ab23e721fde135011f57',
+  '984b8ccf22ce2431ad229b557d307c8f',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=6k0ArVyBT/qKtFCz/BmROueRBV8AAAAAQUIPAAAAAABc+Rm0uXWefoXQ8v+h8xRT; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=4s5/2s0cSl6BiSD6Lq9jyPxEB18AAAAAQUIPAAAAAACTHqTuukUrMz91ibf69a9/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CDh3W1LvBmzrDpbMYMlkBAAAAAB5CwLsiH1WjcKdVd2Rq8U8; path=/; Domain=.contentful.com',
+  'nlbi_673446=ieLTUE3Vky0TF3kFYMlkBAAAAACgJ1cUBP4ZwsvKE4pAM16I; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=KEMUJwkdxkseGU4EPWpmA+eRBV8AAAAAp7sSazn5V/zD8ZN8ey4Bew==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=sk3HbGRD0CTQ2FsGPWpmA/xEB18AAAAAcTzp/qkG5tAnyjmdDFg9jg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38163362-38163373 NNNY CT(0 0 0) RT(1594200551595 28) q(0 0 0 -1) r(3 3) U5'
+  '14-86055310-86055322 NNNY CT(0 0 0) RT(1594311932630 31) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6824,8 +6824,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:07.970Z",
-    "updatedAt": "2020-07-08T09:29:11.133Z",
+    "createdAt": "2020-07-09T16:25:29.850Z",
+    "updatedAt": "2020-07-09T16:25:32.618Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6834,8 +6834,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:11.133Z",
-    "firstPublishedAt": "2020-07-08T09:29:08.494Z",
+    "publishedAt": "2020-07-09T16:25:32.618Z",
+    "firstPublishedAt": "2020-07-09T16:25:30.290Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6908,11 +6908,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -6921,9 +6921,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:12 GMT',
-  'ETag',
-  'W/"2083079281209736772"',
+  'Thu, 09 Jul 2020 16:25:33 GMT',
+  'etag',
+  'W/"12367945497557339651"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6941,21 +6941,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '06d93387ea3f0bf3642cf7f8a52d36c9',
+  'ac93a389a6f11d7502ce7a1ae7fa1f64',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=VUSiNVg0QYeXs/Y1S/73QOiRBV8AAAAAQUIPAAAAAADvz/plCZCpla/S4eYQOCMt; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kOSlc4dMR+Caop1eztAyF/1EB18AAAAAQUIPAAAAAACsTHncDFaH+uzqjMMrVPwc; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hRkkP3t8SCjN6vSmYMlkBAAAAAC1nrZVeeT3p2Bmx4Zb0Otm; path=/; Domain=.contentful.com',
+  'nlbi_673446=pE21HlONMRiZZX2JYMlkBAAAAAAGalXmY1EdPrPdMAmZAXUK; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=UrRsGhqvc0yLGU4EPWpmA+iRBV8AAAAAYLwUu+G+wWkM2Nl9C1s1xA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=crq/YvE7CgYs2VsGPWpmA/1EB18AAAAAnouxCPjgapDa8joHUIjl6Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15109140-15109144 NNNN CT(87 87 0) RT(1594200551996 34) q(0 0 2 -1) r(4 4) U5'
+  '10-27144425-27144429 NNNY CT(0 0 0) RT(1594311933034 28) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6971,8 +6971,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:09.123Z",
-    "updatedAt": "2020-07-08T09:29:12.355Z",
+    "createdAt": "2020-07-09T16:25:30.832Z",
+    "updatedAt": "2020-07-09T16:25:33.352Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6981,8 +6981,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:12.355Z",
-    "firstPublishedAt": "2020-07-08T09:29:10.011Z",
+    "publishedAt": "2020-07-09T16:25:33.352Z",
+    "firstPublishedAt": "2020-07-09T16:25:31.293Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -7054,11 +7054,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -7067,9 +7067,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:13 GMT',
-  'ETag',
-  'W/"300933915263834668"',
+  'Thu, 09 Jul 2020 16:25:34 GMT',
+  'etag',
+  'W/"3405819313589139461"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7079,29 +7079,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '7',
   'X-Contentful-Request-Id',
-  'fbabc97122fe58ddcfec8b3d1c1d3363',
+  'bc4a4df664a3b9dba967b0d2a7d65f2c',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BBJf80WFTrKrj9Zk436EhuiRBV8AAAAAQUIPAAAAAABBQGxFTJHOG/jiYz7BBC9Y; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=pDMq78kgRlufT6T+FqPgv/1EB18AAAAAQUIPAAAAAABEAjjscaFmTAwLOeJHrFA5; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=YbzJFK5IeVw4EfMCYMlkBAAAAACZgKVtPjqpdRLweIm8BYso; path=/; Domain=.contentful.com',
+  'nlbi_673446=T8P5YCewp1VNNbRsYMlkBAAAAABRfZXbLwan6O2rAWLLOf9d; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=khFDcqGwvnDnGU4EPWpmA+iRBV8AAAAAVZNeDvt6axSCqIerjy3FCw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=9Xe3QrQi8yh+2VsGPWpmA/1EB18AAAAAyI+Y7tBETrKk0860LrzxYA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15109233-15109242 NNNY CT(0 0 0) RT(1594200552609 27) q(0 0 0 -1) r(2 2) U5'
+  '10-27144448-27144452 NNNY CT(0 0 0) RT(1594311933344 30) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7126,8 +7126,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "person",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:29:07.970Z",
-        "updatedAt": "2020-07-08T09:29:11.133Z",
+        "createdAt": "2020-07-09T16:25:29.850Z",
+        "updatedAt": "2020-07-09T16:25:32.618Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7136,8 +7136,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-08T09:29:11.133Z",
-        "firstPublishedAt": "2020-07-08T09:29:08.494Z",
+        "publishedAt": "2020-07-09T16:25:32.618Z",
+        "firstPublishedAt": "2020-07-09T16:25:30.290Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7212,11 +7212,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -7225,9 +7225,70 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:13 GMT',
-  'ETag',
-  'W/"2343073592995067427"',
+  'Thu, 09 Jul 2020 16:25:34 GMT',
+  'etag',
+  'W/"16334866240907286472"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'a4947269b7cc8e118f151fafa30cbe42',
+  'transfer-encoding',
+  'chunked',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=wsHV3ElTTCuyjuGE+oENXv1EB18AAAAAQUIPAAAAAADhU34Fp+6eNRRXKMvFQ/QS; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=liNvOCiY4SJ2a/DvYMlkBAAAAABb5bnZT75oQ0tm+XTLhwQI; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=c77hb+GiUxjJ2VsGPWpmA/1EB18AAAAAuLQReh4E+Wy2jK+xc6En6g==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '5-42740509-42740513 NNNY CT(0 0 0) RT(1594311933650 30) q(0 0 0 -1) r(2 2) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogpost', {"name":"blog post","fields":[{"name":"title","id":"title","type":"Symbol"},{"name":"category","id":"category","type":"Symbol"}]})
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-09T16:25:34.705Z","updatedAt":"2020-07-09T16:25:34.705Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:34 GMT',
+  'etag',
+  '"8198607709353951105"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7245,82 +7306,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '86efa69946e14188ee18b5b73ef61fad',
-  'transfer-encoding',
-  'chunked',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=sYPFDM7KS2GBgAU3jkuMPOmRBV8AAAAAQUIPAAAAAAAN1pV6iyq6xyrOiXA5A9Cf; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=wusDKLlLpTDFHRrXYMlkBAAAAAAF+ViuvGNfsVz90VC+fjwx; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=kPMVdbsM2Rk7Gk4EPWpmA+mRBV8AAAAAhIi+YsQuqO9ZoerqltRSbw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '10-15109281-15109290 NNNY CT(0 0 0) RT(1594200552923 30) q(0 0 0 -1) r(3 3) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogpost', {"name":"blog post","fields":[{"name":"title","id":"title","type":"Symbol"},{"name":"category","id":"category","type":"Symbol"}]})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-08T09:29:14.132Z","updatedAt":"2020-07-08T09:29:14.132Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:14 GMT',
-  'ETag',
-  '"4384978854005202805"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '7',
-  'X-Contentful-Request-Id',
-  '91437c3af7c51634a64d865a864ac77a',
+  '05c9e5cc9b53994106caf4f5d9d1e792',
   'Content-Length',
   '1255',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=15/J3tGxRl2vgTHrrbYWDumRBV8AAAAAQUIPAAAAAAB1mhNAKeScOigNiwqwAuYn; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=jW3/wzCXSveqwZErnKd27f5EB18AAAAAQUIPAAAAAABVQqGxO2K9l4u+ttxbdYDP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Lth/CpFbGzZIRbEFYMlkBAAAAACpiBi3+wwPcnYZ2q2oSBKl; path=/; Domain=.contentful.com',
+  'nlbi_673446=0FX9Qq2RqxZlZPFFYMlkBAAAAADLKU2cVSCP/mbJYEb2jqiY; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=EZbtSwf1BEa7Gk4EPWpmA+mRBV8AAAAAm+HwffWhR7UHumOqRydXVw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=vazlK7+IrwtC2lsGPWpmA/5EB18AAAAAoO0k6cnud4/nTpuC352qJg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-25305219-25305233 NNNY CT(0 0 0) RT(1594200553263 31) q(0 0 0 -1) r(5 5) U5'
+  '14-86055727-86055736 NNNY CT(0 0 0) RT(1594311933962 32) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7336,8 +7336,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogpost",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:14.132Z",
-    "updatedAt": "2020-07-08T09:29:14.793Z",
+    "createdAt": "2020-07-09T16:25:34.705Z",
+    "updatedAt": "2020-07-09T16:25:35.188Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7361,8 +7361,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:14.793Z",
-    "publishedAt": "2020-07-08T09:29:14.793Z",
+    "firstPublishedAt": "2020-07-09T16:25:35.188Z",
+    "publishedAt": "2020-07-09T16:25:35.188Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -7409,11 +7409,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -7422,9 +7422,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:14 GMT',
-  'ETag',
-  'W/"733732047088947825"',
+  'Thu, 09 Jul 2020 16:25:35 GMT',
+  'etag',
+  'W/"10181970523647773160"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7442,21 +7442,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fe3387b48d5b85ed5567398f47cb2e51',
+  'd8bcc3903013853ebdb62d2cb646efea',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=VDTLg/qhTXegRVYjg6DIKuqRBV8AAAAAQUIPAAAAAACFeo4HHCJA8I6xdynn082X; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=C0VTBnX9Sqmb9F1THk3Pjv5EB18AAAAAQUIPAAAAAAAUmHpDwi76rKuFEKMrZNrc; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Nd1ZE6/ZQyVTq3U+YMlkBAAAAADoL6quCFehyxWpE4CNYyKg; path=/; Domain=.contentful.com',
+  'nlbi_673446=9yXhfc+p2xHwKOzeYMlkBAAAAABEDqqH/g1flNIPWgji2Veb; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=nESCcmmHBmFiG04EPWpmA+qRBV8AAAAAo64H6qZNz63WwC/MCyTymg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=GCKTU0OGVjnb2lsGPWpmA/5EB18AAAAA1x2DmbDN3ZLz3+aXOu6RKg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15109412-15109419 NNNN CT(93 93 0) RT(1594200553841 32) q(0 0 2 -1) r(5 5) U5'
+  '12-55399698-55399704 NNNY CT(0 0 0) RT(1594311934467 32) q(0 1 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7473,10 +7473,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "6XJW4wlIjh4ynLg1dGjDGr",
+    "id": "4UwZKzKY3KkejAHj3cRPeQ",
     "type": "Entry",
-    "createdAt": "2020-07-08T09:29:15.610Z",
-    "updatedAt": "2020-07-08T09:29:15.610Z",
+    "createdAt": "2020-07-09T16:25:35.984Z",
+    "updatedAt": "2020-07-09T16:25:35.984Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7525,136 +7525,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:15 GMT',
-  'ETag',
-  '"8837316908764154734"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'bff22067f8768aa833e0623ac1accdf4',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=wCBfaR1MQKu1uskUIRuPC+uRBV8AAAAAQUIPAAAAAABKaUpHz73dVdZ5pjX5baAt; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=f3UnRPl15UMTOX2eYMlkBAAAAABqTNZgY2eoVmos24MBONNn; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=NifRSFuikDokHE4EPWpmA+uRBV8AAAAApfZjK0dhFeASOagg/KMgCQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
-  'X-Iinfo',
-  '10-15109513-15109522 NNYY CT(0 0 0) RT(1594200554671 24) q(0 0 0 -1) r(5 5) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .post('/spaces/bohepdihyxin/environments/env-integration/entries', {"fields":{"title":{"en-US":"hello!"}}})
-  .reply(201, {
-  "metadata": {
-    "tags": []
-  },
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "48YUNvi7GyTbywYMw0G8W7",
-    "type": "Entry",
-    "createdAt": "2020-07-08T09:29:16.132Z",
-    "updatedAt": "2020-07-08T09:29:16.132Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 0,
-    "version": 1,
-    "contentType": {
-      "sys": {
-        "type": "Link",
-        "linkType": "ContentType",
-        "id": "blogpost"
-      }
-    }
-  },
-  "fields": {
-    "title": {
-      "en-US": "hello!"
-    }
-  }
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:16 GMT',
-  'ETag',
-  '"9527377056603118564"',
+  'Thu, 09 Jul 2020 16:25:36 GMT',
+  'etag',
+  '"5128819315185328829"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7672,15 +7556,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '46450cba6820c41f2a9214239433a958',
+  '0558861dc2188fee7788d9ff2ad3ee52',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=otgmZjH/TyOcFmllCrTyN+uRBV8AAAAAQUIPAAAAAACAxy3N6VWoiK473S0GYkOL; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=I1aRO2oJT8q4CE5g5+g1nv9EB18AAAAAQUIPAAAAAAATK1f1tMuryWHq23wor9NM; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=i8ZjGvzWQz3Fp9FEYMlkBAAAAADvpF5fmHeRGL3JXrQwRzzM; path=/; Domain=.contentful.com',
+  'nlbi_673446=cL/4PCiPK0/7gUrGYMlkBAAAAAD/QVO47CuJq5ThUtSWv6D8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=hnU4EomXyBjXHE4EPWpmA+uRBV8AAAAAkVSy4W7+XuPZST+VEaR1dw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=x2VGcgXQRyl921sGPWpmA/9EB18AAAAAfpYnFYbEROakOVJXn7kC0Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7688,7 +7572,123 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '7-16019102-16019104 NNYY CT(0 0 0) RT(1594200555271 30) q(0 0 0 -1) r(4 4) U5'
+  '12-55399832-55399835 NNYY CT(0 0 0) RT(1594311935083 30) q(0 0 0 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .post('/spaces/bohepdihyxin/environments/env-integration/entries', {"fields":{"title":{"en-US":"hello!"}}})
+  .reply(201, {
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "54GyBcsJ9GSwtZkFAXcyfs",
+    "type": "Entry",
+    "createdAt": "2020-07-09T16:25:36.565Z",
+    "updatedAt": "2020-07-09T16:25:36.565Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 0,
+    "version": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "blogpost"
+      }
+    }
+  },
+  "fields": {
+    "title": {
+      "en-US": "hello!"
+    }
+  }
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:36 GMT',
+  'etag',
+  '"4645637625467400399"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'c002a73405ea9c410312cfbb7016df3e',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=t2rwlKijQ42FhyK3RNHhwQBFB18AAAAAQUIPAAAAAABiU34ZceJgIok00CE3sTUP; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=84PaPidSRXrYh4OLYMlkBAAAAADqRo6xFb3gUKAYEbXOImhZ; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=y6dhBG9vCRYT3FsGPWpmAwBFB18AAAAAE/u18Z7SqlvnSvKG4T5Gig==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '13-66929295-66929305 NNYY CT(0 0 0) RT(1594311935691 34) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7713,8 +7713,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogpost",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:29:14.132Z",
-        "updatedAt": "2020-07-08T09:29:14.793Z",
+        "createdAt": "2020-07-09T16:25:34.705Z",
+        "updatedAt": "2020-07-09T16:25:35.188Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7723,8 +7723,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-08T09:29:14.793Z",
-        "firstPublishedAt": "2020-07-08T09:29:14.793Z",
+        "publishedAt": "2020-07-09T16:25:35.188Z",
+        "firstPublishedAt": "2020-07-09T16:25:35.188Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7788,11 +7788,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -7801,9 +7801,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:16 GMT',
-  'ETag',
-  'W/"11858116845950581117"',
+  'Thu, 09 Jul 2020 16:25:36 GMT',
+  'etag',
+  'W/"7881515414895237677"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7813,29 +7813,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '26748d335c44a7762e0245d5f3368f55',
+  '40b9192a6ffab587b1c50e20e319f727',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=j+xHoMUlTZu5s89wyO3QNuyRBV8AAAAAQUIPAAAAAACwvkI11ldKHdJ7BN7pyBHn; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=H6XTs9ihTYKqZPSh8xvhSgBFB18AAAAAQUIPAAAAAABfgS01KesZOt09hvqQRD/n; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=l5/ZPd22mQ0cqoSWYMlkBAAAAAAOm8ZxjZK+u3r0/48pm7EV; path=/; Domain=.contentful.com',
+  'nlbi_673446=NcGxNnQJ+xJHfSFDYMlkBAAAAABwH6GC/fXFbCbHLArkHXIp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=QBGzVVe6FmpFHU4EPWpmA+yRBV8AAAAA7SMcET30fPYEPG8HbbWgJg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=okFiSrsThFBn3FsGPWpmAwBFB18AAAAAXw9XnTm2wERfD+K+SGdJJQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49185203-49185211 NNNY CT(0 0 0) RT(1594200555893 37) q(0 0 0 -1) r(3 3) U5'
+  '13-66929412-66929422 NNNY CT(0 0 0) RT(1594311936206 27) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7861,10 +7861,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "6XJW4wlIjh4ynLg1dGjDGr",
+        "id": "4UwZKzKY3KkejAHj3cRPeQ",
         "type": "Entry",
-        "createdAt": "2020-07-08T09:29:15.610Z",
-        "updatedAt": "2020-07-08T09:29:15.610Z",
+        "createdAt": "2020-07-09T16:25:35.984Z",
+        "updatedAt": "2020-07-09T16:25:35.984Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7914,10 +7914,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "48YUNvi7GyTbywYMw0G8W7",
+        "id": "54GyBcsJ9GSwtZkFAXcyfs",
         "type": "Entry",
-        "createdAt": "2020-07-08T09:29:16.132Z",
-        "updatedAt": "2020-07-08T09:29:16.132Z",
+        "createdAt": "2020-07-09T16:25:36.565Z",
+        "updatedAt": "2020-07-09T16:25:36.565Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7968,11 +7968,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -7981,9 +7981,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:17 GMT',
-  'ETag',
-  'W/"9968428482162813099"',
+  'Thu, 09 Jul 2020 16:25:37 GMT',
+  'etag',
+  'W/"14291565929482659107"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8001,21 +8001,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'eae360279af674223f1de79e99b4444d',
+  'a0ed72087e55cc46547b3dd635a19d44',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=dyjbvqWTQny+gCOJTtv7d+yRBV8AAAAAQUIPAAAAAAAnLtALubg7E3u5o/FNtavZ; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mwHTDqKCSp6JYMp6/+8IMgBFB18AAAAAQUIPAAAAAACjzXVJdRPtfzX749Z4VObC; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=K4F0NqXWzTE8lwNzYMlkBAAAAAC5Y6t/5iHL1/qqxOGtyj3S; path=/; Domain=.contentful.com',
+  'nlbi_673446=97dAX/dGh1X8ZxtlYMlkBAAAAAAq2m/lVc/ugh11FePVf3nC; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=5GJoYnlokhPNHU4EPWpmA+yRBV8AAAAApjRcuLIJFqqiHDKzFDTWAg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=vBlrCaUYWCXY3FsGPWpmAwBFB18AAAAAHEImRaNafkal6Q4ZJGaGeA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-11765640-11765643 NNNN CT(86 87 0) RT(1594200556301 30) q(0 0 2 -1) r(4 4) U5'
+  '11-41052284-41052296 NNNY CT(0 0 0) RT(1594311936520 35) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8056,8 +8056,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -8087,9 +8087,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:17 GMT',
+  'Thu, 09 Jul 2020 16:25:37 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -8109,7 +8109,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '6261fde6fb36bb1300eb97ebcf2b1530',
+  'f8e523c9c5bc6f9e89d118d412cbe4fc',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -8121,11 +8121,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BhHjd76qTlW3gg4Kqbmy0O2RBV8AAAAAQUIPAAAAAACp6aVwzo86vSsy6WO9s8Ea; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=4hnSPyYHRAaVOFUSyRK01QBFB18AAAAAQUIPAAAAAACHJ+nOLGXq49XyLB6LN9G9; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=BD2yYrFb9Hi1GXvNYMlkBAAAAAAnDixGB8+/yzMux/dDXHzg; path=/; Domain=.contentful.com',
+  'nlbi_673446=Y57GO97KYE9HV8B1YMlkBAAAAADGuZmOC7BhvycXMcb2JhJx; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=qWMEFsbz700eHk4EPWpmA+2RBV8AAAAAPIJ/pYU5XT3UhUL5pBSVVA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=ygARZNiMNQkP3VsGPWpmAwBFB18AAAAA1X5IZiKkr7HG+2NdElVMdQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8133,11 +8133,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-23197035-23197048 NNYY CT(0 0 0) RT(1594200556920 35) q(0 0 0 -1) r(1 1) U5'
+  '4-26742059-26742063 NNYY CT(0 0 0) RT(1594311936776 32) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/6XJW4wlIjh4ynLg1dGjDGr', {"sys":{"id":"6XJW4wlIjh4ynLg1dGjDGr","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4UwZKzKY3KkejAHj3cRPeQ', {"sys":{"id":"4UwZKzKY3KkejAHj3cRPeQ","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8150,10 +8150,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "6XJW4wlIjh4ynLg1dGjDGr",
+    "id": "4UwZKzKY3KkejAHj3cRPeQ",
     "type": "Entry",
-    "createdAt": "2020-07-08T09:29:15.610Z",
-    "updatedAt": "2020-07-08T09:29:17.926Z",
+    "createdAt": "2020-07-09T16:25:35.984Z",
+    "updatedAt": "2020-07-09T16:25:37.875Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8205,11 +8205,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -8218,9 +8218,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:17 GMT',
-  'ETag',
-  'W/"5653218681908984038"',
+  'Thu, 09 Jul 2020 16:25:37 GMT',
+  'etag',
+  'W/"11519352141687709313"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8238,25 +8238,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '7',
   'X-Contentful-Request-Id',
-  '39d7f837301ab48bcc8404beb1d935ec',
+  'e75776abb84ed510b639ed3c4d20f91e',
   'Content-Length',
-  '391',
+  '390',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=2Gglb/4UTEGO2tYjBlBNK+2RBV8AAAAAQUIPAAAAAACLQ/M7/6by5xMGvA6oBAj2; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lpfrydYQRWultUxPLPSi3AFFB18AAAAAQUIPAAAAAAAqfEXyiQ0k4YRy0dRtmxgq; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gaQaA8HNXlFQr2PeYMlkBAAAAACiP+kNrs1cvYTYsxhUpeJA; path=/; Domain=.contentful.com',
+  'nlbi_673446=DnfNR1Osnnc4un5IYMlkBAAAAADcIEweNfo2ItZ+VraU6VCy; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=0RBVJ/O6f2p6Hk4EPWpmA+2RBV8AAAAAxmO5Dpq3FnbM+CJJnqGRcg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=CriKUW/Y+Cao3VsGPWpmAwFFB18AAAAAXhsdcGbLXpB53z+oBQcs6Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38164792-38164799 NNNY CT(0 0 0) RT(1594200557133 39) q(0 0 0 -1) r(3 3) U5'
+  '13-66929587-66929594 NNNN CT(86 87 0) RT(1594311936989 28) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/6XJW4wlIjh4ynLg1dGjDGr/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/4UwZKzKY3KkejAHj3cRPeQ/published')
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8269,10 +8269,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "6XJW4wlIjh4ynLg1dGjDGr",
+    "id": "4UwZKzKY3KkejAHj3cRPeQ",
     "type": "Entry",
-    "createdAt": "2020-07-08T09:29:15.610Z",
-    "updatedAt": "2020-07-08T09:29:18.279Z",
+    "createdAt": "2020-07-09T16:25:35.984Z",
+    "updatedAt": "2020-07-09T16:25:38.255Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8281,8 +8281,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-08T09:29:18.279Z",
-    "firstPublishedAt": "2020-07-08T09:29:18.279Z",
+    "publishedAt": "2020-07-09T16:25:38.255Z",
+    "firstPublishedAt": "2020-07-09T16:25:38.255Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8334,11 +8334,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -8347,9 +8347,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:18 GMT',
-  'ETag',
-  'W/"16194463526073525585"',
+  'Thu, 09 Jul 2020 16:25:38 GMT',
+  'etag',
+  'W/"12592086046620630163"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8367,25 +8367,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '30e531dc0a595e07d9175b47c3b7d72b',
-  'transfer-encoding',
-  'chunked',
+  '1bfbdc17235b8230ab8c39d069e7471d',
+  'Content-Length',
+  '419',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=hldqUoPGQsO78Lbcuu6cNO2RBV8AAAAAQUIPAAAAAADan9sb/pjvHC8xFiUuimn9; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=D5bW8bk2TGOeVIbKTmUnTQFFB18AAAAAQUIPAAAAAAB5aYGvCwjL7nRStmVvyPzV; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WLCbAfWjpU2hxKmSYMlkBAAAAADVfEivWs74BJu1R7d/teow; path=/; Domain=.contentful.com',
+  'nlbi_673446=HP/gRmeBtgxmBh+RYMlkBAAAAADYshcBFR5BDCSSjMYjD2Mb; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=IlYCH+zbAAfnHk4EPWpmA+2RBV8AAAAAVlrarZLtewsA9f/3cLpmAg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=1SemFjBar0hM3lsGPWpmAwFFB18AAAAAzUiM6NDz9x0+/J7YGR0UBA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-23197127-23197132 NNNY CT(0 0 0) RT(1594200557536 28) q(0 0 0 -1) r(3 3) U5'
+  '14-86056725-86056736 NNNY CT(0 0 0) RT(1594311937539 30) q(0 0 0 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/48YUNvi7GyTbywYMw0G8W7', {"sys":{"id":"48YUNvi7GyTbywYMw0G8W7","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/54GyBcsJ9GSwtZkFAXcyfs', {"sys":{"id":"54GyBcsJ9GSwtZkFAXcyfs","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8398,10 +8398,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "48YUNvi7GyTbywYMw0G8W7",
+    "id": "54GyBcsJ9GSwtZkFAXcyfs",
     "type": "Entry",
-    "createdAt": "2020-07-08T09:29:16.132Z",
-    "updatedAt": "2020-07-08T09:29:18.939Z",
+    "createdAt": "2020-07-09T16:25:36.565Z",
+    "updatedAt": "2020-07-09T16:25:39.055Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8453,11 +8453,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -8466,9 +8466,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:18 GMT',
-  'ETag',
-  'W/"14647931782181984559"',
+  'Thu, 09 Jul 2020 16:25:39 GMT',
+  'etag',
+  'W/"2850861518525753052"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8486,25 +8486,25 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '40813420348fcd75c61e9938108c05d4',
+  '435168a404170ec378dd3ef02eb96800',
   'Content-Length',
-  '389',
+  '387',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=gA2ugM6GT7Wou0qrdlms1u6RBV8AAAAAQUIPAAAAAAD3xa6Wad5/iCOGQKbk9kQM; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=s7p1yyukSbCrs7392FPHuQJFB18AAAAAQUIPAAAAAACn4RECK0cDtC4kixbPpASP; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AMnGDzweIQ9DcOJhYMlkBAAAAACV9NQRR+hlSqXRprk8j3pN; path=/; Domain=.contentful.com',
+  'nlbi_673446=2qPtRbnnu1dyd1luYMlkBAAAAAAEaONMfBVzPNxl/hOujo6D; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=KAYER7wgY2CLH04EPWpmA+6RBV8AAAAAEh4EuLRlyWDir+a518tf0w==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=H+mmY6ew8zXY3lsGPWpmAwJFB18AAAAAJOmqfVtkT/QLuQ+7R51owA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15953268-15953273 NNNY CT(0 0 0) RT(1594200558155 29) q(0 0 0 -1) r(3 3) U5'
+  '4-26742200-26742210 NNNN CT(86 87 0) RT(1594311938156 34) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/48YUNvi7GyTbywYMw0G8W7/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/54GyBcsJ9GSwtZkFAXcyfs/published')
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8517,10 +8517,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "48YUNvi7GyTbywYMw0G8W7",
+    "id": "54GyBcsJ9GSwtZkFAXcyfs",
     "type": "Entry",
-    "createdAt": "2020-07-08T09:29:16.132Z",
-    "updatedAt": "2020-07-08T09:29:19.323Z",
+    "createdAt": "2020-07-09T16:25:36.565Z",
+    "updatedAt": "2020-07-09T16:25:39.477Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8529,8 +8529,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-08T09:29:19.323Z",
-    "firstPublishedAt": "2020-07-08T09:29:19.323Z",
+    "publishedAt": "2020-07-09T16:25:39.477Z",
+    "firstPublishedAt": "2020-07-09T16:25:39.477Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8582,11 +8582,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -8595,9 +8595,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:19 GMT',
-  'ETag',
-  'W/"1899161820118669756"',
+  'Thu, 09 Jul 2020 16:25:39 GMT',
+  'etag',
+  'W/"4955621065309646556"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8615,21 +8615,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '4023416f5032082425202d2f02906560',
+  '7a230b11c27c22f43688645bff7367c2',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nhFPbb3SShGPdQZ8LEBkX+6RBV8AAAAAQUIPAAAAAAD5fFMrrmTStTRUWBDoxDzU; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FYI2SlZ2Rt6jkmVYxs9PGANFB18AAAAAQUIPAAAAAADk57nxAfkAZI7VWtPGgcet; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WKfHDSgpQnSKjsLVYMlkBAAAAADHPjOX0Ag3PurtDWkJUmv7; path=/; Domain=.contentful.com',
+  'nlbi_673446=ED40ECpV4XV1HYSvYMlkBAAAAAB80plhg/xXBZHvvehfScWk; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=TXH/LPQlqDQhIE4EPWpmA+6RBV8AAAAAkSmgv2/RrozSmUk72dp0XA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=W2TmDVYfMHNC31sGPWpmAwNFB18AAAAAIUvhOMlBgUg3iwEyTbaouA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38165175-38165185 NNNY CT(0 0 0) RT(1594200558557 41) q(0 0 0 -1) r(4 4) U5'
+  '5-42741314-42741317 NNNY CT(0 0 0) RT(1594311938772 30) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8655,10 +8655,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "48YUNvi7GyTbywYMw0G8W7",
+        "id": "54GyBcsJ9GSwtZkFAXcyfs",
         "type": "Entry",
-        "createdAt": "2020-07-08T09:29:16.132Z",
-        "updatedAt": "2020-07-08T09:29:19.323Z",
+        "createdAt": "2020-07-09T16:25:36.565Z",
+        "updatedAt": "2020-07-09T16:25:39.477Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8667,8 +8667,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-08T09:29:19.323Z",
-        "firstPublishedAt": "2020-07-08T09:29:19.323Z",
+        "publishedAt": "2020-07-09T16:25:39.477Z",
+        "firstPublishedAt": "2020-07-09T16:25:39.477Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8721,10 +8721,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "6XJW4wlIjh4ynLg1dGjDGr",
+        "id": "4UwZKzKY3KkejAHj3cRPeQ",
         "type": "Entry",
-        "createdAt": "2020-07-08T09:29:15.610Z",
-        "updatedAt": "2020-07-08T09:29:18.279Z",
+        "createdAt": "2020-07-09T16:25:35.984Z",
+        "updatedAt": "2020-07-09T16:25:38.255Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8733,8 +8733,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-08T09:29:18.279Z",
-        "firstPublishedAt": "2020-07-08T09:29:18.279Z",
+        "publishedAt": "2020-07-09T16:25:38.255Z",
+        "firstPublishedAt": "2020-07-09T16:25:38.255Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8788,11 +8788,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -8801,9 +8801,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:20 GMT',
-  'ETag',
-  'W/"5731344669494480860"',
+  'Thu, 09 Jul 2020 16:25:40 GMT',
+  'etag',
+  'W/"4179381182970640430"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8813,29 +8813,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'd59e332d4aa197265ce52bc8a1323d3d',
+  'd8e8294086e83fbcabb0b04a74d1b7a3',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=KucdcjFsTK63QK7cvPEKUe+RBV8AAAAAQUIPAAAAAAAoNLBh1MH2moKMHdS1PkQM; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=+MZgESQBSCeYiKuUhHqUzwNFB18AAAAAQUIPAAAAAAAciGHjiATzQBESvd7UPMkI; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qQvMMi8nrgopSu0ZYMlkBAAAAAD5in4996SLsnYu8MM0uywB; path=/; Domain=.contentful.com',
+  'nlbi_673446=WZIePZchXm/Kdj4UYMlkBAAAAAAuMpCfAlhQEh1h6vedtxMV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=H3jGEJLogWO8IE4EPWpmA++RBV8AAAAA4anVmHeJx2/AnBLOiq8fDw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=P5uxZLcejlzY31sGPWpmAwNFB18AAAAAVXzad718xgFtXEoqwLCptg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38165278-38165284 NNNN CT(88 89 0) RT(1594200559025 20) q(0 0 2 -1) r(4 4) U5'
+  '11-41052640-41052648 NNNN CT(93 93 0) RT(1594311939286 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8861,97 +8861,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:20 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:40 GMT',
+  'etag',
   '"10440568906820546102"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '2538dfca5f6e7be62823fb94c9fb0a6a',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=J7VQaZ8YS9+E2cN22nPgre+RBV8AAAAAQUIPAAAAAADnlZRaLK4ADuxOt8VFQne6; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=zVx/DTP3wSTpuoxuYMlkBAAAAADuoSBv0nBbg94cRiUA8Z/R; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=+R5zO+GNS3QVIU4EPWpmA++RBV8AAAAAY2yJycEq/rzrWGWHqArnFA==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
-  'X-Iinfo',
-  '9-11765991-11765995 NNYY CT(0 0 0) RT(1594200559573 26) q(0 1 1 -1) r(2 2) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface')
-  .reply(404, {
-  "sys": {
-    "type": "Error",
-    "id": "NotFound"
-  },
-  "message": "The resource could not be found.",
-  "details": {
-    "type": "ContentType",
-    "id": "blogPost",
-    "environment": "env-integration",
-    "space": "bohepdihyxin"
-  },
-  "requestId": "cbf6d8148bd7a6bc0d0f0068e0c6a134"
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:20 GMT',
-  'ETag',
-  '"2126644456247425345"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8969,15 +8892,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'cbf6d8148bd7a6bc0d0f0068e0c6a134',
+  '68c4928e033b8ff5c386e767b65f6187',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=F1kYbnB0SKa95LzyYLwb2fCRBV8AAAAAQUIPAAAAAACaMkGrj4XElUtWuS1aQYeO; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=EDwSMu/IQxu07ggFFiarXANFB18AAAAAQUIPAAAAAABNDwfng9i7+byRu9y2GTJY; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=I9yeW1nEGgZgyZdQYMlkBAAAAADsMhFJ2Q0eUZlU99+E0/6H; path=/; Domain=.contentful.com',
+  'nlbi_673446=Uf3eLv3UJRJ+TOFJYMlkBAAAAACgwAjNWw4N+ggzZydmyKJ0; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=SKKIPFdbng6GIU4EPWpmA/CRBV8AAAAAWHzk2Yw5Qtfzl6x8cSv02A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=zY8BaTMuuEIR4FsGPWpmAwNFB18AAAAALGvZHaSsso3ng+DDo4Ke8A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8985,7 +8908,84 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49186735-49186752 NNYY CT(0 0 0) RT(1594200559985 26) q(0 0 0 -1) r(2 2) U5'
+  '13-66930350-66930356 NNYY CT(0 0 0) RT(1594311939800 30) q(0 0 0 -1) r(1 1) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface')
+  .reply(404, {
+  "sys": {
+    "type": "Error",
+    "id": "NotFound"
+  },
+  "message": "The resource could not be found.",
+  "details": {
+    "type": "ContentType",
+    "id": "blogPost",
+    "environment": "env-integration",
+    "space": "bohepdihyxin"
+  },
+  "requestId": "c4a642654a66bbe0cfdd13da3b99be37"
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:40 GMT',
+  'etag',
+  '"14226196473492830399"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35997',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '7',
+  'X-Contentful-Request-Id',
+  'c4a642654a66bbe0cfdd13da3b99be37',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=4YBP+s67SrSdHdahLlwzfgRFB18AAAAAQUIPAAAAAAAlUzzJQy3w0pIrTo8EiPzp; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=wwK8KW1qhm6gZijmYMlkBAAAAACAeGsrSnDBY0IUIWOO98IP; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=QYSEXw6RYmtM4FsGPWpmAwRFB18AAAAA1u7QZZGMPZP7p/gGtDMmwg==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '4-26742398-26742401 NNYY CT(0 0 0) RT(1594311940092 33) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9026,8 +9026,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -9057,9 +9057,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:21 GMT',
+  'Thu, 09 Jul 2020 16:25:41 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -9079,7 +9079,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '8db9a54455343b7a678a8092d88a509d',
+  'e3622ae9d590bb08f67d9aeb260e423b',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -9091,11 +9091,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=li47bv22R6+1JYJUDxC59fCRBV8AAAAAQUIPAAAAAACib1FeEcY3NqNSmg96GKc9; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FIh8edipT2q5Hgoidyh3PwRFB18AAAAAQUIPAAAAAAC06Hs/PrdBP16N2xIs43P/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TRErCYjzy3kArcPNYMlkBAAAAACaXOazf96MBMbLDVrT/iOL; path=/; Domain=.contentful.com',
+  'nlbi_673446=6q//ZGShLnypdTb0YMlkBAAAAABxtS6e7pIjuW426VWmYWKz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=rpErV5veM1/tIU4EPWpmA/CRBV8AAAAA86j2rFR5JLdOGdxVNudI1Q==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=i9VBEdUw4jWW4FsGPWpmAwRFB18AAAAA1LHXDRIcZC2Xkz2B99tAWg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9103,12 +9103,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-15953610-15953613 NNYY CT(0 0 0) RT(1594200560399 28) q(0 0 0 -1) r(1 1) U5'
+  '6-13875339-13875342 NNYY CT(0 0 0) RT(1594311940408 29) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost', {"name":"Blog post","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-08T09:29:21.616Z","updatedAt":"2020-07-08T09:29:21.616Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-09T16:25:41.377Z","updatedAt":"2020-07-09T16:25:41.377Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -9119,20 +9119,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:21 GMT',
-  'ETag',
-  '"7742368282418156454"',
+  'Thu, 09 Jul 2020 16:25:41 GMT',
+  'etag',
+  '"7948710513735787671"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9150,21 +9150,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '03ba5082bb92346ef4faf3a1c10c6a87',
+  'd5baedfef4857038ca8bb465032fd752',
   'Content-Length',
   '1054',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=7yRp0b3EQNuMRM0YrqbdEPGRBV8AAAAAQUIPAAAAAAClOu8eCESjTMuShOL9oBmX; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3uRKILxNTtiey80Tp3wEJQRFB18AAAAAQUIPAAAAAAAhaBG7okPPJ0HdyBaqFFSK; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zdSeS1BpNG96CirrYMlkBAAAAAATXOLQ3SG23xxzNQ7edC+L; path=/; Domain=.contentful.com',
+  'nlbi_673446=XJ0/fNd4REVb47ZEYMlkBAAAAAAHzWVOj9NjTYaZjQtuqKQt; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=IBxJBzvWUzWOIk4EPWpmA/GRBV8AAAAAXz/FIH12tOQKclfGoOGM7A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=4y39eXX+N27+4FsGPWpmAwRFB18AAAAAqvw3PhqB9oYtKKHyf/FAVw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-16019700-16019703 NNNY CT(0 0 0) RT(1594200560699 30) q(0 0 0 -1) r(4 4) U5'
+  '11-41052868-41052873 NNNY CT(0 0 0) RT(1594311940614 31) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9180,8 +9180,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:21.616Z",
-    "updatedAt": "2020-07-08T09:29:22.010Z",
+    "createdAt": "2020-07-09T16:25:41.377Z",
+    "updatedAt": "2020-07-09T16:25:41.897Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9205,8 +9205,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:22.010Z",
-    "publishedAt": "2020-07-08T09:29:22.010Z",
+    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
+    "publishedAt": "2020-07-09T16:25:41.897Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -9243,11 +9243,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -9256,9 +9256,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:22 GMT',
-  'ETag',
-  'W/"3150762685610494880"',
+  'Thu, 09 Jul 2020 16:25:41 GMT',
+  'etag',
+  'W/"1268252573313628680"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9276,21 +9276,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '7',
   'X-Contentful-Request-Id',
-  'de7c6330e155daea638dc862c294d066',
+  'fae62935f1bea8b4124a32e1e801fb74',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=WxxiNUJpSKePF5h3wHPikfGRBV8AAAAAQUIPAAAAAACdFPGSbpLjcdyCJBF5jmSs; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Qt0RI0y6Sim/EMYWajcrAwVFB18AAAAAQUIPAAAAAAA3SAk5Raewh4dPvWHGW1gC; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=iK+ZfwejzzqWdmViYMlkBAAAAAAvGgU8Uq2AHahBBlzgUR6d; path=/; Domain=.contentful.com',
+  'nlbi_673446=zuZgSgQPsFwJUJp/YMlkBAAAAABENwJN1J1PPY5prarfxT4w; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Aa+BFTofSlsAI04EPWpmA/GRBV8AAAAA8/bYAKx8v3/pGlpcLOtNCQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=dRRuI4TOO3GR4VsGPWpmAwVFB18AAAAAA9tdjVxgbA9Dz8OVcrrioQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15110684-15110693 NNNY CT(0 0 0) RT(1594200561225 27) q(0 0 0 -1) r(4 4) U5'
+  '14-86057633-86057645 NNNN CT(97 89 0) RT(1594311940990 41) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9317,7 +9317,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9325,7 +9325,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:22.808Z",
+    "updatedAt": "2020-07-09T16:25:42.239Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -9360,11 +9360,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -9373,9 +9373,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:22 GMT',
-  'ETag',
-  'W/"3636952435045690094"',
+  'Thu, 09 Jul 2020 16:25:42 GMT',
+  'etag',
+  'W/"15460693560588132469"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9393,21 +9393,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '8ced2779217408014ccdd98f8dc0d9d1',
+  'cbd637ecfb9aae7eda985b0e9e3fa182',
   'Content-Length',
-  '381',
+  '384',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=eoaaoRyvT/yaFWoEGgHIFfKRBV8AAAAAQUIPAAAAAACaY3WBHGWvDQwN9A7xqi3P; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ftkN97EORQOlnBn6Ah7JUwVFB18AAAAAQUIPAAAAAAAhq1oU+V6O5xPTBv8vkcYd; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=n007LOPULC1vQUPgYMlkBAAAAADw4eQl8krWUY1o7sBMlvHK; path=/; Domain=.contentful.com',
+  'nlbi_673446=8/C6ETwat0zF+8OxYMlkBAAAAADkO/dMHhTLP2H9WKSOJE3s; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=/R0wS5nThQ26I04EPWpmA/KRBV8AAAAASB1PNs2CIR9VbaoKXDEP0A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=5tPTR1KtzG3R4VsGPWpmAwVFB18AAAAA0evyQ5SuVG8AE+uyGPimRA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15953798-15953801 NNNN CT(93 93 0) RT(1594200561823 33) q(0 0 2 -1) r(4 4) U5'
+  '11-41052965-41052969 NNNY CT(0 0 0) RT(1594311941522 27) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9424,7 +9424,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9432,7 +9432,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:22.808Z",
+    "updatedAt": "2020-07-09T16:25:42.239Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9477,11 +9477,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -9490,9 +9490,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:23 GMT',
-  'ETag',
-  'W/"16802488552562001322"',
+  'Thu, 09 Jul 2020 16:25:42 GMT',
+  'etag',
+  'W/"652615658264279945"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9502,29 +9502,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '976ae755bce08ee9209ff957c80faa67',
-  'Content-Length',
-  '369',
+  '81091d9b6248bb72672ad353abba3a24',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=QwMT3+TZRkai6RfhFD3RgPKRBV8AAAAAQUIPAAAAAABDk/wxNO+hMZLrl/ErleM2; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sVMp5BbjQbOTWhkBlaKFrQVFB18AAAAAQUIPAAAAAAB6RkLjoU2JCRPPSjRh2EkB; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TxyAJaFBiyZnJxTLYMlkBAAAAABX4hUgSuyD3BHUhb3UM0Lq; path=/; Domain=.contentful.com',
+  'nlbi_673446=5xb4cS5uODMUyIlbYMlkBAAAAAAoNzs0U0FOfTHge8IJuiY/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=M4HXXADTg3Y+JE4EPWpmA/KRBV8AAAAAMX0vkyGaq1tvLg+YcGgX6A==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=rzX2SCY+ATXy4VsGPWpmAwVFB18AAAAAtR8GwkFnCAOE/aUX5CVzbA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-11766307-11766309 NNNN CT(86 86 0) RT(1594200562443 33) q(0 0 2 -1) r(4 4) U5'
+  '13-66930815-66930816 NNNY CT(0 0 0) RT(1594311941778 30) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9549,8 +9549,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:29:21.616Z",
-        "updatedAt": "2020-07-08T09:29:22.010Z",
+        "createdAt": "2020-07-09T16:25:41.377Z",
+        "updatedAt": "2020-07-09T16:25:41.897Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -9559,8 +9559,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-08T09:29:22.010Z",
-        "firstPublishedAt": "2020-07-08T09:29:22.010Z",
+        "publishedAt": "2020-07-09T16:25:41.897Z",
+        "firstPublishedAt": "2020-07-09T16:25:41.897Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -9614,11 +9614,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -9627,9 +9627,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:24 GMT',
-  'ETag',
-  'W/"8712359651516567491"',
+  'Thu, 09 Jul 2020 16:25:42 GMT',
+  'etag',
+  'W/"17983529376578233374"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9639,29 +9639,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '0ac319c626ad6db67094aba400954223',
+  'c0a39a73c06da3512507cc5748ef7561',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=0N2o91agRAeediYC3n68xPORBV8AAAAAQUIPAAAAAAAVwLI1s7ET153939hS4FF/; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=zZgYPIoeTGGO6mXG8/9d6AZFB18AAAAAQUIPAAAAAAD55Nb9qProDOh2K0EglBV+; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=uNfCUmWkEAqzVKKCYMlkBAAAAADFnXPYj89Hyc3nwx1LIE5Z; path=/; Domain=.contentful.com',
+  'nlbi_673446=GiX9D76xeF2XNRLGYMlkBAAAAADO1IfL+BtWIPEEKqZWWoLV; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=OcxyIqHO5SrjJE4EPWpmA/ORBV8AAAAAWSOJ3SaDlJkf8Wh1ZPq2EA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=E967cbdhx2Ef4lsGPWpmAwZFB18AAAAAVKMR9rChlW8x+aEe0bvAhw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38166660-38166672 NNNN CT(93 94 0) RT(1594200563061 32) q(0 0 2 -1) r(5 5) U5'
+  '13-66930860-66930868 NNNY CT(0 0 0) RT(1594311942032 32) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9678,7 +9678,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9686,7 +9686,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:22.808Z",
+    "updatedAt": "2020-07-09T16:25:42.239Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9731,11 +9731,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -9744,9 +9744,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:24 GMT',
-  'ETag',
-  'W/"16802488552562001322"',
+  'Thu, 09 Jul 2020 16:25:43 GMT',
+  'etag',
+  'W/"652615658264279945"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9764,21 +9764,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '32c74c693c57daefe58c61bbe6d0e1bc',
+  '032ce0edab5e83324fd71db496ddeff0',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=z1qvM4/xTYu0QI23O3dVFPORBV8AAAAAQUIPAAAAAAC+/7C2Bj3Fqm2Z3NYVZcvS; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=4QstpQvMRNKIAmzfGMQcgAZFB18AAAAAQUIPAAAAAAA9G9LV+Y3Vbj5vQxXJ+XKi; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qGBZU7himAhjOupuYMlkBAAAAACdbxrutDtgyIQHUczfwvbV; path=/; Domain=.contentful.com',
+  'nlbi_673446=eySYWDX4zBJGsfy5YMlkBAAAAACngl/qEr05OKj9hkGy2SaK; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=rW5hIeaoc08zJU4EPWpmA/ORBV8AAAAA2DmKJrbTdXJa56fB05jkyg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=zR0eeN7wWyqq4lsGPWpmAwZFB18AAAAAUh+SkbWrKPl+smeVq3nmQg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-25306883-25306886 NNNY CT(0 0 0) RT(1594200563667 27) q(0 0 0 -1) r(2 2) U5'
+  '14-86058100-86058111 NNNN CT(95 93 0) RT(1594311942450 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9819,8 +9819,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -9850,9 +9850,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:24 GMT',
+  'Thu, 09 Jul 2020 16:25:43 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -9872,7 +9872,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'ae2349c5deb0e32e4cc880642d6812c2',
+  'e31446d5a2f1a3bb1ebe4f03113e8eb6',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -9884,11 +9884,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ckT4dYBWRqWd00lP3XhCjPSRBV8AAAAAQUIPAAAAAAA+jr3O7T8pZCPWJhiOCdcj; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fLf+1PJHSgeJOVAA2qOoygdFB18AAAAAQUIPAAAAAAAJWyeI8nUvke3hVljbb7nw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=VzU2R6xqbXJCgaFkYMlkBAAAAACO67LwDsOdL9wSsqAja0SZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=4sXlbYP362b+PfChYMlkBAAAAADwiuCrlu1eCB9NH3NDvoF4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=T8ePSAYObAOTJU4EPWpmA/SRBV8AAAAAuVfIHjDDthkGyOdmtmRRPg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=99fNclfX4WLj4lsGPWpmAwdFB18AAAAAPKYfWzooQhD0BxJ+ljk7yg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9896,7 +9896,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49188564-49188591 NNYY CT(0 0 0) RT(1594200564067 31) q(0 0 0 -1) r(2 2) U5'
+  '14-86058273-86058283 NNYY CT(0 0 0) RT(1594311942912 28) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9912,8 +9912,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:21.616Z",
-    "updatedAt": "2020-07-08T09:29:25.109Z",
+    "createdAt": "2020-07-09T16:25:41.377Z",
+    "updatedAt": "2020-07-09T16:25:43.910Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9922,8 +9922,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-08T09:29:22.010Z",
-    "firstPublishedAt": "2020-07-08T09:29:22.010Z",
+    "publishedAt": "2020-07-09T16:25:41.897Z",
+    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -9975,11 +9975,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -9988,9 +9988,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:25 GMT',
-  'ETag',
-  'W/"18268310546141433329"',
+  'Thu, 09 Jul 2020 16:25:43 GMT',
+  'etag',
+  'W/"12092743357779974201"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10008,21 +10008,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '7',
   'X-Contentful-Request-Id',
-  '4cc269f5f8390e258514770a3d74dce7',
+  'afa2c0f2ac1d8afd7e59bb1a98753550',
   'Content-Length',
-  '451',
+  '450',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/AwDWBMOTQ2bMord7Y4w+vSRBV8AAAAAQUIPAAAAAADdGRIGMA8xZmoMrc4kxwJy; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=6JEaPP34TZapwK6d6LRRuwdFB18AAAAAQUIPAAAAAAAkmIT5QgMFtezdrijCVaMO; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=0w7hMiydQUjzb4dYYMlkBAAAAADFASGa/8aH/jFiRKz/HpH/; path=/; Domain=.contentful.com',
+  'nlbi_673446=vjBJOlE4Qixqu0HOYMlkBAAAAADGxcZY2ZPhFan7tfoRYiJY; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=CCdbaXVE41TtJU4EPWpmA/SRBV8AAAAAqUTM/EwJrqyY3XHtJJrAzg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=+Xc+In3XT2dI41sGPWpmAwdFB18AAAAAYb5c8QQySmBgnVy17AW/+A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38167200-38167213 NNNY CT(0 0 0) RT(1594200564321 34) q(0 0 0 -1) r(3 3) U5'
+  '10-27145049-27145051 NNNY CT(0 0 0) RT(1594311943172 33) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10038,8 +10038,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:21.616Z",
-    "updatedAt": "2020-07-08T09:29:25.426Z",
+    "createdAt": "2020-07-09T16:25:41.377Z",
+    "updatedAt": "2020-07-09T16:25:44.209Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10048,8 +10048,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:25.426Z",
-    "firstPublishedAt": "2020-07-08T09:29:22.010Z",
+    "publishedAt": "2020-07-09T16:25:44.209Z",
+    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10101,11 +10101,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -10114,9 +10114,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:25 GMT',
-  'ETag',
-  'W/"4100440324430187088"',
+  'Thu, 09 Jul 2020 16:25:44 GMT',
+  'etag',
+  'W/"10568345880193897593"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10134,26 +10134,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fa0a018f125e47caa60b1769bfc80759',
+  '3aeec2fd779994e3748059f6928276c2',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=r1js58pnR0qm4+oe1oV+nPSRBV8AAAAAQUIPAAAAAABnzqMzqe9Y7vycJBgNbH7X; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YOA3MacQQLGbaOn1X0YW7AdFB18AAAAAQUIPAAAAAACdb5MO/wLwmS1yf/W4mO9T; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=vINEDdind1Li5b98YMlkBAAAAABvB3uInC+rMbHzcuX4AO4B; path=/; Domain=.contentful.com',
+  'nlbi_673446=CSMeel1t/VZWhBwDYMlkBAAAAAAkW1kG5zDhZYfKTSGS18y7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=6rokL3908ThxJk4EPWpmA/SRBV8AAAAAQUqcI6f+9C43i7Xp2jSYLQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=dqShcPi0LHjN41sGPWpmAwdFB18AAAAApgWZWmTslRwqOFd6CjAaAA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-23199115-23199118 NNNY CT(0 0 0) RT(1594200564695 25) q(0 0 0 -1) r(2 2) U5'
+  '11-41053287-41053289 NNNY CT(0 0 0) RT(1594311943508 30) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[]})
-  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-08T09:29:22.131Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-08T09:29:25.995Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-09T16:25:41.965Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-09T16:25:45.474Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -10164,20 +10164,81 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:26 GMT',
-  'ETag',
-  '"15500255157282216583"',
+  'Thu, 09 Jul 2020 16:25:45 GMT',
+  'etag',
+  '"164470994564451341"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '77f40772d3fa0c10b296aa42120f76de',
+  'Content-Length',
+  '880',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=yoVnRL0NTBCq89A7opW9PQhFB18AAAAAQUIPAAAAAABDNmiIKhiLNUbbkJewVXjw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=CsFdD4zNbWOB92ncYMlkBAAAAACT8lAr88E8Np1/2R1Pb/Ga; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=3KflSJ6EmnoN5VsGPWpmAwhFB18AAAAA95E3eKgvOFbzMnDi5nfkjQ==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '10-27145182-27145188 NNNY CT(0 0 0) RT(1594311944748 33) q(0 0 0 -1) r(2 2) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}]})
+  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-09T16:25:41.965Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-09T16:25:45.782Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:25:45 GMT',
+  'etag',
+  '"15680840757178577283"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10195,82 +10256,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'b111adb743ba4b9201d050015c2f35fa',
-  'Content-Length',
-  '880',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=DOIBZ9LLSwyVk0HZIcKgwvWRBV8AAAAAQUIPAAAAAABtbOyMzpdab4meqaeJ/8ko; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=HAZrac2KhyVGVtVtYMlkBAAAAABwwZjE/Htf5FMV0KJPfq8T; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=mCqoOHejh24IJ04EPWpmA/WRBV8AAAAA2qPm5CwCljyTPBENRxUbpg==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '13-38167515-38167520 NNNY CT(0 0 0) RT(1594200565105 20) q(0 0 0 -1) r(3 3) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}]})
-  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-08T09:29:22.131Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-08T09:29:26.427Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:26 GMT',
-  'ETag',
-  '"1353032664004169366"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  '7c795210468bd9a911237f4430dae9cb',
+  'cc67c080b19994a4f55a3e8e1dd1690d',
   'Content-Length',
   '987',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=sdeAgWDlTrWJ+/ONDdklbfWRBV8AAAAAQUIPAAAAAACWzJb0ULZbSscw4+VSJngc; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FlZtZ41vSB+QG6CtBvbYjglFB18AAAAAQUIPAAAAAAA9zXcf2B75ZeHm+3O5dnKW; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=kvvlWI3d8SjFsgRHYMlkBAAAAACofZasNpOhAZh0kT3vYY6R; path=/; Domain=.contentful.com',
+  'nlbi_673446=bYghH+fcaEUua5ihYMlkBAAAAAD4gGljo9EAqBfD9DoYS7yf; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=uPH5bQMSdlx/J04EPWpmA/WRBV8AAAAASNSxqnbp23pI5unLDbP8aw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=sPAYbJIFIXtO5VsGPWpmAwlFB18AAAAAvQrHXwp6jNeK+KHks/BGUw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15111355-15111364 NNNY CT(0 0 0) RT(1594200565708 33) q(0 0 0 -1) r(2 2) U5'
+  '11-41053522-41053528 NNNY CT(0 0 0) RT(1594311945052 36) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10287,7 +10287,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10295,7 +10295,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:26.427Z",
+    "updatedAt": "2020-07-09T16:25:45.782Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10337,20 +10337,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:26 GMT',
-  'ETag',
-  '"4404711708377082897"',
+  'Thu, 09 Jul 2020 16:25:46 GMT',
+  'etag',
+  '"5740236003190935857"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10360,23 +10360,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '733426682962bf7dbab234a1e072530c',
+  '71ae7561764a453e34e91fb89d12dfe7',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Pf4hylTrQteMmN1VVEfqKvaRBV8AAAAAQUIPAAAAAAD2JGOEBI9tLYV6MGVt2HdR; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3bgK9aBVT7a6TfKmw52diglFB18AAAAAQUIPAAAAAAA6Zu4u3c1o8nTovxxJ2KJ/; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=mGQpZME4niK1xCjGYMlkBAAAAADsQzYPP1DMaPNfDdwg3Axk; path=/; Domain=.contentful.com',
+  'nlbi_673446=++RZHufIMwNIfg0TYMlkBAAAAACfMoahRAPOzkiode0Xh2l9; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=wiL3Fj2gFnMEKE4EPWpmA/aRBV8AAAAAvDHg+E3cNJ3NSV1PN4MbmA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=n4raM+r9rQt15VsGPWpmAwlFB18AAAAApTPjazj/pImI5Ku12Hu9VA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10384,7 +10384,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '7-16020347-16020354 NNYY CT(0 0 0) RT(1594200566124 36) q(0 0 0 -1) r(2 2) U5'
+  '13-66931612-66931620 NNYY CT(0 0 0) RT(1594311945333 25) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10409,8 +10409,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-08T09:29:21.616Z",
-        "updatedAt": "2020-07-08T09:29:25.426Z",
+        "createdAt": "2020-07-09T16:25:41.377Z",
+        "updatedAt": "2020-07-09T16:25:44.209Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -10419,8 +10419,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-08T09:29:25.426Z",
-        "firstPublishedAt": "2020-07-08T09:29:22.010Z",
+        "publishedAt": "2020-07-09T16:25:44.209Z",
+        "firstPublishedAt": "2020-07-09T16:25:41.897Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -10474,11 +10474,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -10487,9 +10487,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:27 GMT',
-  'ETag',
-  'W/"8482228186319929138"',
+  'Thu, 09 Jul 2020 16:25:46 GMT',
+  'etag',
+  'W/"18203384032350722570"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10507,21 +10507,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd626c43dfb6086d4954a6cb7017a172f',
-  'Content-Length',
-  '523',
+  'd355086962b2bdf5b152720ae615ffe3',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=P0p58gfGRSWHAoZcGvSxXfaRBV8AAAAAQUIPAAAAAABRk5b41VI7INFt/pTMgcg3; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=d0zZXfakRMKZUD97EQQjgAlFB18AAAAAQUIPAAAAAAA979DKSSr8+1u1bAR2AWOq; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=j3ZoHFfrn0Itwr5TYMlkBAAAAAA/v9OYepHOc2N53NYu4MJZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=WJwmPQVfZ0jWmfZlYMlkBAAAAABINzktTQnX/Cm9QhzsNYa2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=N6oqVscs/1mIKE4EPWpmA/aRBV8AAAAAL3bwtWxY846XQCqcypMb5g==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=ymFnXHO4GGXq5VsGPWpmAwlFB18AAAAAcPtLE2Vdx7zxwtnYE0dzYg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38167940-38167954 NNNY CT(0 0 0) RT(1594200566441 27) q(0 0 0 -1) r(3 3) U5'
+  '14-86058997-86059018 NNNN CT(88 94 0) RT(1594311945576 36) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10538,7 +10538,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10546,7 +10546,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:26.427Z",
+    "updatedAt": "2020-07-09T16:25:45.782Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10588,20 +10588,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:27 GMT',
-  'ETag',
-  '"4404711708377082897"',
+  'Thu, 09 Jul 2020 16:25:46 GMT',
+  'etag',
+  '"5740236003190935857"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10619,15 +10619,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'b30c6969b67757fb62d9dec219eabe27',
+  'eeda4647a2aad023e1afeb1622940d9e',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=25ETdwHUTsi5s8PUMPXaUfeRBV8AAAAAQUIPAAAAAADN3i5W+rX3ovNa8xHuCwK2; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=a48/ZiuZRqu1UeugpyjqugpFB18AAAAAQUIPAAAAAAAWD/wwjD9p/nGGv4zqxmMw; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=wc4DYM5H/Rm+GQXIYMlkBAAAAADcfygKbofb4jyWmyINzKDt; path=/; Domain=.contentful.com',
+  'nlbi_673446=bSZMFM42wRzFtjSZYMlkBAAAAABdDJT23hQVKW2QXxHACQBp; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=CK21aCsXGQELKU4EPWpmA/eRBV8AAAAAS6q7hkaEspUr+6q0dtRRZA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=zCsyTUPOFBwi5lsGPWpmAwpFB18AAAAA7zZBrm/rSmtxQGQxEKl/Mg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10635,7 +10635,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-31556287-31556308 NNYY CT(0 0 0) RT(1594200566967 32) q(0 1 1 -1) r(2 2) U5'
+  '14-86059127-86059144 NNYY CT(0 0 0) RT(1594311946040 30) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10676,8 +10676,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -10707,9 +10707,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:28 GMT',
+  'Thu, 09 Jul 2020 16:25:47 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -10729,7 +10729,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5914dcaac2ecad27b1892daa243d76ba',
+  'aaaba061a492c30be8ebb1f94963ec02',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -10741,11 +10741,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=zZLSt3RkR/KOKJ2lIijRUveRBV8AAAAAQUIPAAAAAAAubrt+GKeCbvTVawCNG9Ux; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ddxc+GqUT0yzzy+tmn1OOQpFB18AAAAAQUIPAAAAAABH7ocNwTmuBs3BUbLViQH0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=NNYxB+WTLhQMwwA5YMlkBAAAAADIIo0XYKDD9IkOr7TcRMio; path=/; Domain=.contentful.com',
+  'nlbi_673446=6bfpBDG3ql3k2IocYMlkBAAAAAD2aujorJkNMVeb2ZnsI/ZG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=JVg2FNRY8AhoKU4EPWpmA/eRBV8AAAAAVj7UPwP1kmk3p9Ommny6Mg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=xslmOi25aCdG5lsGPWpmAwpFB18AAAAAI4Gjs8t5E26nUj5xTX3RcA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10753,7 +10753,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '5-25307580-25307595 NNYY CT(0 0 0) RT(1594200567367 28) q(0 0 0 -1) r(2 2) U5'
+  '14-86059232-86059241 NNYY CT(0 0 0) RT(1594311946348 28) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10769,8 +10769,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:21.616Z",
-    "updatedAt": "2020-07-08T09:29:28.743Z",
+    "createdAt": "2020-07-09T16:25:41.377Z",
+    "updatedAt": "2020-07-09T16:25:47.401Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10779,8 +10779,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-08T09:29:25.426Z",
-    "firstPublishedAt": "2020-07-08T09:29:22.010Z",
+    "publishedAt": "2020-07-09T16:25:44.209Z",
+    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10832,11 +10832,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -10845,9 +10845,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:28 GMT',
-  'ETag',
-  'W/"1727322478051387339"',
+  'Thu, 09 Jul 2020 16:25:47 GMT',
+  'etag',
+  'W/"14139904167359079263"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10865,21 +10865,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'e2829b6e1fdc43212023cc3c1068a35c',
-  'transfer-encoding',
-  'chunked',
+  '1dea22701040cbbf02d0b135ececa946',
+  'Content-Length',
+  '464',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=euJ6PyXhTYWkzi0RR8vW3viRBV8AAAAAQUIPAAAAAAAgBMYg3UsYqLgk2y+thD5k; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=CGiTYgHbS9Gcqk5qIuiW6ApFB18AAAAAQUIPAAAAAABYNA84juUu2LFegxdYbEsq; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=i/IFBT3Lykgkc+QHYMlkBAAAAAAW0rNUSYsM46xkVbeCoaaG; path=/; Domain=.contentful.com',
+  'nlbi_673446=efWuFFXOh0lREdv0YMlkBAAAAAD4FrXGrnbIPxTb0gLnJ7G8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=BMG2LIqwyV8VKk4EPWpmA/iRBV8AAAAAqGYoBtW6SmE/4dko+uxQXw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=skqYM5cd+BO55lsGPWpmAwpFB18AAAAAvSwYvT7lVT4VzmyzqJgf2g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-25307645-25307658 NNNN CT(92 94 0) RT(1594200567667 29) q(0 0 2 -1) r(6 6) U5'
+  '11-41053694-41053698 NNNY CT(0 0 0) RT(1594311946654 36) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10895,8 +10895,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:21.616Z",
-    "updatedAt": "2020-07-08T09:29:29.193Z",
+    "createdAt": "2020-07-09T16:25:41.377Z",
+    "updatedAt": "2020-07-09T16:25:48.040Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10905,8 +10905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-08T09:29:29.193Z",
-    "firstPublishedAt": "2020-07-08T09:29:22.010Z",
+    "publishedAt": "2020-07-09T16:25:48.040Z",
+    "firstPublishedAt": "2020-07-09T16:25:41.897Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10958,11 +10958,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -10971,9 +10971,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:29 GMT',
-  'ETag',
-  'W/"4983730096326083862"',
+  'Thu, 09 Jul 2020 16:25:48 GMT',
+  'etag',
+  'W/"15968548495450935525"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10983,29 +10983,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '7',
   'X-Contentful-Request-Id',
-  '7c8511d6f7af97f41c125edebff16dc7',
-  'Content-Length',
-  '457',
+  'dd769b87822c1d8f1b2af34d4c1b511b',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FNpAxmOqQkGt9Bxgps0YJviRBV8AAAAAQUIPAAAAAACb7POQetHQzkhfez4B3ajj; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=v6LWldsVSviSnByUmip8OwtFB18AAAAAQUIPAAAAAADRsK3js7ARrwwSiFsfl2GV; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Vma7N/y/hFw7i1fLYMlkBAAAAABsBnqd6JIFX88pFGF3Pba5; path=/; Domain=.contentful.com',
+  'nlbi_673446=XcYMM+oSuhbX+TmIYMlkBAAAAAApaoKtJuZgR5wwpikxVlJQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=VsFMBkUaQgSIKk4EPWpmA/iRBV8AAAAAk/NItxJSI0bcNwqGGWzU1w==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=C/waIBKyOzWD51sGPWpmAwtFB18AAAAAXywOWu7Z1ETc3+CAFX9A2Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38168461-38168476 NNNY CT(0 0 0) RT(1594200568377 34) q(0 0 0 -1) r(3 3) U5'
+  '7-27376821-27376825 NNNN CT(86 87 0) RT(1594311947162 26) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11032,7 +11032,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11040,7 +11040,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:29.921Z",
+    "updatedAt": "2020-07-09T16:25:48.396Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11075,11 +11075,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -11088,9 +11088,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:29 GMT',
-  'ETag',
-  'W/"15048179391873331841"',
+  'Thu, 09 Jul 2020 16:25:48 GMT',
+  'etag',
+  'W/"12897938895799238249"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11100,29 +11100,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '0abcdfdba18905c0a4f4c9e18819dd20',
-  'Content-Length',
-  '417',
+  '972dc895b46e376bef8bb0f83c801fd0',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NhQhvj4jQcSN+CEEA7SDnPmRBV8AAAAAQUIPAAAAAABrrrbpuRWPtNdvOGqu4TXp; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=XUs0+2bRReSX7SFzmRio2gtFB18AAAAAQUIPAAAAAAA4rYmrFINOR6Q1Su4RynH0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8VmaT+VX7VB9beQpYMlkBAAAAAD51eLXkwDUskyBQ/N16IRP; path=/; Domain=.contentful.com',
+  'nlbi_673446=RT9VcZEtZRu7qjcIYMlkBAAAAACQ6SdrHoSkHaHQXOCa1bAU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=rBQ6CLl39zQwK04EPWpmA/mRBV8AAAAAJwdb/e98hoDR/araCVPjcA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=B4egBrNSdG/X51sGPWpmAwtFB18AAAAA73TLQCA7H+LZIbzZdSLTXQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38168654-38168663 NNNN CT(88 110 0) RT(1594200568901 37) q(0 0 2 -1) r(5 5) U5'
+  '14-86059650-86059659 NNNY CT(0 0 0) RT(1594311947682 27) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11139,7 +11139,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-08T09:29:22.131Z",
+    "createdAt": "2020-07-09T16:25:41.965Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11147,7 +11147,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:29.921Z",
+    "updatedAt": "2020-07-09T16:25:48.396Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11192,11 +11192,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -11205,9 +11205,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:30 GMT',
-  'ETag',
-  'W/"17679555954716826188"',
+  'Thu, 09 Jul 2020 16:25:48 GMT',
+  'etag',
+  'W/"11422179183294694942"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11217,29 +11217,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'c01ed3fd20e6ab4250f7d87e805eaed1',
+  '436e908cd1f5f64269fe20d1b48a0961',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=6qJ8Su9iS0aQ+zjuwl4iGvmRBV8AAAAAQUIPAAAAAABBs/vsUtM2ouekXjiqIYDk; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=2PwWjhSqT9uupD06bTc5MQxFB18AAAAAQUIPAAAAAADQlt4f9pUU2PXgAqgVvkJR; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=mzVANwJnXXiwJ7egYMlkBAAAAAD7sBWutavlkSmMephE/v0Z; path=/; Domain=.contentful.com',
+  'nlbi_673446=4ZOXACa6bnAzwSZOYMlkBAAAAABLQAUZanSZzNDxXQwSQxse; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=QMk7Jwah4WWWK04EPWpmA/mRBV8AAAAA7PdKfH6RSP5Rm5OMxYxnlQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=1m2fE/h5iTk/6FsGPWpmAwxFB18AAAAAoACXbFITLTvWirx7dxy0VA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31556933-31556941 NNNY CT(0 0 0) RT(1594200569607 30) q(0 0 0 -1) r(2 2) U5'
+  '13-66932232-66932239 NNNY CT(0 0 0) RT(1594311947986 37) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11265,19 +11265,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:30 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:49 GMT',
+  'etag',
   '"10440568906820546102"',
   'Server',
   'Contentful',
@@ -11288,23 +11288,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  'c03bb62d8106e57c5bd13dcc28bdf8a9',
+  '3a30d6d8ea9b02729469a134ffd84332',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=m/we0AttQ4a8bXRNZ9cOUPqRBV8AAAAAQUIPAAAAAACv7Vrioek6lEJQ7zQSK35H; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Sr9h+yVgR5Gj5xo+bHcDIAxFB18AAAAAQUIPAAAAAABRAYcfMs3niveA0w77vR5G; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hoeVM0kgOkTzc9YkYMlkBAAAAACJPksGoyvLthJE32cHnrVT; path=/; Domain=.contentful.com',
+  'nlbi_673446=y3g9R6z7vQ6DMH+1YMlkBAAAAACo6twvkAHU7e0XxMWCejYB; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=4ULRRte2eXIYLE4EPWpmA/qRBV8AAAAAsGRTSDOAnKlVqbEQT+UMmw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=srllJ/IyxkuN6FsGPWpmAwxFB18AAAAAIXyk5wj7o3eC+mmWR5r5tg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11312,7 +11312,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-38168963-38168981 NNYN CT(89 97 0) RT(1594200569954 39) q(0 0 2 -1) r(4 4) U5'
+  '9-20702034-20702036 NNYY CT(0 0 0) RT(1594311948295 34) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11329,7 +11329,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "03246d2edc5f5aa1974f3bedea65fcab"
+  "requestId": "11db998bd87bab9772ef718e2c0d7a57"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -11342,20 +11342,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:31 GMT',
-  'ETag',
-  '"10441873911343582427"',
+  'Thu, 09 Jul 2020 16:25:49 GMT',
+  'etag',
+  '"12748295005095661981"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11373,15 +11373,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '03246d2edc5f5aa1974f3bedea65fcab',
+  '11db998bd87bab9772ef718e2c0d7a57',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=IFtFxVlcSvi5csOInGc+pfqRBV8AAAAAQUIPAAAAAAAFaMWX41NLt9JFzbGqxrS4; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YOIwEzYgSxO7SXuzBXmfegxFB18AAAAAQUIPAAAAAAAKRMlVbYw82wm3w+6TKuUh; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FEoZGO53kA5BPu7LYMlkBAAAAAAejwrOMvj9O8sCKPUc0xAf; path=/; Domain=.contentful.com',
+  'nlbi_673446=UWpfSGoA/GaSee42YMlkBAAAAACJGUcAbwazgcVxy3sCLIlt; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=QYj3NXthTxpzLE4EPWpmA/qRBV8AAAAAFA4Lp3pyjlyi3+7OKOeAPA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=QP62JAGzTi3g6FsGPWpmAwxFB18AAAAAKYoRd2jTrVXNPz06Dpnbqg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11389,7 +11389,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-49191137-49191150 NNYY CT(0 0 0) RT(1594200570629 36) q(0 0 0 -1) r(1 1) U5'
+  '7-27376931-27376936 NNYY CT(0 0 0) RT(1594311948600 29) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11430,8 +11430,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -11461,9 +11461,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:31 GMT',
+  'Thu, 09 Jul 2020 16:25:49 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -11483,7 +11483,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '27e6b880faed11d86502fc762fce7d9a',
+  'b8c6e52183eb166811925687f293657e',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -11495,11 +11495,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=/m2biMhlRBmQJCj8ulv8NfuRBV8AAAAAQUIPAAAAAAC0JiU/3CsIgd71rDTIyDIe; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=CZKoaI4/QpC0NuYsNkjLPQ1FB18AAAAAQUIPAAAAAAAA5+bdC4hjqNTo73Nk81c4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Ege3f99Ym3FRkZwCYMlkBAAAAABpFH+ooSFwqApCZPQ5CEpQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=4SdlWySBeCquPSh7YMlkBAAAAAAjPohrRVKjBL89YhISbFTU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=o98dGfGJ7lHaLE4EPWpmA/uRBV8AAAAAcdLcRY2Ej2KWaYqkYP+4Vg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=l7kaHz/CvAFI6VsGPWpmAw1FB18AAAAA2v1kEzQIbyeC/2aFuCQueg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11507,12 +11507,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-38169262-38169266 NNYN CT(90 94 0) RT(1594200570941 41) q(0 0 2 -1) r(3 3) U5'
+  '13-66932423-66932430 NNYN CT(94 108 0) RT(1594311948907 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/customSidebar', {"name":"Custom sidebar","fields":[],"description":"How to add, remove and update widgets"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-08T09:29:32.268Z","updatedAt":"2020-07-08T09:29:32.268Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-09T16:25:50.343Z","updatedAt":"2020-07-09T16:25:50.343Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -11523,20 +11523,20 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:32 GMT',
-  'ETag',
-  '"9575472236522722500"',
+  'Thu, 09 Jul 2020 16:25:50 GMT',
+  'etag',
+  '"16071230911097891680"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11554,21 +11554,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '7408e2dd0c9a850e1cebb744b920b998',
+  '824d39188323cd87b2087374e841fb9b',
   'Content-Length',
   '882',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=50ZE6yrgSS2qufczlI++mPuRBV8AAAAAQUIPAAAAAAB70RKaL58p6JMK4uDX/E7+; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=NfstNlktTgWNMi0jbhjODw1FB18AAAAAQUIPAAAAAABVBOvvLuiJC3nqmQN8sFzH; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XiQcSwM5vXWljpreYMlkBAAAAADMBOmIoZQl/JY637p/T+Hp; path=/; Domain=.contentful.com',
+  'nlbi_673446=bmt/QZChfj17h5RQYMlkBAAAAADJsF2ACwEXloXxNnaypQbT; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=pt8sVLSCKRJ9LU4EPWpmA/uRBV8AAAAANCne4vm1h1wErDfTMmV0Gw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=46vmcrJCgzv16VsGPWpmAw1FB18AAAAAzwMpiNWGQ6qty8cTAJ81QA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15112393-15112401 NNNY CT(0 0 0) RT(1594200571453 31) q(0 0 0 -1) r(4 4) U5'
+  '12-55402552-55402566 NNNN CT(85 86 0) RT(1594311949418 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11584,8 +11584,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "customSidebar",
     "type": "ContentType",
-    "createdAt": "2020-07-08T09:29:32.268Z",
-    "updatedAt": "2020-07-08T09:29:32.638Z",
+    "createdAt": "2020-07-09T16:25:50.343Z",
+    "updatedAt": "2020-07-09T16:25:50.795Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -11609,8 +11609,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-08T09:29:32.638Z",
-    "publishedAt": "2020-07-08T09:29:32.638Z",
+    "firstPublishedAt": "2020-07-09T16:25:50.795Z",
+    "publishedAt": "2020-07-09T16:25:50.795Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -11636,11 +11636,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -11649,9 +11649,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:32 GMT',
-  'ETag',
-  'W/"12169768649734047588"',
+  'Thu, 09 Jul 2020 16:25:50 GMT',
+  'etag',
+  'W/"15928841085311407481"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11669,21 +11669,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '3cc6e72966a002f8898dcc6dc6843418',
+  'a82ba50348a7df62c941bafde52a3c19',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vU80JZh8Q9Ca5qhAm3yrdvyRBV8AAAAAQUIPAAAAAABH8Rzz+pUmQ6nps8WUdGUC; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=UPlP9SQbQcypBUef7mhpKA5FB18AAAAAQUIPAAAAAADovHmzgJTeAMYDUlhQDB7J; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=fzu5U3HdbBlGabDeYMlkBAAAAABek9qAtzUXgbapKC1lprR5; path=/; Domain=.contentful.com',
+  'nlbi_673446=CAavesWlGEwSU70EYMlkBAAAAACv7C0CEWhGYG0VAMAjoFBj; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=JC0iH/719h3pLU4EPWpmA/yRBV8AAAAACiV0ErzZ6y0TOv7b/Z6/0g==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=yoXNWfYz2jxj6lsGPWpmAw5FB18AAAAA3HiJGDtW1WSX3PdxI9Gg5Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49191529-49191552 NNNY CT(0 0 0) RT(1594200571887 58) q(0 0 0 -1) r(3 3) U5'
+  '14-86060439-86060448 NNNY CT(0 0 0) RT(1594311950028 31) q(0 0 0 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11724,7 +11724,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-08T09:29:32.716Z",
+    "createdAt": "2020-07-09T16:25:50.869Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11732,7 +11732,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:33.194Z",
+    "updatedAt": "2020-07-09T16:25:51.346Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11767,11 +11767,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -11780,9 +11780,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:33 GMT',
-  'ETag',
-  'W/"13333534100293685761"',
+  'Thu, 09 Jul 2020 16:25:51 GMT',
+  'etag',
+  'W/"3520669431517539200"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11800,21 +11800,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '40c5f558e5b7329c80988de2208b5328',
+  '15fd7617ebb27799e8534b5233758765',
   'Content-Length',
   '461',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=qT6b04LOQ9yYe/6UdArqZ/yRBV8AAAAAQUIPAAAAAACwol5yiStdSumokwmDdUpK; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rUoB4YUyR96Kxsd7gxz4ZA5FB18AAAAAQUIPAAAAAAAQ5kI1y6fZ2WXCbxLNoWib; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TldONgdYIhbWLTnOYMlkBAAAAACGz+2C0GNmB0FLzKJ5w31+; path=/; Domain=.contentful.com',
+  'nlbi_673446=DUcuXgHzWWc6vM4pYMlkBAAAAADEKJkp9024um8cYK68YR02; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=SLouDmf2BD9fLk4EPWpmA/yRBV8AAAAA9RNjximSslqYxvURkuB9SA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=Wm5CJ/69NhrG6lsGPWpmAw5FB18AAAAA4bzo4aMrrCtWKjcoE7J0KA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49191654-49191663 NNNN CT(88 87 0) RT(1594200572263 28) q(0 0 2 -1) r(4 4) U5'
+  '11-41054200-41054202 NNNN CT(88 95 0) RT(1594311950438 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11855,7 +11855,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 3,
-    "createdAt": "2020-07-08T09:29:32.716Z",
+    "createdAt": "2020-07-09T16:25:50.869Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11863,7 +11863,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:33.703Z",
+    "updatedAt": "2020-07-09T16:25:51.683Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11898,11 +11898,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -11911,9 +11911,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:33 GMT',
-  'ETag',
-  'W/"13560564731360435247"',
+  'Thu, 09 Jul 2020 16:25:51 GMT',
+  'etag',
+  'W/"17904900338714515033"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11931,21 +11931,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '2a560dddc4f3bf7a912ba4d9cf290302',
-  'Content-Length',
-  '461',
+  'c74c500ca22b2b01007c8a92b6ec907e',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=birc4LYmQZmiWQ0CYGziA/2RBV8AAAAAQUIPAAAAAABSQ1QFmPLXJkpEj3JH/fO4; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=uTZ6+qE0ThWFVBfCEYvGeA9FB18AAAAAQUIPAAAAAACg5paf5/k+6hZGfmhKlnUW; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=CKLuJG1bcH3t+vK8YMlkBAAAAACGxpf8pSne4hk6n2takzoM; path=/; Domain=.contentful.com',
+  'nlbi_673446=TqU7KygdZHJJlsFaYMlkBAAAAADE4dLyBLc4jh5SHDI0paof; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=1GfLEObuy2ziLk4EPWpmA/2RBV8AAAAArzCRDzgcjNhTUuGCBVWLMw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=kbVpJ/qiPDAs61sGPWpmAw9FB18AAAAAuW1OvitVpBWrPVTc4ItNyw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-16021288-16021289 NNNY CT(0 0 0) RT(1594200572895 28) q(0 0 0 -1) r(2 2) U5'
+  '13-66932884-66932892 NNNY CT(0 0 0) RT(1594311950962 34) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11986,7 +11986,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-08T09:29:32.716Z",
+    "createdAt": "2020-07-09T16:25:50.869Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11994,7 +11994,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:34.046Z",
+    "updatedAt": "2020-07-09T16:25:52.201Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12029,11 +12029,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12042,9 +12042,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:34 GMT',
-  'ETag',
-  'W/"15762925112122620964"',
+  'Thu, 09 Jul 2020 16:25:52 GMT',
+  'etag',
+  'W/"8991075568487977346"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12054,29 +12054,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  '5cce0faae568f7bc1e879b9cd6dd3c4a',
-  'Content-Length',
-  '460',
+  'b2014fc79500d0fed8584337e20c2063',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nWgqX2hBQ6+AFpJbnwr4Wf2RBV8AAAAAQUIPAAAAAAA8QloSG9COWedFqqJs69O8; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=gAKcwhKtQV+Q+sJ8QllpBw9FB18AAAAAQUIPAAAAAAAyIZMpNWOYwSw9qXbFMseS; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zuM5SZtAJUxt3bMAYMlkBAAAAAAeC/pej3JhxLpJhSjjmXK2; path=/; Domain=.contentful.com',
+  'nlbi_673446=NVIiMUtS1jLpCJPZYMlkBAAAAABC8O7InFpLmXnUjie3/BCf; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=B5U8EoP9AQE6L04EPWpmA/2RBV8AAAAAc9Kr2rtX8qKChRS8HvW71Q==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=FYwyNwLcTWuy61sGPWpmAw9FB18AAAAA2oisIkOcSimcp+NKBeMgYQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31557765-31557769 NNNY CT(0 0 0) RT(1594200573301 34) q(0 0 0 -1) r(2 2) U5'
+  '4-26743437-26743438 NNNY CT(0 0 0) RT(1594311951472 30) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12117,7 +12117,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-08T09:29:32.716Z",
+    "createdAt": "2020-07-09T16:25:50.869Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12125,7 +12125,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:34.656Z",
+    "updatedAt": "2020-07-09T16:25:52.571Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12160,11 +12160,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12173,9 +12173,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:34 GMT',
-  'ETag',
-  'W/"8534115041703044911"',
+  'Thu, 09 Jul 2020 16:25:52 GMT',
+  'etag',
+  'W/"8667122013226520874"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12185,29 +12185,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '294d56f6a3652d7ac18238c3d9911393',
+  'c12d53c54f4e1919ce358d18ac750076',
   'Content-Length',
-  '461',
+  '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=sgxRTAj8Q22oMRpiZqkjJf6RBV8AAAAAQUIPAAAAAAC8c8LnelYmFen8A21gruaD; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=RqhVb9xWRb6zYWKYBT53jxBFB18AAAAAQUIPAAAAAAC0gao9138yaXQv1RGZd3gn; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=nqMNeWtVI1NPLoqOYMlkBAAAAADKpJ0FlNN3rs0Efr58T0q2; path=/; Domain=.contentful.com',
+  'nlbi_673446=nIWFGzihFSmuJCSBYMlkBAAAAABZZW48Se9WG+XJMrcSZb1h; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=l33YAfz810TdL04EPWpmA/6RBV8AAAAAwq9Zf2bDIeOZC7xnxz7rkQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=ELXgGzaATWMQ7FsGPWpmAxBFB18AAAAAlqp4QQl0M+NPhWluRKmd/Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31557844-31557850 NNNN CT(93 94 0) RT(1594200573703 30) q(0 0 2 -1) r(4 4) U5'
+  '13-66933163-66933170 NNNY CT(0 0 0) RT(1594311951776 28) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12242,7 +12242,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-08T09:29:32.716Z",
+    "createdAt": "2020-07-09T16:25:50.869Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12250,7 +12250,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:35.095Z",
+    "updatedAt": "2020-07-09T16:25:52.990Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12285,11 +12285,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12298,9 +12298,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:35 GMT',
-  'ETag',
-  'W/"8244854842825657763"',
+  'Thu, 09 Jul 2020 16:25:53 GMT',
+  'etag',
+  'W/"18044677227004125461"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12310,29 +12310,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '39a0b536638ee3f346901723ec9513a4',
-  'Content-Length',
-  '448',
+  '403f7baf4dc39cd6fb645776de5d10c5',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kAQeDa0oQi6sEklv8RrD/v6RBV8AAAAAQUIPAAAAAADsFTfHd6205A2N2AMejJd+; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=y1Rup8TpScSTEAAE9DpZghBFB18AAAAAQUIPAAAAAADgZy4IQdp6bs9EYzrY4uu0; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=n7/UAHSDmCT6a4eYYMlkBAAAAADjfvaEZf4lUAb+Sr1j5k+5; path=/; Domain=.contentful.com',
+  'nlbi_673446=19wAJoHccCngSMxkYMlkBAAAAADVK7ai9NoqWwnN6QVKAJ53; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=wOSTVTEUCz5LME4EPWpmA/6RBV8AAAAAfqXtu7mOXcqCCtwwhq3T5w==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=M+pdacM9oSSe7FsGPWpmAxBFB18AAAAAuMkFsiNYVSaVl0Bk4PKmzQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-31557978-31557990 NNNY CT(0 0 0) RT(1594200574332 35) q(0 0 0 -1) r(2 2) U5'
+  '6-13875815-13875818 NNNY CT(0 0 0) RT(1594311952280 30) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12349,7 +12349,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-08T09:29:32.716Z",
+    "createdAt": "2020-07-09T16:25:50.869Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12357,7 +12357,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:35.095Z",
+    "updatedAt": "2020-07-09T16:25:52.990Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12410,11 +12410,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12423,9 +12423,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:35 GMT',
-  'ETag',
-  'W/"5973954764533079482"',
+  'Thu, 09 Jul 2020 16:25:54 GMT',
+  'etag',
+  'W/"10874627288313817418"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12443,21 +12443,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '97067b2846fc46b32886be6922e0199a',
-  'transfer-encoding',
-  'chunked',
+  'bb73e94b0739d2e9154d6f905452865b',
+  'Content-Length',
+  '435',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NDRczOCwRGqYUI/KBUZtef6RBV8AAAAAQUIPAAAAAABQbvF7HZGGKvRvfSOHIKxm; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=NYu4KMrlQcmx4BFtyct0ixJFB18AAAAAQUIPAAAAAAApZVPaQP4Q7qIQkDOJX7Zj; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=x0RpetjL+UNXFgPdYMlkBAAAAACREs8SRvZxP+ofT0PzKAT2; path=/; Domain=.contentful.com',
+  'nlbi_673446=1I15QGKIqA7Bqhl5YMlkBAAAAADh127TVeDIuKk3QfYMKj25; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=1LmMQP9PoyueME4EPWpmA/6RBV8AAAAAdGfb/GlD4U/aHO8yLTXa+Q==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=lzeFLBmSe0eB7lsGPWpmAxJFB18AAAAAhJ+vYIY02WfeloELdnKijg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15955412-15955414 NNNY CT(0 0 0) RT(1594200574730 33) q(0 0 0 -1) r(2 2) U5'
+  '4-26743573-26743576 NNNY CT(0 0 0) RT(1594311952600 28) q(0 0 0 -1) r(17 17) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12529,11 +12529,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12542,8 +12542,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:35 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:25:55 GMT',
+  'etag',
   'W/"9102674631899357591"',
   'Server',
   'Contentful',
@@ -12554,29 +12554,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '25695501eaa42c895a20491cd8e22198',
-  'transfer-encoding',
-  'chunked',
+  '988eb93f5a35970b46986cf483e6baa7',
+  'Content-Length',
+  '375',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=HGt8ElaCSzGcBz4yVomNBf+RBV8AAAAAQUIPAAAAAACPbqYQLsdZ1Pf/OofG0SXG; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=q9XOBYCXRXOb8DoZKFw0oxJFB18AAAAAQUIPAAAAAAA2MQ2bWogz+1gA3bV26Tpr; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zLRZJE6T7XPDTHYUYMlkBAAAAAAJQgnwm4yaK6aFmDYhlRYs; path=/; Domain=.contentful.com',
+  'nlbi_673446=28e5eVZr6QqKbVHWYMlkBAAAAACFfpQpjPWQVwjA9klNeTIQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=tEt+HrxBpgwMMU4EPWpmA/+RBV8AAAAAm7LYgIl8sNTVa3lCBgPxsg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=Lb5hVnfWznbD7lsGPWpmAxJFB18AAAAALg/iT5b2sRfd/781tQZXCQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38170459-38170467 NNNY CT(0 0 0) RT(1594200575039 32) q(0 0 0 -1) r(2 2) U5'
+  '5-42743642-42743652 NNNY CT(0 0 0) RT(1594311954439 38) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12617,8 +12617,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -12648,9 +12648,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:36 GMT',
+  'Thu, 09 Jul 2020 16:25:55 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -12662,15 +12662,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '77237314de662140edccc5daca98ba8f',
+  '37ee1db700f8d9edc76e30c4189b6964',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -12682,11 +12682,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=XxuUCy6DS9y45ui7UX3HiP+RBV8AAAAAQUIPAAAAAACo48nhx61p0JyCF9Gf9HbC; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=d0oOfp0USdqs+ywkAznTKxJFB18AAAAAQUIPAAAAAACjCkUxD4r+3dbPXgrakN9y; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=vlAMZoEGrDhU40nzYMlkBAAAAACBcO7zIf7l3y5vfdO56dBQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=QYV2NwauV1Q4z9U2YMlkBAAAAAAMXK1C9/RMRmaFvpbtv+bt; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=3/fVM0eVsQByMU4EPWpmA/+RBV8AAAAARjJW1XtiYLrR/OuhLhy2dA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=EerPeUT1ykb07lsGPWpmAxJFB18AAAAAX+crnyYHowQFbRpr7riB9w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -12694,7 +12694,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-15112986-15112989 NNYY CT(0 0 0) RT(1594200575545 35) q(0 0 0 -1) r(1 1) U5'
+  '11-41054766-41054773 NNYY CT(0 0 0) RT(1594311954738 29) q(0 0 0 -1) r(1 1) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12754,7 +12754,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:36.809Z",
+    "updatedAt": "2020-07-09T16:25:55.871Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12789,11 +12789,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12802,9 +12802,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:36 GMT',
-  'ETag',
-  'W/"16179174573381818363"',
+  'Thu, 09 Jul 2020 16:25:55 GMT',
+  'etag',
+  'W/"12171348567539028359"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12814,29 +12814,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '800d960b0074699010ec003268d47591',
-  'Content-Length',
-  '542',
+  '47bc0925fe7af7f49d0d73766522998b',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4EgC6JDgRPWTUGFGdjC66ACSBV8AAAAAQUIPAAAAAAAKRdeDNsl8vX6/eL1rvGNH; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3n1xJDmiSiGlBZWncsOtHhNFB18AAAAAQUIPAAAAAADOkaCJDPQWSFYCiyl/zZHz; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RB03R04uK2JmJXhWYMlkBAAAAABhLyTBnpjeSbUmYRc5Zscl; path=/; Domain=.contentful.com',
+  'nlbi_673446=MFK/RThSTBFCWBq8YMlkBAAAAAD/EEKzn9BqtSU+eKIB7Xuw; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=MQ9QRTVrtAgVMk4EPWpmAwCSBV8AAAAAajQIEEINUK2Kc794ec8dcw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=0qd3Xh9Qyk1571sGPWpmAxNFB18AAAAAjo9bM0v0xPNl5gM4dtpUxw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-15113023-15113032 NNNN CT(93 93 0) RT(1594200575753 39) q(0 0 2 -1) r(5 5) U5'
+  '14-86061911-86061925 NNNY CT(0 0 0) RT(1594311955148 39) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12896,7 +12896,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:38.110Z",
+    "updatedAt": "2020-07-09T16:25:56.315Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12931,11 +12931,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -12944,9 +12944,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:38 GMT',
-  'ETag',
-  'W/"17004450656447411572"',
+  'Thu, 09 Jul 2020 16:25:56 GMT',
+  'etag',
+  'W/"8087280609649312617"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12964,21 +12964,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '3f63b2c0bea051a5e7dfdee4a754b8f9',
-  'transfer-encoding',
-  'chunked',
+  'f63615b3f6bbab0298877310e342b378',
+  'Content-Length',
+  '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nqVNgCIFScaFu7U0+qtUuAGSBV8AAAAAQUIPAAAAAADKRC2Pbv6YsPaJBUemiq44; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=DFKc6/DdSOudJnlTzRIw8RNFB18AAAAAQUIPAAAAAAA+289jRivEiysXH765RnPM; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AuLEKv4MLWLBmsOtYMlkBAAAAAD6cyQ75PR2enoFFqa/Mthi; path=/; Domain=.contentful.com',
+  'nlbi_673446=C/fYEaxk8hOr65sVYMlkBAAAAAAsJzGfVeuQlXa8tsPn8//a; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=cD8qQD6lAgR7M04EPWpmAwGSBV8AAAAAOFlMlfyC5/1UA6EQOsIrOg==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=67bgXTvW+BLd71sGPWpmAxNFB18AAAAAPNEHtag87OaIivefTYH2pA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-49193372-49193382 NNNY CT(0 0 0) RT(1594200577323 33) q(0 0 0 -1) r(2 2) U5'
+  '10-27145819-27145822 NNNN CT(88 88 0) RT(1594311955418 31) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13038,7 +13038,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:38.525Z",
+    "updatedAt": "2020-07-09T16:25:59.137Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13073,11 +13073,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -13086,9 +13086,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:38 GMT',
-  'ETag',
-  'W/"5943141905108528965"',
+  'Thu, 09 Jul 2020 16:25:59 GMT',
+  'etag',
+  'W/"11334213927273169520"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13106,21 +13106,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a670162aee57750097fb73f9f0553f6f',
+  'c460325ba19e70ec0bb4075f87f16aeb',
   'Content-Length',
-  '542',
+  '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=7EBli2ILSPa5yaDrQOtDeQKSBV8AAAAAQUIPAAAAAADYNmVNJodup8zNzTFDMj0X; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=8QV8enFHSEOJBxEFOG3EpxZFB18AAAAAQUIPAAAAAAAEKclum9lsZl1zwI52fv+M; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XMT6ZcILrEVg7ZWeYMlkBAAAAACEemZ7pBTj7pnwg4MkMVNV; path=/; Domain=.contentful.com',
+  'nlbi_673446=SSgRX2QM5DSCSWnFYMlkBAAAAAC9GS4R2fHLY/qWyN8oUbLF; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=ppS3RUz2BBnZM04EPWpmAwKSBV8AAAAAFGenMNvSYkSqqNDms6bbxw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=8S7wUqeI03yW8lsGPWpmAxZFB18AAAAA7SQypoWRMk/JXe7pSA9SUw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38171327-38171334 NNNY CT(0 0 0) RT(1594200577713 30) q(0 0 0 -1) r(3 3) U5'
+  '9-20702526-20702529 NNNY CT(0 0 0) RT(1594311958418 27) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13180,7 +13180,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:39.193Z",
+    "updatedAt": "2020-07-09T16:25:59.578Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13215,11 +13215,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -13228,9 +13228,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:39 GMT',
-  'ETag',
-  'W/"10657304615781701896"',
+  'Thu, 09 Jul 2020 16:25:59 GMT',
+  'etag',
+  'W/"2400676016350313103"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13240,29 +13240,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'b332dd03bf81d38681514e08569f6c73',
-  'Content-Length',
-  '540',
+  'e6c298cabe3867ecccfb20f24f2e8126',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=0zRWSbVIT9OUyIXqPG0gtgKSBV8AAAAAQUIPAAAAAADk6/pzKtCnK0lGLM165vO3; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=dAuN0g7RS5aIdOtn9RTYVRdFB18AAAAAQUIPAAAAAACWN1kFTPQAyOaHZQgn75FY; expires=Fri, 09 Jul 2021 11:06:43 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=dwkCS991nCfJbZa2YMlkBAAAAABnM427it63W2QonIF/GkmZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=zANXfae1wh9+lKylYMlkBAAAAAC5Z0HSzU6MwTennjeE4LGh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=PJSKK+r8W16VNE4EPWpmAwKSBV8AAAAA3jKeSJ0zs+ZMSENVyTbaQw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=+Sm2ILsF+wMN81sGPWpmAxdFB18AAAAA01JG/EasW+5TQJru6wxypA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-8165956-8165958 NNNN CT(88 89 0) RT(1594200578203 36) q(0 0 2 -1) r(4 4) U5'
+  '4-26744199-26744205 NNNY CT(0 0 0) RT(1594311958854 29) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13316,7 +13316,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:39.611Z",
+    "updatedAt": "2020-07-09T16:25:59.947Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13351,11 +13351,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -13364,9 +13364,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:39 GMT',
-  'ETag',
-  'W/"15000591828655616771"',
+  'Thu, 09 Jul 2020 16:25:59 GMT',
+  'etag',
+  'W/"4114434414238587969"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13376,29 +13376,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35997',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '7',
   'X-Contentful-Request-Id',
-  '69f95e4d7c8cb0ff6c2b8eb2181d9ec3',
-  'transfer-encoding',
-  'chunked',
+  '706d303d82738b781e1e386597ca2e95',
+  'Content-Length',
+  '524',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3NdPudzNSkG9Dsvk2D/XOgOSBV8AAAAAQUIPAAAAAACgDkLKZjUiH6DewxrWWiiX; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=nGbLUHTNT9uQbBigqkAEYxdFB18AAAAAQUIPAAAAAAB/BxcqeB5l78L7QH9xt/e6; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=l6LudIsraQs6BeoeYMlkBAAAAAA0gCaaQFdZqG31fKQxIyZN; path=/; Domain=.contentful.com',
+  'nlbi_673446=LWnfHTMgbV94MlEeYMlkBAAAAAB1l4y9m0jfAMzLb2CFG6MW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=Vu4WQpBcUAb7NE4EPWpmAwOSBV8AAAAAqSNAWsI4RbnGt3s0f9yuJA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=dVXbPs5mTlVS81sGPWpmAxdFB18AAAAAzShExcdlb/BP5ePLRQkhbQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15955785-15955788 NNNY CT(0 0 0) RT(1594200578819 36) q(0 0 0 -1) r(2 2) U5'
+  '13-66934914-66934921 NNNY CT(0 0 0) RT(1594311959224 33) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13423,7 +13423,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-08T09:29:39.611Z",
+    "updatedAt": "2020-07-09T16:25:59.947Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -13487,11 +13487,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   
   
@@ -13500,9 +13500,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:39 GMT',
-  'ETag',
-  'W/"5699774397590529919"',
+  'Thu, 09 Jul 2020 16:26:00 GMT',
+  'etag',
+  'W/"10418961072770146335"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13512,29 +13512,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '9',
   'X-Contentful-Request-Id',
-  'de8d4188d2c04647b172e5edb218b00b',
+  '849a870d4b3bfed5360134f1829837a8',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=iPumb4RwSnS5V4lxXL3AcQOSBV8AAAAAQUIPAAAAAAC4DM5UaBFBowDW1DmKtYp3; expires=Wed, 07 Jul 2021 11:06:41 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3GZws7RvRu+8yI1G1LfAVRdFB18AAAAAQUIPAAAAAAAYt/unTVNvk/gMxl/asMUo; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=G7kxUKwMugFDd7pzYMlkBAAAAAA5XbARpBXRVkJ0fK13iI8o; path=/; Domain=.contentful.com',
+  'nlbi_673446=IXZDGKzlr1W0Zc5QYMlkBAAAAAA1nNsNQiDKaUldZHIBWczT; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=vOjbO2cHkEk4NU4EPWpmAwOSBV8AAAAAsOiU07KIX5bRHJcdVgEvaQ==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=3NM+eqcaTAfO81sGPWpmAxdFB18AAAAAuBzkStpT8ZtoJfVA4JT+Bw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15955816-15955822 NNNY CT(0 0 0) RT(1594200579232 34) q(0 0 0 -1) r(2 2) U5'
+  '14-86063284-86063296 NNNN CT(93 93 0) RT(1594311959494 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13558,19 +13558,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
-  'CF-Space-Id',
+  'cf-space-id',
   'bohepdihyxin',
   'Content-Type',
   'application/vnd.contentful.management.v1+json',
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:40 GMT',
-  'ETag',
+  'Thu, 09 Jul 2020 16:26:00 GMT',
+  'etag',
   '"9177491833369070274"',
   'Server',
   'Contentful',
@@ -13581,23 +13581,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '4e0104191a38ad3337545e3970dccbe0',
+  'a9d1d1eab17024a094093b94e220dfba',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=9i94tpfbSlK246RhV75ICgOSBV8AAAAAQUIPAAAAAAAgmMo6JhtxQNRz2EGBMY3r; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kEwXzO48TbybEN4vRte05BhFB18AAAAAQUIPAAAAAAB6qhCzOKmZ8xyXLijKstY4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TlvnSG9lD04EXl/LYMlkBAAAAAC31q/foMpjeqPJvsDXe1Qe; path=/; Domain=.contentful.com',
+  'nlbi_673446=bUFBKs90yX/niCAOYMlkBAAAAABa1NnESqDHeJKfsrBcfiKq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=7uJzJNstOX2RNU4EPWpmAwOSBV8AAAAAVtgOOUlPEKRuX3ny8EJ99Q==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=h9srJCp+Wgsl9FsGPWpmAxhFB18AAAAAZDHtHtwtlFkltPMHKhRKmA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13605,7 +13605,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-15113506-15113512 NNYY CT(0 0 0) RT(1594200579541 31) q(0 0 0 -1) r(2 2) U5'
+  '14-86063493-86063502 NNYY CT(0 0 0) RT(1594311960066 32) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13646,8 +13646,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-08T09:28:33Z",
-        "updatedAt":"2020-07-08T09:28:33Z"
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
       }
     }
   ]
@@ -13677,82 +13677,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:40 GMT',
+  'Thu, 09 Jul 2020 16:26:00 GMT',
   'ETag',
-  'W/"855f501d2c1eb3ce053b957368a0c380"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '8',
-  'X-Contentful-Request-Id',
-  'de1285d5dab2fdd04bdb5b952e417d1f',
-  'X-Download-Options',
-  'noopen',
-  'X-Frame-Options',
-  'ALLOWALL',
-  'X-Permitted-Cross-Domain-Policies',
-  'none',
-  'X-XSS-Protection',
-  '1; mode=block',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=iHzwsSRgRF6j48l/5OHRqAOSBV8AAAAAQUIPAAAAAABkUx/CMu90RxvAGUSFvE57; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=RfZxRphT6DBiyN9kYMlkBAAAAAA0EE+YaktEQddTb05XHaNy; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_245_673446=QNYcBgFQL3DRNU4EPWpmAwOSBV8AAAAA/pANabOfRRzwr/CPxPoy8w==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
-  'X-Iinfo',
-  '9-11768014-11768017 NNYY CT(0 0 0) RT(1594200579849 27) q(0 0 0 -1) r(1 1) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":0},"name":"marketing"})
-  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-08T09:29:40.920Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-08T09:29:40.920Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'CF-Environment-Id',
-  'env-integration',
-  'CF-Environment-Uuid',
-  'env-integration',
-  'CF-Space-Id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 08 Jul 2020 09:29:41 GMT',
-  'ETag',
-  '"10275718093581198956"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13770,21 +13699,92 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '7',
   'X-Contentful-Request-Id',
-  'a70304cb80b73353dd65159f9d8a7641',
+  '50b995a713e0be601930a8bb72137599',
+  'X-Download-Options',
+  'noopen',
+  'X-Frame-Options',
+  'ALLOWALL',
+  'X-Permitted-Cross-Domain-Policies',
+  'none',
+  'X-XSS-Protection',
+  '1; mode=block',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=xo+8pvqsQaKqtPYe8t605xhFB18AAAAAQUIPAAAAAAAz68PN9uMtrJ3e53tVpI//; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=4siwPCGKKlfww5D2YMlkBAAAAACqA5ouwDqKKOd8sop5LbDq; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=s2YGK/gYTlhp9FsGPWpmAxhFB18AAAAAiOcOm5DY6dHooQ2kNXQcrw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '12-55404539-55404548 NNYY CT(0 0 0) RT(1594311960310 35) q(0 0 0 -1) r(1 1) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":0},"name":"marketing"})
+  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-09T16:26:01.234Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-09T16:26:01.234Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:26:01 GMT',
+  'etag',
+  '"13236965944598722177"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'f11f4848e50730ae907423f1f41faa33',
   'Content-Length',
   '740',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kExPVzuFQQyOEAByPvKhywSSBV8AAAAAQUIPAAAAAAAbqodzZ1gOx1LNfOyh6qtB; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Jn1sirpaQWabO+EVK3XOFhhFB18AAAAAQUIPAAAAAABI4CGAnNAIxB6tqUw4gu57; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=yqueGuuxR2NQs2ISYMlkBAAAAADQctULU43GPy1CtZ/nVIko; path=/; Domain=.contentful.com',
+  'nlbi_673446=jW5McE74R1yI0ePxYMlkBAAAAACIhlLkzm1x6V72MvNzTsey; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=XQimG0DmKTFVNk4EPWpmAwSSBV8AAAAAf/0ggvDPIvZSN/R2zxWSLw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=gS2Bfgz4QF6u9FsGPWpmAxhFB18AAAAAMotTYF43iL3IJVoAJzI+ng==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38171900-38171912 NNNY CT(0 0 0) RT(1594200580043 31) q(0 0 0 -1) r(5 5) U5'
+  '11-41055457-41055459 NNNY CT(0 0 0) RT(1594311960516 28) q(0 0 0 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13821,8 +13821,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-08T09:29:40.920Z",
-    "updatedAt": "2020-07-08T09:29:40.920Z",
+    "createdAt": "2020-07-09T16:26:01.234Z",
+    "updatedAt": "2020-07-09T16:26:01.234Z",
     "version": 1
   },
   "name": "marketing"
@@ -13838,10 +13838,228 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Etag',
   'Access-Control-Max-Age',
   '1728000',
-  'CF-Environment-Id',
+  'cf-environment-id',
   'env-integration',
-  'CF-Environment-Uuid',
+  'cf-environment-uuid',
   'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:26:01 GMT',
+  'etag',
+  '"9835733008416165370"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  'ea927dd8db75bbd267fd616238879e6c',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=G8v+TOQuQWi/eYhqFRiTyxlFB18AAAAAQUIPAAAAAAD4afRQKRpOo9oDfXDwYu0y; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=Tsr4AcPFNX9QjWQ5YMlkBAAAAACgNnj2utU99hwWP1SimsT5; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=jdTwIyfBhA8h9VsGPWpmAxlFB18AAAAAxq6udxgKp8hh+YLspNWlDg==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '13-66935267-66935275 NNYN CT(85 86 0) RT(1594311960892 30) q(0 0 1 -1) r(3 3) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/tags')
+  .query({"limit":"100","order":"sys.createdAt","skip":"0"})
+  .reply(200, {
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "items": [
+    {
+      "sys": {
+        "type": "Tag",
+        "id": "sampletag",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "bohepdihyxin"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "env-integration",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+          }
+        },
+        "createdAt": "2020-07-09T16:26:01.234Z",
+        "updatedAt": "2020-07-09T16:26:01.234Z",
+        "version": 1
+      },
+      "name": "marketing"
+    }
+  ]
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:26:02 GMT',
+  'etag',
+  '"1064381601898507789"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35997',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '7',
+  'X-Contentful-Request-Id',
+  '7d356ef7bfb49b2c86302a30185acb4c',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=ZLfz7tEFR/KWuFXgKrfUYRlFB18AAAAAQUIPAAAAAAB5mPm7rvP5qb/NZPKvfe/Y; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=MQb9OegQqDubCSbQYMlkBAAAAAA72l4lXP4m+TwxoG+1rKZj; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=UAwoL0IqOVKB9VsGPWpmAxlFB18AAAAAafhAG5wOhp8x7ohYbGDHvA==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '13-66935366-66935370 NNYY CT(0 0 0) RT(1594311961322 28) q(0 0 0 -1) r(1 1) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/locales')
+  .query({"limit":"100","order":"sys.createdAt","skip":"0"})
+  .reply(200, {
+  "total":1,
+  "limit":100,
+  "skip":0,
+  "sys":{
+    "type":"Array"
+  },
+  "items":[
+    {
+      "name":"U.S. English",
+      "internal_code":"en-US",
+      "code":"en-US",
+      "fallbackCode":null,
+      "default":true,
+      "contentManagementApi":true,
+      "contentDeliveryApi":true,
+      "optional":false,
+      "sys":{
+        "type":"Locale",
+        "id":"0zK7OynpqVdcSetOBfe5P8",
+        "version":1,
+        "space":{
+          "sys":{
+            "type":"Link",
+            "linkType":"Space",
+            "id":"bohepdihyxin"
+          }
+        },
+        "environment":{
+          "sys":{
+            "type":"Link",
+            "linkType":"Environment",
+            "id":"env-integration"
+          }
+        },
+        "createdAt":"2020-07-09T16:25:00Z",
+        "updatedAt":"2020-07-09T16:25:00Z"
+      }
+    }
+  ]
+}
+
+, [
+  'Accept-Ranges',
+  'bytes',
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'Cache-Control',
+  'max-age=0',
+  'CF-Organization-Id',
+  '3ubGFD1MWA6VgVYbIwSBg8',
   'CF-Space-Id',
   'bohepdihyxin',
   'Content-Type',
@@ -13849,9 +14067,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:41 GMT',
+  'Thu, 09 Jul 2020 16:26:02 GMT',
   'ETag',
-  '"245938797627537510"',
+  'W/"9db5145faafd31cb9e80b0cd866c7368"',
+  'Referrer-Policy',
+  'strict-origin-when-cross-origin',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13869,15 +14089,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '058ade4d85c2667f9fef1a076e54a729',
+  '8015aacb681b75bca4556fa8515fff47',
+  'X-Download-Options',
+  'noopen',
+  'X-Frame-Options',
+  'ALLOWALL',
+  'X-Permitted-Cross-Domain-Policies',
+  'none',
+  'X-XSS-Protection',
+  '1; mode=block',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=a4kgf3iWROqcDkxIwD3T3wSSBV8AAAAAQUIPAAAAAAC0Salxw5d7P+GnFkh4KTBd; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=dcB4fTPlR/W6C69rfSl+qRlFB18AAAAAQUIPAAAAAAAF72pMwk2H4i3PiqY0PP0U; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=5byqFubqzxRjMtv2YMlkBAAAAACQicY+zNIaZk4TXMx2qddw; path=/; Domain=.contentful.com',
+  'nlbi_673446=rIxHP06lLGw7Z4l3YMlkBAAAAAD7jTL1rJG+VF15qVPsyjeM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=NyCEWnT7I02VNk4EPWpmAwSSBV8AAAAABV/eVTAMhbccHwXBuf3UiA==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=qrFPa1WT0yjM9VsGPWpmAxlFB18AAAAAGcWlNEMXNJNCNKEFJrsMaw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13885,7 +14113,169 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '6-8166163-8166173 NNYY CT(0 0 0) RT(1594200580669 32) q(0 0 0 -1) r(2 2) U5'
+  '14-86063959-86063969 NNYY CT(0 0 0) RT(1594311961616 34) q(0 0 0 -1) r(1 1) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":1},"name":"better marketing"})
+  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-09T16:26:01.234Z","updatedAt":"2020-07-09T16:26:02.848Z","version":2},"name":"better marketing"}, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:26:02 GMT',
+  'etag',
+  '"12844811058257837964"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  '2a56ad100e19b9fb2bb444f994704c04',
+  'Content-Length',
+  '747',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=Q29s/RzDQVekZeGxzM7/vxpFB18AAAAAQUIPAAAAAAA8ML+eYPkzY6DPIQbf1vTU; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=3V9zW9zL6X8WsGZhYMlkBAAAAADCoI61eQTOdOpWOx9DHReu; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=PGd/ClSvdA9r9lsGPWpmAxpFB18AAAAA/B/7EMcTmHPJepxLP3O+JA==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '10-27146213-27146216 NNNN CT(93 94 0) RT(1594311961820 32) q(0 0 2 -1) r(6 6) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .get('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag')
+  .reply(200, {
+  "sys": {
+    "type": "Tag",
+    "id": "sampletag",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "createdAt": "2020-07-09T16:26:01.234Z",
+    "updatedAt": "2020-07-09T16:26:02.848Z",
+    "version": 2
+  },
+  "name": "better marketing"
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Thu, 09 Jul 2020 16:26:03 GMT',
+  'etag',
+  '"12844811058257837964"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '23e6a105f06cf5d9f87dfe583a0525c3',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=pMD1cw0rSg+D0AMWlxNOZRtFB18AAAAAQUIPAAAAAACS/NyKx7kj2SbY8yel1Fu4; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=GrJ3RCLB0i7zE8TgYMlkBAAAAADk3rt6axKoyYeMC7nix1Sw; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_245_673446=bDHkLXh9dHQV91sGPWpmAxtFB18AAAAAtCpqx7BUe90s6pP9CUljJw==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '2-9266366-9266369 NNYN CT(86 86 0) RT(1594311962720 29) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13910,7 +14300,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 08 Jul 2020 09:29:42 GMT',
+  'Thu, 09 Jul 2020 16:26:04 GMT',
   'Referrer-Policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -13930,7 +14320,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '547ffa5ed871ab730e4cb789d88ec8e3',
+  '574a04ae36776afe066c7eb1efbd32a9',
   'X-Download-Options',
   'noopen',
   'X-Frame-Options',
@@ -13942,13 +14332,13 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=dc0l3G/KTvqQI2Ar+cpepQaSBV8AAAAAQUIPAAAAAADTu80YEn+QKU26TJKvjlHl; expires=Wed, 07 Jul 2021 11:06:42 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/Z/BUdQKS2ucYHpTmqA5zxxFB18AAAAAQUIPAAAAAAAI15Fi3zqWpXJB7P4pjJvr; expires=Fri, 09 Jul 2021 11:06:44 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=YfJhRHDpZSSt4kBuYMlkBAAAAAAkdLgSjXD+amJP/XhBdVhG; path=/; Domain=.contentful.com',
+  'nlbi_673446=SY/FA3/FZH22p09PYMlkBAAAAADF08YRZGivl4IrOyPcasCd; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_245_673446=7wWOaOrxQG7KN04EPWpmAwaSBV8AAAAAdipWsICcSp8hJwKWugdNjw==; path=/; Domain=.contentful.com',
+  'incap_ses_245_673446=fhKRO1hKiGEO+FsGPWpmAxxFB18AAAAAEZ6eb9ttartvTwZILJYPAw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-38172147-38172155 NNNY CT(0 0 0) RT(1594200581079 32) q(0 0 0 -1) r(11 11) U5'
+  '12-55405065-55405069 NNNY CT(0 0 0) RT(1594311963142 31) q(0 0 0 -1) r(9 9) U5'
 ]);

--- a/test/fixtures/contentful-migration-integration.js
+++ b/test/fixtures/contentful-migration-integration.js
@@ -58,7 +58,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:27 GMT',
+  'Wed, 15 Jul 2020 13:01:39 GMT',
   'etag',
   'W/"9f8886bb475af980f12a1a32fbc74d55"',
   'referrer-policy',
@@ -80,7 +80,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '9057a4e24052f7c3f48338535c7c2127',
+  'f463b858894bc5c525d70b11b13fc1fb',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -92,11 +92,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=OtjZD+wfQNC+wQaNbQQIFj/mDl8AAAAAQUIPAAAAAAALda/NuDQPd3SPub1Ff9rZ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=XoZ8nheaQ1azEuZ4+NUa/zL+Dl8AAAAAQUIPAAAAAABtyUGHKa7kraVai4e3slVn; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Pc1ZQsDu9DLwr0RLKsJtVwAAAAAkiHAGCrbGQuepjm2WWS5J; path=/; Domain=.contentful.com',
+  'nlbi_673446=GF8NZgWm43qDzP7vKsJtVwAAAACdNLtBv11q+F+IzQLdlz8s; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=h1SFLXXJ+F6S8A5OOoVtAz/mDl8AAAAAO3G0uysaUF/JUznRo34BMQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=oX5VB4E6+CgWqitOOoVtAzP+Dl8AAAAAsdyh6dyWdCEocOI/mEsX4w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -104,12 +104,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-35990224-35990249 NNYN CT(91 87 0) RT(1594811966954 36) q(0 0 2 -1) r(4 4) U5'
+  '4-16156885-16156891 NNYN CT(93 93 0) RT(1594818098789 40) q(0 0 2 2) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration', {"name":"env-integration"})
-  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-15T11:19:28Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T11:19:28Z"}}, [
+  .reply(201, {"name":"env-integration","sys":{"type":"Environment","id":"env-integration","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"status":{"sys":{"type":"Link","linkType":"Status","id":"queued"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-15T13:01:40Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T13:01:40Z"}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -131,9 +131,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:28 GMT',
+  'Wed, 15 Jul 2020 13:01:40 GMT',
   'etag',
-  'W/"181d13d6b5da34be69e3b92f3f801712"',
+  'W/"f2f73240950f6fb6767db9ca09766d82"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -153,7 +153,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'be027272b2a90c1bf60d123910621e90',
+  '4c0f4081f38ad36770e6d0b59134777e',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -167,15 +167,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3JwtreFiS8CK3kjx7BbNd0DmDl8AAAAAQUIPAAAAAAAkz/7SCe5E5hN8FWySgI74; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=x3mhKjOGQrCubJ4WcjOs+TT+Dl8AAAAAQUIPAAAAAAAGZYQ1A0tfOjGodmH7kZet; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=2wXVQyNungozxc0VKsJtVwAAAABJdJrydttwznNQtoQsYlVZ; path=/; Domain=.contentful.com',
+  'nlbi_673446=MoCqBQP4wk5/PMieKsJtVwAAAAA4oRrpCe+oTLvUY98kCug8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=3alZBf3nCwRi8w5OOoVtA0DmDl8AAAAA3Nx+rw94v+EwNafOb+Vi8Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1ftWKXA5ZDHQqytOOoVtAzT+Dl8AAAAA3vJnQ+x889uqYR6vJpGu2g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24180819-24180829 NNNN CT(86 94 0) RT(1594811967461 35) q(0 0 2 -1) r(11 11) U5'
+  '12-31839320-31839326 NNNN CT(88 89 0) RT(1594818099425 30) q(0 0 2 -1) r(11 11) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -207,7 +207,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt":"2020-07-15T11:19:28Z",
+    "createdAt":"2020-07-15T13:01:40Z",
     "updatedBy":{
       "sys":{
         "type":"Link",
@@ -215,7 +215,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id":"1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "updatedAt":"2020-07-15T11:19:29Z"
+    "updatedAt":"2020-07-15T13:01:41Z"
   }
 }
 
@@ -243,9 +243,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:29 GMT',
+  'Wed, 15 Jul 2020 13:01:41 GMT',
   'etag',
-  'W/"07a13e6af80e3bada83a5dc19a517648"',
+  'W/"b632bea14042aae91a6c6d5419e3ecb6"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -265,7 +265,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '52cae5876809dd6d1a4acc4b3ece494b',
+  '386c023900af40b7fb6b27cd0a3b5909',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -277,11 +277,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BJdowjuKQxOQban9jOtXb0HmDl8AAAAAQUIPAAAAAABWEW9OVmxJvkAeJpWInMfq; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=DzEL8QrhQSGj9itxUaCazzX+Dl8AAAAAQUIPAAAAAADO8RazLh+ZISBtGXJg+nmU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=m94XIMJPXidJ3YYRKsJtVwAAAAD0ufYdzgbHO5DKDNmaenYw; path=/; Domain=.contentful.com',
+  'nlbi_673446=aNEjXwL3/WQs9jZTKsJtVwAAAAAlaC3VywQyCuo5ZvA5iDai; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=CBJUNvw19iRG9Q5OOoVtA0HmDl8AAAAAwHA/Y3Bulik48aN7kQ2bhQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=8RH/DGecQSvQrCtOOoVtAzX+Dl8AAAAApwpFrGfKqCeiB3UgwiqyIA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -289,7 +289,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '5-23224440-23224449 NNYN CT(93 93 0) RT(1594811968691 28) q(0 0 2 -1) r(8 8) U5'
+  '10-15248178-15248190 NNYN CT(87 87 0) RT(1594818100744 23) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -326,7 +326,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:30 GMT',
+  'Wed, 15 Jul 2020 13:01:42 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -346,15 +346,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '09ef8eec121221461e1c1c317d7616ad',
+  'be6a79771bf848886a23f0250994f66d',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mFyovW2/QOeUIGApLimCGELmDl8AAAAAQUIPAAAAAACpI28uuE/5GUqWar9ZHQ89; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=01fFGjRVT/GxeJoc/UToXzb+Dl8AAAAAQUIPAAAAAABVuWn1kxyCEAqWTR22DyWh; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=pUWmJFYzwDZepMlBKsJtVwAAAAAgs4bPFpX+PDN6KW9ViUYy; path=/; Domain=.contentful.com',
+  'nlbi_673446=kDFxV/7VXn/WW3ZWKsJtVwAAAAD658qDetb631wx7N6I16N3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=lZYcdw7BTy6c9g5OOoVtA0LmDl8AAAAA76ZqTIMBsgtJT7eZwkoljA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/owdNGnZszEjritOOoVtAzb+Dl8AAAAAlNcCAgpzFVu4IeH7SYb/VQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -362,7 +362,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-30361925-30361931 NNYN CT(89 88 0) RT(1594811969744 28) q(0 0 2 -1) r(5 5) U5'
+  '11-25359542-25359546 NNYN CT(111 87 0) RT(1594818101699 29) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -403,8 +403,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -434,9 +434,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:31 GMT',
+  'Wed, 15 Jul 2020 13:01:43 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -456,7 +456,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '60eb35385f67a6f06e21884f176c39ff',
+  'a4583cfb1089f5f75738cc00fc8ffbef',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -468,11 +468,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lVAxBuPcRqSspV1DqWU5PkPmDl8AAAAAQUIPAAAAAACCcvrd76UkGSzpx0vJRRT/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=H6t2dBUcTgm9qe3uLPWPcjf+Dl8AAAAAQUIPAAAAAACmf3A33fJ/nYWwCWnMKZPM; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=75J+UqnJJgKZWcGTKsJtVwAAAAA9kAiVulnatkS4lJzpXZZv; path=/; Domain=.contentful.com',
+  'nlbi_673446=J7SVRObymFAPrJL7KsJtVwAAAACisQxEcmgK9Kajkekfs3G7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=TUXhE4zieVcJ+Q5OOoVtA0PmDl8AAAAAlKzlnb5fBsgfhux/wSdYYw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=q2v+VFdhgibzrytOOoVtAzf+Dl8AAAAAon4LHxwmr+TtEGi21RFl/w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -480,12 +480,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-47471192-47471217 NNYN CT(94 86 0) RT(1594811970522 34) q(0 0 2 -1) r(9 9) U5'
+  '13-37638233-37638243 NNYN CT(93 95 0) RT(1594818102691 38) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog', {"name":"angry dog","fields":[{"id":"woofs","name":"woof woof","type":"Number","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-15T11:19:32.579Z","updatedAt":"2020-07-15T11:19:32.579Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dog","type":"ContentType","createdAt":"2020-07-15T13:01:44.968Z","updatedAt":"2020-07-15T13:01:44.968Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"angry dog","description":"super angry","fields":[{"id":"woofs","name":"woof woof","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -507,9 +507,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:32 GMT',
+  'Wed, 15 Jul 2020 13:01:45 GMT',
   'etag',
-  '"12660136450868038466"',
+  '"8986452046298379445"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -527,21 +527,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '7b5e05aefc0f42e5b4d7a55959090b09',
+  '15f70f068f00328b83c48c682f3976df',
   'Content-Length',
   '1051',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=qdp3WBYvSU6ynMJan2e5yUTmDl8AAAAAQUIPAAAAAAAWbmiwUCJS/75/KLKZEQCl; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=St5Vto1pTkuP/FCRwNiiUTj+Dl8AAAAAQUIPAAAAAACLxwA6FTVWDEDSG7pMEhwS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=B9FTOWtZfXToTFPuKsJtVwAAAABCqpM7g0yNcD07cEf3mE6a; path=/; Domain=.contentful.com',
+  'nlbi_673446=LEU2fMlpF0TiA6NvKsJtVwAAAACzAI6n9IsO9F5iOYoC6Iev; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=f3tWFqQ2zEkZ+w5OOoVtA0TmDl8AAAAAXXuxcyN4LB3YRemgbBt+RA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Yf74PMl8x0dMsStOOoVtAzj+Dl8AAAAAXlo6hIlOpo2IdoJxSYA8Ow==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-23224843-23224849 NNNN CT(88 88 0) RT(1594811971545 35) q(0 0 2 -1) r(8 8) U5'
+  '8-4808157-4808162 NNNN CT(93 93 0) RT(1594818103735 28) q(0 0 2 -1) r(12 12) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -557,8 +557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:33.294Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:45.789Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -582,8 +582,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
-    "publishedAt": "2020-07-15T11:19:33.294Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
+    "publishedAt": "2020-07-15T13:01:45.789Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -633,9 +633,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:33 GMT',
+  'Wed, 15 Jul 2020 13:01:45 GMT',
   'etag',
-  'W/"14340618065612228904"',
+  'W/"14221311967568643208"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -653,21 +653,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e811bb86af4ad72b27579909b08a2bc0',
-  'Content-Length',
-  '442',
+  '1f812d7a33af9a813ea76da41d3fc692',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mgM+ebC+TLeLQKnFVzm7lUXmDl8AAAAAQUIPAAAAAADsGz0HzdBjlfCYaJM3G+Mn; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Js/I9uhoT+elkc2Gboqxnjn+Dl8AAAAAQUIPAAAAAAAwXHK1dgvS3Q469IDrH19K; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=f41DItStEUUjsImkKsJtVwAAAADR/AiN9nQXDAoiR1RJvbA5; path=/; Domain=.contentful.com',
+  'nlbi_673446=XcsmHeQRC0gJmoIPKsJtVwAAAADPL7aaH2WJrg8isRXptB1C; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=uaqpVOCORQBa/Q5OOoVtA0XmDl8AAAAAOTdztRoSRsxpeksnIHBNWg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=joClaqTCRGkUsitOOoVtAzn+Dl8AAAAAY422JkTD1B/OaFgEy4pL5g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30362632-30362654 NNNN CT(93 93 0) RT(1594811972443 34) q(0 0 2 -1) r(6 6) U5'
+  '10-15248862-15248865 NNNN CT(93 94 0) RT(1594818105085 36) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -683,8 +683,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:33.294Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:45.789Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -693,8 +693,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:19:33.294Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:45.789Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -759,9 +759,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:33 GMT',
+  'Wed, 15 Jul 2020 13:01:46 GMT',
   'etag',
-  'W/"6893380049824259986"',
+  'W/"13138777583991722542"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -771,29 +771,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '3ae26c480394dfaf0606691c31b23533',
+  'b9d43cb5c33bb52e75d6e733ffba843a',
   'Content-Length',
-  '443',
+  '444',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=68PPcDAnRAOxxA8h/d2S9UXmDl8AAAAAQUIPAAAAAAAxg6yh/Vk59v+v8uLX/Qs+; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=t92fQdo5SKSkXITi5/puuDr+Dl8AAAAAQUIPAAAAAACKhlmdEBz6Ov8LH5baQaPK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=XYOCfI3CuATEE1snKsJtVwAAAACguCv4gf7gaYyBotSHPDFP; path=/; Domain=.contentful.com',
+  'nlbi_673446=IYqIW5Y4Z0PaDCJCKsJtVwAAAAB9D4LT0YBwkMdplJzBE+f9; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=uhrwXJQlihmS/g5OOoVtA0XmDl8AAAAAvsKIbi5AJ0aU4IAsvJ77hQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=RduAJQsCswP9sitOOoVtAzr+Dl8AAAAAUpP1w0BhytuLoiO4Vx/WZw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24182207-24182216 NNNN CT(86 87 0) RT(1594811973186 32) q(0 0 1 -1) r(3 3) U5'
+  '12-31840701-31840710 NNNN CT(93 96 0) RT(1594818105851 34) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -818,8 +818,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:19:32.579Z",
-        "updatedAt": "2020-07-15T11:19:33.294Z",
+        "createdAt": "2020-07-15T13:01:44.968Z",
+        "updatedAt": "2020-07-15T13:01:45.789Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -828,8 +828,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-15T11:19:33.294Z",
-        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+        "publishedAt": "2020-07-15T13:01:45.789Z",
+        "firstPublishedAt": "2020-07-15T13:01:45.789Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -896,9 +896,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:39 GMT',
+  'Wed, 15 Jul 2020 13:01:52 GMT',
   'etag',
-  'W/"13189261227178789964"',
+  'W/"6224799224826842910"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -916,21 +916,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e20f3a3f6f43f5877c1cc0a9fda36d57',
+  '7895bf9472861fecea4aa45f8a56c48b',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=e4tPep2kQSio2GdvkOp8ukvmDl8AAAAAQUIPAAAAAAAxrp1oC124gh/lUjPawakK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Ct/ddlxlQeuUg/nA9D1CsD/+Dl8AAAAAQUIPAAAAAAApnNdP5R9iD0fQOrU8bVGj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8zCdRsp0nF7gRzpRKsJtVwAAAACS+efxRctrBAakwfqTU96u; path=/; Domain=.contentful.com',
+  'nlbi_673446=tJzdKy0/vxWLjt62KsJtVwAAAAByQPu0GbBq/VIq4BOMN2Ze; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=PqDUYarmQkgWCw9OOoVtA0vmDl8AAAAAI2VEfxesUf8XJl4YSAIUfQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=G/HOcbLq9x9DuStOOoVtAz/+Dl8AAAAAOcE/r60zA2AAFScTdekjTg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14419177-14419183 NNNN CT(93 94 0) RT(1594811978896 28) q(0 0 2 -1) r(3 3) U5'
+  '9-9981753-9981754 NNNN CT(93 93 0) RT(1594818111568 41) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -971,8 +971,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -1002,9 +1002,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:40 GMT',
+  'Wed, 15 Jul 2020 13:01:52 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -1016,15 +1016,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '49983f168ae40e728708090e274c98dd',
+  '08338116431bdaa6d8da2b2796d320a4',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -1036,11 +1036,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=E3Gf1qzuS3ann0j1SvLhA0zmDl8AAAAAQUIPAAAAAAD/CMH1Rf1jMQOeatvemmsz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=A2wRUyTsT4Cciqz9K5xfXUD+Dl8AAAAAQUIPAAAAAACvnHAzL/ZRBzKx7wJ0uJtq; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=KazSVsj6xFrpYEnfKsJtVwAAAABog+DeMsZysQo56FwGrm8i; path=/; Domain=.contentful.com',
+  'nlbi_673446=2lFtJHrBQ1cg24QaKsJtVwAAAAAxzOdz79FCGHhKyHI/52A6; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=1WnEG7r+KEy/DQ9OOoVtA0zmDl8AAAAAJRG7hRxkpFMhCYO74P2e2w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nmWOf7FcR1CruStOOoVtA0D+Dl8AAAAAA9nljKMd4oSNWUhDOOkMmg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1048,7 +1048,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-30364540-30364554 NNYN CT(86 89 0) RT(1594811979531 43) q(0 0 2 -1) r(9 9) U5'
+  '13-37640260-37640269 NNYN CT(87 87 0) RT(1594818112111 29) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1064,8 +1064,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:41.491Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:53.194Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1074,8 +1074,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:19:33.294Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:45.789Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1140,9 +1140,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:41 GMT',
+  'Wed, 15 Jul 2020 13:01:53 GMT',
   'etag',
-  'W/"18145230863164173062"',
+  'W/"16834381757727875952"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1160,21 +1160,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '555f148d9f2db6e96dacef1bdbe402b9',
+  '79c1ab37571f6f854b7ec3749837af02',
   'Content-Length',
-  '448',
+  '449',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=H4OCIwYPSSmUD9ufXQxjXU3mDl8AAAAAQUIPAAAAAABqQ34TpzQFsJdYLxi15dZQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ifD/xGbNSMukXZPABY4Ye0D+Dl8AAAAAQUIPAAAAAAABmyLvAMKGWSsHhTc2DvOH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=m1f9VEriRRFGLtjwKsJtVwAAAACJ3y6if6S9YRvylBlxaa8k; path=/; Domain=.contentful.com',
+  'nlbi_673446=H8usSe5me0+Ugb/eKsJtVwAAAAC6KCVmbI8xifSHmtzVlaq3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=whwlTZgOkGuYDw9OOoVtA03mDl8AAAAAC0rXRpXY2+od9k6+jwHuCQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=pkjvK5K0Gk0zuitOOoVtA0D+Dl8AAAAAw7CjADeWjQx+pIlJ05LRBQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47474787-47474799 NNNN CT(94 87 0) RT(1594811980548 30) q(0 0 2 -1) r(7 7) U5'
+  '14-49415436-49415447 NNNN CT(91 89 0) RT(1594818112511 27) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1190,8 +1190,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:42.055Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:53.832Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1200,8 +1200,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:19:42.055Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:53.832Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1266,9 +1266,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:42 GMT',
+  'Wed, 15 Jul 2020 13:01:53 GMT',
   'etag',
-  'W/"3079181608759559087"',
+  'W/"3496942365540704056"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1278,29 +1278,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '0e5d993397227d0d240acdf8307bee17',
-  'Content-Length',
-  '453',
+  '18d0b7639f968389dfb7d7ef4ae6ba43',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=EAWtRyPpS1mNC2Wfdkxb903mDl8AAAAAQUIPAAAAAADAG472drdTMC65LNmvRfh/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=iKop+TpdTuKWk7apH2nL6EH+Dl8AAAAAQUIPAAAAAAAiLqxHOdNMWyxdYsc0qL9O; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=nr9vFnXb7Ryiow/fKsJtVwAAAAD5zrbVd2HTA80brUcoRRsM; path=/; Domain=.contentful.com',
+  'nlbi_673446=B0C+NtKPAkIBzYJ5KsJtVwAAAADcftnr0wSHoZhaet7AzDTA; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=1cLUWxat+y9JEQ9OOoVtA03mDl8AAAAAhE/faKHZySXIERUj+EFO5g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TBqCFZWROykAuytOOoVtA0H+Dl8AAAAAyxBoJnC9/ybX+JMpssCP5A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30365071-30365090 NNNN CT(103 95 0) RT(1594811981382 37) q(0 0 2 -1) r(5 5) U5'
+  '14-49415578-49415590 NNNN CT(88 92 0) RT(1594818113135 37) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1316,8 +1316,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:42.710Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:54.445Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1326,8 +1326,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:19:42.055Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:53.832Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1381,9 +1381,124 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:42 GMT',
+  'Wed, 15 Jul 2020 13:01:54 GMT',
   'etag',
-  'W/"3062650862090098999"',
+  'W/"16526455989328291084"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '8988a4acafbdc7d587ae2866b3fed7fd',
+  'Content-Length',
+  '375',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=Y9PUBdvuRou/yWgwSZRAuEL+Dl8AAAAAQUIPAAAAAAA21y8APB6Q29IBCRJxK697; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=7/LwEm6tli8i93t0KsJtVwAAAACotn2dVhWKI/BgG9okXQGf; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=JPvxRX2VJDumuytOOoVtA0L+Dl8AAAAAI8TDy5DoRU64H0XXcCNdzA==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '14-49415750-49415758 NNNN CT(88 91 0) RT(1594818113745 36) q(0 0 2 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
+  .reply(200, {
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "dog",
+    "type": "ContentType",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:54.911Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 5,
+    "publishedAt": "2020-07-15T13:01:54.911Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 3,
+    "version": 6,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    }
+  },
+  "displayField": null,
+  "name": "angry dog",
+  "description": "super angry",
+  "fields": []
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 13:01:55 GMT',
+  'etag',
+  'W/"4074023039579984184"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1401,136 +1516,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '6e93d289f3636b3993b122cb6af21b27',
-  'Content-Length',
-  '374',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=N5ca1hscRsmna5D2yTxI907mDl8AAAAAQUIPAAAAAAALzZTy3taZ4qZcD2YQEjTD; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=Du+OOCaVEn7O8IC7KsJtVwAAAADdVC3X9uvRkmb/267oUtON; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=Xm9MQLC3vEO6Eg9OOoVtA07mDl8AAAAAYvoA62vLfHVlTf/xwDR/Fg==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '4-15461784-15461789 NNNN CT(88 89 0) RT(1594811982012 26) q(0 0 2 -1) r(5 5) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/published')
-  .reply(200, {
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "dog",
-    "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:43.470Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 5,
-    "publishedAt": "2020-07-15T11:19:43.470Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 3,
-    "version": 6,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    }
-  },
-  "displayField": null,
-  "name": "angry dog",
-  "description": "super angry",
-  "fields": []
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 15 Jul 2020 11:19:43 GMT',
-  'etag',
-  'W/"16647505954805289641"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'e5ae6a72603ee6075be76b43b4ff09f0',
+  '90fc1327f7d8d1ca26cf54d88f0a1f48',
   'Content-Length',
   '370',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Ib8r5hCjQ6alpxWvhYx6aU/mDl8AAAAAQUIPAAAAAABpR8WenXhihyARMVYSO8DY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BOxBT/JfRkCaaw2abvN9b0L+Dl8AAAAAQUIPAAAAAAAySwDIvriky0H4BdKQOxR2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=UKUyYvJZkUEfU79iKsJtVwAAAADgNVMOK6603V/bGXUNRuMc; path=/; Domain=.contentful.com',
+  'nlbi_673446=pXiYRUpW4n5+pRSpKsJtVwAAAAApl7YfjB/RWZNJwjTQ0afP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=AMekXeMhu1xgFA9OOoVtA0/mDl8AAAAAgJxC86wo2FGsbYS0TeP7xg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=VAmDAjs2RDBdvCtOOoVtA0L+Dl8AAAAA4W22dBAfo6ojlXje3w3EnQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14419770-14419781 NNNN CT(88 88 0) RT(1594811982814 28) q(0 0 2 -1) r(4 4) U5'
+  '8-4808818-4808821 NNNN CT(87 87 0) RT(1594818114263 34) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1546,8 +1546,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:43.470Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:54.911Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1556,8 +1556,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-15T11:19:43.470Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:54.911Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1611,9 +1611,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:44 GMT',
+  'Wed, 15 Jul 2020 13:01:55 GMT',
   'etag',
-  'W/"16647505954805289641"',
+  'W/"4074023039579984184"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1631,21 +1631,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '241c707dc195654eb76b83a0cf30e1d8',
+  '438a43d35471237922ff56d2d72cf186',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=TPbXu+HvTOWqmArYRXnjLk/mDl8AAAAAQUIPAAAAAADwoXBDlX463SFkPRUIEgWv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WFHWqVkeRGaqm6HT/YV3QEP+Dl8AAAAAQUIPAAAAAABCrHM7aZ0aPx7Y3pvYjA3J; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=c+Y3fg5DkX7LW1vFKsJtVwAAAAD81s9kUHLtiq9HeLC4CYD+; path=/; Domain=.contentful.com',
+  'nlbi_673446=D40UcQCjGyejqYWxKsJtVwAAAADQnV/BOSlWvxipw7p6apvQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=SeSrKBzbvVfnFQ9OOoVtA0/mDl8AAAAAPJmCD6oBIhUk2anxghQ34A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+WZiPvm+UzE5vStOOoVtA0P+Dl8AAAAAAmW0RYd60TFhTUIOAuq55g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-35995428-35995439 NNNN CT(88 91 0) RT(1594811983439 31) q(0 0 2 -1) r(5 5) U5'
+  '13-37640855-37640859 NNNN CT(94 105 0) RT(1594818114775 58) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1670,8 +1670,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:19:32.579Z",
-        "updatedAt": "2020-07-15T11:19:43.470Z",
+        "createdAt": "2020-07-15T13:01:44.968Z",
+        "updatedAt": "2020-07-15T13:01:54.911Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -1680,8 +1680,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 5,
-        "publishedAt": "2020-07-15T11:19:43.470Z",
-        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+        "publishedAt": "2020-07-15T13:01:54.911Z",
+        "firstPublishedAt": "2020-07-15T13:01:45.789Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -1737,9 +1737,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:45 GMT',
+  'Wed, 15 Jul 2020 13:01:56 GMT',
   'etag',
-  'W/"3508040354696139078"',
+  'W/"12907712256567366790"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -1749,29 +1749,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '3a3471d93430a0ef0d749cc9cff878e7',
+  '7f1af4f2069ae113ca53f1533e8ac9dd',
   'Content-Length',
-  '436',
+  '435',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MPQPDgkDRxm54vUPwSoL4FHmDl8AAAAAQUIPAAAAAABGURNsMMSYfSBykAPUfFq4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WxuvKlLoQZ+kkXYndo2g00P+Dl8AAAAAQUIPAAAAAAAgnGUSTk/SEPDmiEegKHS5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=QTDsW1ujdGSglcdmKsJtVwAAAAD20iCAyiYJ9kHlMRMY2mJp; path=/; Domain=.contentful.com',
+  'nlbi_673446=YQoNFNvPwl6QtUNIKsJtVwAAAABhkk+7AE+EUCupL6dqAkyZ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=pW/DcSa4EUPeGA9OOoVtA1HmDl8AAAAAyjyVzYQysAex9LxK+2WdEw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nV1BYZ3YtVvovStOOoVtA0P+Dl8AAAAAxgxkTPVaBInYtnfFQ/LNxg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-4528566-4528567 NNNN CT(85 86 0) RT(1594811984832 33) q(0 0 2 -1) r(3 3) U5'
+  '14-49416227-49416242 NNNN CT(86 86 0) RT(1594818115381 34) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1812,8 +1812,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -1843,9 +1843,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:45 GMT',
+  'Wed, 15 Jul 2020 13:01:57 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -1857,15 +1857,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '044443985adf123173a17d71b3bc6204',
+  '91271e364af1c8ea241c978679458485',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -1877,11 +1877,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+RetEnrYTEu3TGIO741dMlHmDl8AAAAAQUIPAAAAAAD5Avf3X0H8UVRAzqkkAMMU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=oepQVzGVTOeBUow4tq9fKET+Dl8AAAAAQUIPAAAAAADEbb/bP0oTXEHKDLgdXS8h; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=7Qk8bJ9UumTB8P0DKsJtVwAAAAChwyJ2EGe8DTjvSJ992CdB; path=/; Domain=.contentful.com',
+  'nlbi_673446=Iu2Tc2cBB08SLzrMKsJtVwAAAADqfhgai4u+qHHu3S9Kg/4E; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=l3w6ML1uWy7PGQ9OOoVtA1HmDl8AAAAA7zFaeNkdLaendgKXG/NIjg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=JZ51VYoh9mRuvytOOoVtA0T+Dl8AAAAAm9YTCSBgHNEZX0cohPNBww==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -1889,7 +1889,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-10880458-10880460 NNYN CT(88 88 0) RT(1594811985383 27) q(0 0 1 -1) r(2 2) U5'
+  '5-24171521-24171526 NNYN CT(88 88 0) RT(1594818115896 29) q(0 0 2 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -1905,8 +1905,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:46.629Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:58.572Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -1915,8 +1915,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-15T11:19:43.470Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:54.911Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -1981,9 +1981,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:46 GMT',
+  'Wed, 15 Jul 2020 13:01:58 GMT',
   'etag',
-  'W/"13317033406405494459"',
+  'W/"8862070852629205290"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2001,21 +2001,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '4ffa9010bfa38eb324fbc632ddcbd534',
+  'fe3c49679c6baf1aa7b4b7320d8b2976',
   'Content-Length',
   '497',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=rMtnpIkxQDanScwvExSLYFLmDl8AAAAAQUIPAAAAAABgYJPcUGD6dmppVLv1IBpQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WhV41+SUTXS6hxLMSFU9QUb+Dl8AAAAAQUIPAAAAAAB10V4ibHe7Hf5GoK4D66u3; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=STBZD2a3nFX/Lk38KsJtVwAAAABkPw+D6egM05z7gWooi6Cs; path=/; Domain=.contentful.com',
+  'nlbi_673446=MgWgJpR9VSh/RkQUKsJtVwAAAAAP1UX3i+5iBT8XY84L5ZjM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ZPpIWqjK9hpaGw9OOoVtA1LmDl8AAAAAESiyJItWczHKD0sfXEwIUw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=M9UwBGomPXClwStOOoVtA0b+Dl8AAAAAW3zcmNiB6t/XExS+rE5kXQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-35996223-35996229 NNNN CT(87 87 0) RT(1594811985882 28) q(0 0 1 -1) r(4 4) U5'
+  '13-37641493-37641502 NNNN CT(94 103 0) RT(1594818117845 29) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2031,8 +2031,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:47.155Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:59.143Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2041,8 +2041,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-15T11:19:47.155Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:59.143Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2107,9 +2107,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:47 GMT',
+  'Wed, 15 Jul 2020 13:01:59 GMT',
   'etag',
-  'W/"5694865152655047241"',
+  'W/"17095158373423822278"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2127,21 +2127,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fa21bc62211d764c28340f5502a3ce09',
-  'Content-Length',
-  '493',
+  '047a0a5c18d84419633d23a340b5af61',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MYqTGyg2SsKuciSsow2K+FLmDl8AAAAAQUIPAAAAAADgZSdWMHj1rylnhOfozead; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=d0YXoZq0R66udl1FZ5x2rkb+Dl8AAAAAQUIPAAAAAACotnmyWxabgfr7qNFPHJKC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=we9TaEkHPHOWYUWWKsJtVwAAAAALdmwWp0qbnstMtdH8D9lT; path=/; Domain=.contentful.com',
+  'nlbi_673446=R9SeBDqiKXKSEkueKsJtVwAAAAAq0xPfC12dP/20a8CtQH3n; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=m04NAyV4AC6XHA9OOoVtA1LmDl8AAAAAYY0hUfWnSVDagUEXnnAzig==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=RufoQtXfFi1+witOOoVtA0b+Dl8AAAAA7PHZpb7EknqN/11LTwkIFQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47476791-47476803 NNNN CT(88 89 0) RT(1594811986504 36) q(0 0 2 -1) r(4 4) U5'
+  '6-7769731-7769733 NNNN CT(93 93 0) RT(1594818118477 32) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2157,8 +2157,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:47.155Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:01:59.143Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2167,8 +2167,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-15T11:19:47.155Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:59.143Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2233,9 +2233,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:47 GMT',
+  'Wed, 15 Jul 2020 13:01:59 GMT',
   'etag',
-  'W/"5694865152655047241"',
+  'W/"17095158373423822278"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2253,21 +2253,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'b0186c7903d6a23c117372476837efdf',
+  '45775ede6145108426cc761615182d38',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=UQ0rKlGdRguvf4in3jDSm1PmDl8AAAAAQUIPAAAAAAAHmI87WFJG4XfqyJh8Uxa1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=9AVEWdIoTiuPE2zhmiLrNEf+Dl8AAAAAQUIPAAAAAABGmrIUoBxkcHuHOYwI0dBR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TZ80W0f1gzUzcq1qKsJtVwAAAAC9IqfnK/dvMwyKxuJNwvtz; path=/; Domain=.contentful.com',
+  'nlbi_673446=X0cxf05NMjUE97ugKsJtVwAAAADQL4HgOUNATPCF1kfgfrXg; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=qKuCfh8hzxH+HQ9OOoVtA1PmDl8AAAAAjsjtJN9HtKLkPJqNe+MAXQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=6LCMD263MVwCwytOOoVtA0f+Dl8AAAAALECfm9bS49/hFQydYCqF4Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47476997-47477013 NNNN CT(88 89 0) RT(1594811987116 34) q(0 0 2 -1) r(5 5) U5'
+  '11-25362995-25363001 NNNN CT(87 86 0) RT(1594818119005 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2292,8 +2292,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:19:32.579Z",
-        "updatedAt": "2020-07-15T11:19:47.155Z",
+        "createdAt": "2020-07-15T13:01:44.968Z",
+        "updatedAt": "2020-07-15T13:01:59.143Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -2302,8 +2302,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 7,
-        "publishedAt": "2020-07-15T11:19:47.155Z",
-        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+        "publishedAt": "2020-07-15T13:01:59.143Z",
+        "firstPublishedAt": "2020-07-15T13:01:45.789Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -2370,9 +2370,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:48 GMT',
+  'Wed, 15 Jul 2020 13:02:00 GMT',
   'etag',
-  'W/"5186700402868981456"',
+  'W/"5462802195168047052"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2390,21 +2390,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '1965f19bfea04faf8e6b481b74affee1',
+  '305bcc2a7b699e57e0543388f6bddc14',
   'Content-Length',
-  '556',
+  '557',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YSA/xQeETX637hvFpovUelTmDl8AAAAAQUIPAAAAAAB/bfO2zgCG42E7MmtLUjHd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sexkvNhNTNeNrVqw22RGMkf+Dl8AAAAAQUIPAAAAAADol8o+LYXBQxrNdXPJWEY7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Gth4X7bJbh3IfoIiKsJtVwAAAACsbEXe8kquqNkBd5zsHJuO; path=/; Domain=.contentful.com',
+  'nlbi_673446=UWhjQr97jwGNA9dDKsJtVwAAAABJyUC2QkEGc/d/bHd7GFra; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=qx34REYQ6CcQHw9OOoVtA1TmDl8AAAAAQxhnZU+3RS/bUlYq4wXotQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=NeZQe7BYIj6GwytOOoVtA0f+Dl8AAAAAp6opm+O6ER3b8gcm1Pm1og==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15462394-15462401 NNNN CT(93 94 0) RT(1594811987737 28) q(0 0 2 -1) r(4 4) U5'
+  '13-37641906-37641911 NNNN CT(98 88 0) RT(1594818119484 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2421,7 +2421,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-15T11:19:33.362Z",
+    "createdAt": "2020-07-15T13:01:45.975Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2429,7 +2429,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:19:47.228Z",
+    "updatedAt": "2020-07-15T13:01:59.219Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -2480,9 +2480,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:48 GMT',
+  'Wed, 15 Jul 2020 13:02:00 GMT',
   'etag',
-  '"16677162563861590957"',
+  '"10328964868745585516"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2500,15 +2500,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '4c45a8edc9fda5135e4f8c170c009c5e',
+  '53ba7b78acc070f212b624e2605d30b9',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=LkhyOekuSw2+Jilp+h8zV1TmDl8AAAAAQUIPAAAAAAATG71HNnb3NH3U72VqNbuj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=txBcVZhmQfW+1vxvI5GuL0j+Dl8AAAAAQUIPAAAAAAAG7z7IZ9DGyqkQikVfJB8Y; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=IBSAFo5Rs2ZcemLcKsJtVwAAAAAU14mtfyDs5qnMAM6IEErK; path=/; Domain=.contentful.com',
+  'nlbi_673446=8elke7aCKTIcKrm6KsJtVwAAAACu1Yfv/6rVEIJHDrSLtTli; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=PTZKG1NV9EByIA9OOoVtA1TmDl8AAAAAUltNp2gcOpaxIPwP//VXEQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Bpc5MZgvRz51xCtOOoVtA0j+Dl8AAAAATkHxSbQDEdJu/NKg3yZQBA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2516,7 +2516,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24185972-24185980 NNYN CT(87 87 0) RT(1594811988340 35) q(0 0 2 -1) r(3 3) U5'
+  '4-16158566-16158571 NNYN CT(94 96 0) RT(1594818120087 31) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2557,8 +2557,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -2588,9 +2588,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:50 GMT',
+  'Wed, 15 Jul 2020 13:02:01 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -2610,7 +2610,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e797fc36c7ea4e7481b1de3d6e9e77a1',
+  '58571a4e5b5fef787dae0b55d744a19d',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -2622,11 +2622,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=G+5HSBGzQb68yLUxtrRwblXmDl8AAAAAQUIPAAAAAADNNnci4t2bKquS+2MKjSwx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SA43ni2LS6SRg+pk+2Rb+En+Dl8AAAAAQUIPAAAAAADLnzdXYkZYtz7ODpntdFaH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=iSPZM1Py2ASfkZe0KsJtVwAAAAD+TAOCGMAwEoXUo4hBKZ9p; path=/; Domain=.contentful.com',
+  'nlbi_673446=4rjeG+5W0AR7QxikKsJtVwAAAADjDtba3fqBaGzoXmqXShCN; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=YH0tGq5g3yxzIw9OOoVtA1XmDl8AAAAADcfOtbd1ph14mw15WMXByQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=YOZjTMztJA0JxStOOoVtA0n+Dl8AAAAAMpXyuQHkn7pVu5dycTXj2A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -2634,7 +2634,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24186108-24186116 NNYN CT(92 88 0) RT(1594811988954 30) q(0 0 2 -1) r(9 9) U5'
+  '10-15250753-15250763 NNYN CT(88 91 0) RT(1594818120705 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2650,8 +2650,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:50.723Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:02:01.811Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2660,8 +2660,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 7,
-    "publishedAt": "2020-07-15T11:19:47.155Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:01:59.143Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2726,9 +2726,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:50 GMT',
+  'Wed, 15 Jul 2020 13:02:01 GMT',
   'etag',
-  'W/"14338444956490695869"',
+  'W/"4622327958590640074"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2738,29 +2738,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '030b8908d327e83ca76537443e5a5dc7',
+  'aa12ddefdfba742d87700840d41f8b8b',
   'Content-Length',
-  '503',
+  '502',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=qmougX3rRYKVBk9CuBGhxFbmDl8AAAAAQUIPAAAAAADYMiu/Cm7fB111yJ0qLVFx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=OlSi5rrBS92gwAmNbh5o3Un+Dl8AAAAAQUIPAAAAAABm/g80+6XjryQDXEvFPo0c; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=OOGUd5C1aBBw2rnFKsJtVwAAAABZnE0M610qeY1sPSD5pe3W; path=/; Domain=.contentful.com',
+  'nlbi_673446=FW8QPvxxSziOPhNMKsJtVwAAAAAvD7gPgFPWvxaKnibfnecD; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=LEKHQh0gryZkJQ9OOoVtA1bmDl8AAAAAdsAS7Fwso7tQgekuxH/MFw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=dr1Xf9+gly6bxStOOoVtA0n+Dl8AAAAAHVL0SIPqQQzEDZ9PsnwqZQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47478056-47478083 NNNN CT(93 94 0) RT(1594811990022 35) q(0 0 2 -1) r(4 4) U5'
+  '9-9982995-9983003 NNNN CT(86 86 0) RT(1594818121115 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2776,8 +2776,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:51.257Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:02:02.423Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2786,8 +2786,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-15T11:19:51.257Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:02:02.423Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -2852,9 +2852,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:51 GMT',
+  'Wed, 15 Jul 2020 13:02:02 GMT',
   'etag',
-  'W/"6552828642614742331"',
+  'W/"14016522848545623486"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2872,26 +2872,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f3b8c3e1a99f64a650b048306d62ae5b',
+  '1b5a912fb5ed2d1d9e8af6b2b2f47557',
   'Content-Length',
-  '498',
+  '502',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=0UNxNr2sQvOyu0JJ9bcj9lfmDl8AAAAAQUIPAAAAAABB7uvr7t8/U0v05Km8+2DE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=f8SFoCq8R6q0CX6V0nz1pEr+Dl8AAAAAQUIPAAAAAADympfe8P3eVTzOhHvpxAjN; expires=Wed, 14 Jul 2021 14:42:28 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FJLJc+GS6mAuLG8UKsJtVwAAAABWyy0l2z9Mf4YY/ara98tH; path=/; Domain=.contentful.com',
+  'nlbi_673446=/4WAXF7wQAojZqWjKsJtVwAAAAATWm++XnUVdOuxSZrcYVxD; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=8J9zNZfRVS6qJg9OOoVtA1fmDl8AAAAAcaGlcKFg/hVgtKSSPENpXQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=hdJbKLekXh1bxitOOoVtA0r+Dl8AAAAAklJh47rl1lbIuzjCrJR5nw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30367754-30367763 NNNN CT(89 88 0) RT(1594811990594 39) q(0 0 2 -1) r(4 4) U5'
+  '0-1892524-1892525 NNNN CT(89 88 0) RT(1594818121765 34) q(0 1 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dog/editor_interface', {"controls":[{"fieldId":"aDifferentId"}]})
-  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-15T11:19:33.362Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T11:19:51.897Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[{"fieldId":"aDifferentId"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":6,"createdAt":"2020-07-15T13:01:45.975Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T13:02:03.029Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"dog","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -2913,9 +2913,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:51 GMT',
+  'Wed, 15 Jul 2020 13:02:03 GMT',
   'etag',
-  '"829332846074526072"',
+  '"7115631463570675073"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -2933,21 +2933,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '01767358811fc1acf7b4ebda36c2dccc',
+  '1f4c13927b28a314f49ace0b775cb832',
   'Content-Length',
   '922',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3e9V+xvKQ2q9JTOrF34YalfmDl8AAAAAQUIPAAAAAADLrcPaO8ceXIap+wtMKutB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=iFPtTtqWR6WtWtv0A5FlkEr+Dl8AAAAAQUIPAAAAAABvFBfcUQa3+gv3g5d14JxQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=dvHQNkv+mzSI6jH/KsJtVwAAAACF/RBx6Y8GrRQU9Mgzghno; path=/; Domain=.contentful.com',
+  'nlbi_673446=14AoZjtOiWmVdnNPKsJtVwAAAAAo7tsoixwOG1f1oMxoELzH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=P6T1Cw4ZgThFKA9OOoVtA1fmDl8AAAAAhphwZZddQCCq2WwOUUKQJg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=IhqjZEFWKTICxytOOoVtA0r+Dl8AAAAAEudBHWJ8NWy7uhT39kLitQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30367969-30367982 NNNN CT(93 93 0) RT(1594811991208 44) q(0 0 2 -1) r(4 4) U5'
+  '14-49418180-49418193 NNNN CT(99 97 0) RT(1594818122337 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -2963,8 +2963,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:52.506Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:02:03.651Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -2973,8 +2973,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 9,
-    "publishedAt": "2020-07-15T11:19:51.257Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:02:02.423Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3039,9 +3039,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:52 GMT',
+  'Wed, 15 Jul 2020 13:02:03 GMT',
   'etag',
-  'W/"15178747109335340619"',
+  'W/"4282600203012412214"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3059,21 +3059,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '8d6cc2a9d315b2aa022fb62954f14fff',
+  'c33389763781caa7c5ebf7dca968ec2f',
   'Content-Length',
-  '494',
+  '499',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=2CMKjJ1cTyagE64g4x8XNVjmDl8AAAAAQUIPAAAAAACfIzwHM2d61/ageGynigy1; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=U7e3Rfk9ThSWjFwNKR5F8Ev+Dl8AAAAAQUIPAAAAAABnlGTk7MsGjYY8aLSiryIm; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=38y2Hy5vwB8lcglxKsJtVwAAAABzHRxJ0YRS7vZk219kJ6vS; path=/; Domain=.contentful.com',
+  'nlbi_673446=nRllc6J483E/P7btKsJtVwAAAAAxmAVnQTR8P/Jsvp+AhGsj; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=7KkLCKJuqjCmKQ9OOoVtA1jmDl8AAAAAlSLYgjhRnYRmKDmSd96L2w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=oBTsTIu/0TPrxytOOoVtA0v+Dl8AAAAA3C/xBl4YisvdM74EM859ng==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-23228233-23228237 NNNN CT(93 94 0) RT(1594811991823 29) q(0 0 2 -1) r(4 4) U5'
+  '14-49418339-49418352 NNNN CT(89 92 0) RT(1594818122961 32) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3089,8 +3089,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:53.100Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:02:04.213Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3099,8 +3099,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 11,
-    "publishedAt": "2020-07-15T11:19:53.100Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:02:04.213Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3165,9 +3165,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:53 GMT',
+  'Wed, 15 Jul 2020 13:02:04 GMT',
   'etag',
-  'W/"15879163713603625765"',
+  'W/"13392554756622697985"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3185,21 +3185,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '90f6c5aa373dbc7f66f0ffa0334cdce2',
-  'transfer-encoding',
-  'chunked',
+  'd6cb961d6df3f45c0410f335ad2220a8',
+  'Content-Length',
+  '494',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nq8eiwOvRqO0gXJk7U7hrFjmDl8AAAAAQUIPAAAAAAC/Pm8BNe68FJ0aZVCHXSeV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=QZYb1hIVQCW8MeaXO74/GUz+Dl8AAAAAQUIPAAAAAACW82cQjCJjT3mo/KRel23A; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=27AwZxOX6Rr1cUkPKsJtVwAAAACajjdp5bShsUw9cJ91+lbG; path=/; Domain=.contentful.com',
+  'nlbi_673446=srXbcUj+DTYgkSkBKsJtVwAAAACneQKGgF0v6RRwbOIZlxlC; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0h6NVC+GDRIeKw9OOoVtA1jmDl8AAAAASNKVX0KPO1ZEj+lVHwVvqw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nCPVNuOfM3HLyCtOOoVtA0z+Dl8AAAAAJSVK7MlUCjwAal+F3TZ06g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14421253-14421267 NNNN CT(85 88 0) RT(1594811992440 31) q(0 0 2 -1) r(5 5) U5'
+  '12-31844331-31844343 NNNN CT(91 87 0) RT(1594818123561 34) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3215,8 +3215,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:53.100Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:02:04.213Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3225,8 +3225,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 11,
-    "publishedAt": "2020-07-15T11:19:53.100Z",
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "publishedAt": "2020-07-15T13:02:04.213Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3291,9 +3291,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:53 GMT',
+  'Wed, 15 Jul 2020 13:02:04 GMT',
   'etag',
-  'W/"15879163713603625765"',
+  'W/"13392554756622697985"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3311,21 +3311,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '889c500f6f4fc82535b9373e262726bf',
-  'transfer-encoding',
-  'chunked',
+  '538db64cdcc6756f977f0fe8df79d6f5',
+  'Content-Length',
+  '494',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=GRqkfJMpT52b7VSWPFprW1nmDl8AAAAAQUIPAAAAAAArAsYcLRBmWfUjne1NnFF2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WrpZ4VW6TLOJGLIYKnfT30z+Dl8AAAAAQUIPAAAAAADsbn4nnRcajB8w3rVjH/Oo; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=HNMac/3rDHiPkD+GKsJtVwAAAAChaZCxvZUaS7h47VUApmq8; path=/; Domain=.contentful.com',
+  'nlbi_673446=aJ1YLcmDcwdW+AjmKsJtVwAAAAAn44EFzHuviKlDk8I8JfxJ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=i17GegisXRZcLA9OOoVtA1nmDl8AAAAAoOUGoKVCUiKWFJCU58yZLw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=L/ueGgvoIE5MyStOOoVtA0z+Dl8AAAAA4hL1EZsuMyWMbT4GYmY8eA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30368466-30368486 NNNN CT(95 94 0) RT(1594811993058 44) q(0 0 1 -1) r(3 3) U5'
+  '5-24172410-24172417 NNNN CT(93 94 0) RT(1594818124079 29) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3350,8 +3350,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "dog",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:19:32.579Z",
-        "updatedAt": "2020-07-15T11:19:53.100Z",
+        "createdAt": "2020-07-15T13:01:44.968Z",
+        "updatedAt": "2020-07-15T13:02:04.213Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -3360,8 +3360,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 11,
-        "publishedAt": "2020-07-15T11:19:53.100Z",
-        "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+        "publishedAt": "2020-07-15T13:02:04.213Z",
+        "firstPublishedAt": "2020-07-15T13:01:45.789Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -3428,9 +3428,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:54 GMT',
+  'Wed, 15 Jul 2020 13:02:05 GMT',
   'etag',
-  'W/"10008067805799834274"',
+  'W/"7022488585122683169"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3448,21 +3448,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f12d60916b5d15d76ab2304d1d9fee0a',
+  '6ac77745c3fe5717df75b34cbe23b7e2',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=AANKsGnTQ/29RtpcqBxDslnmDl8AAAAAQUIPAAAAAACSWQQGPrGI1S0LgFyk2mDh; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MEd4D/VmQWyoKKcn8+ozTkz+Dl8AAAAAQUIPAAAAAADmKuE94yRHaEcz5SJV6hCp; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=9MtrG1pdx0IQTfpvKsJtVwAAAABJ80WMRoAPihJayV8caEf6; path=/; Domain=.contentful.com',
+  'nlbi_673446=spc1QQNj6FxIwFPAKsJtVwAAAADpm1JrzBcmvjtkWSWqQvUW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=PZlXRTzJKnlSLQ9OOoVtA1nmDl8AAAAAn9VL+DTjXa3qTYvu7F+ISw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=GdWSQ5gOnVnvyStOOoVtA0z+Dl8AAAAAl2awyRQmf+2i9r8tebpqkA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47479349-47479372 NNNN CT(94 88 0) RT(1594811993524 31) q(0 0 2 -1) r(4 4) U5'
+  '8-4809672-4809674 NNNN CT(87 88 0) RT(1594818124537 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3499,7 +3499,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:54 GMT',
+  'Wed, 15 Jul 2020 13:02:05 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -3519,15 +3519,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '3812548edd546535b6484177b3bac5c1',
+  'b975e237b1b407420d7ea68ea4d66943',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=qdC3zeq/SLWXYfugd5wd9FrmDl8AAAAAQUIPAAAAAAAwzGchDvw0SjTtjjRgB+ic; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=IvdeeVu4QQmAXinCV1+4iU3+Dl8AAAAAQUIPAAAAAACI7XV70wsy5+MCjlGCppz2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ZjAyZZpGMyv6R2m0KsJtVwAAAADVa4Uf57KXyprtNpf+rdrX; path=/; Domain=.contentful.com',
+  'nlbi_673446=iO9fFYIpjG8ZnlP/KsJtVwAAAAD6VcCYdPGT4aVBXSqPkSt5; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=+7GwAsFgtypXLg9OOoVtA1rmDl8AAAAA/2qk7VRO/XWacgD+9iwJtg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Vgr6TlKGNiuxyitOOoVtA03+Dl8AAAAA5dzPrRo4bnY74ZQgyZc+XQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3535,7 +3535,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24187364-24187374 NNYN CT(88 88 0) RT(1594811993990 35) q(0 0 2 -1) r(3 3) U5'
+  '13-37643089-37643093 NNYN CT(96 93 0) RT(1594818125003 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3576,8 +3576,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -3607,9 +3607,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:55 GMT',
+  'Wed, 15 Jul 2020 13:02:06 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -3629,7 +3629,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'd16fdf3361ceaec7ca77aa4f8b8d538e',
+  '079c6a773123d3eb123f02ddcdc05998',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -3641,11 +3641,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=l2KwCgn+S2S4W4BmbmsEhVrmDl8AAAAAQUIPAAAAAABqbrisBKK9OJe54g6XKpfv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=PjxxierASg+8e1FWLxZ0EU7+Dl8AAAAAQUIPAAAAAACOQE5ssjvn5qU/0SJq5GX9; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=yMa9Uo5c+w6LhBCCKsJtVwAAAABsBrcRilbXoAILC9k4lXpz; path=/; Domain=.contentful.com',
+  'nlbi_673446=7iumLN7p+g305nbRKsJtVwAAAACTyVXi5Pyo7ha5mly00bGz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=/KWrRH/sCyM1Lw9OOoVtA1rmDl8AAAAAeAQ0ilgnao4Hdeqc+uIr8A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=aTa4RolhwSvfyytOOoVtA07+Dl8AAAAAdV/R1Z/6IDF0kvUME9RaqA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3653,7 +3653,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-14421653-14421655 NNYN CT(86 87 0) RT(1594811994488 30) q(0 0 1 -1) r(2 2) U5'
+  '9-9983629-9983632 NNYN CT(86 92 0) RT(1594818125527 31) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3669,8 +3669,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dog",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:32.579Z",
-    "updatedAt": "2020-07-15T11:19:55.548Z",
+    "createdAt": "2020-07-15T13:01:44.968Z",
+    "updatedAt": "2020-07-15T13:02:07.418Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -3678,7 +3678,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "Environment"
       }
     },
-    "firstPublishedAt": "2020-07-15T11:19:33.294Z",
+    "firstPublishedAt": "2020-07-15T13:01:45.789Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -3736,9 +3736,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:55 GMT',
+  'Wed, 15 Jul 2020 13:02:07 GMT',
   'etag',
-  'W/"2193406852284124990"',
+  'W/"10785647676859928817"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3748,29 +3748,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'e348689c045e80d6331df799ff237bdb',
+  '97a10d710d83138c5fb6fbf61b5754c6',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=i9wCp46jSG6Gein6EQKWwFvmDl8AAAAAQUIPAAAAAACtHiG9eCF3+T9BW5pvt70q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=X/JzzGRqQNS2k1/bDVBYO0/+Dl8AAAAAQUIPAAAAAACAuCWspMCwo26oPQegCYOd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=vC1zXi4ipyKK1e3mKsJtVwAAAAC9DLsaE+QuTvgzVxFz1Tyz; path=/; Domain=.contentful.com',
+  'nlbi_673446=Ik02UbvKvEXHJsnmKsJtVwAAAACME2YDjZOYqgqF0YAXNaa7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=g/Q/T8xShiAxMQ9OOoVtA1vmDl8AAAAA5mFgKwnRUYUBrN9/7SlRZQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=w3UdMFsZ5CeSzCtOOoVtA0/+Dl8AAAAAND7Q9qtCoz1cY+g5K2Bgzw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-10881120-10881130 NNNN CT(87 86 0) RT(1594811994894 30) q(0 0 1 -1) r(4 4) U5'
+  '4-16159053-16159058 NNNN CT(89 179 0) RT(1594818126657 28) q(0 0 3 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3797,7 +3797,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:56 GMT',
+  'Wed, 15 Jul 2020 13:02:08 GMT',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3807,27 +3807,27 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  '1edd33e81038e1e1d554a0de2595f178',
+  '683bfebcf190541dc1a0046535a4a907',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=oMygffbQRkCXHCKjm1KkB1vmDl8AAAAAQUIPAAAAAACU5Jlm/j+z3BIl74scSCUL; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=bbPUKmN4R9i76QSkaytR8k/+Dl8AAAAAQUIPAAAAAAD7G0j7o8pQDUxcpGq3jduU; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=zRYDP2EzsGwXHnAbKsJtVwAAAAAEuH00Pu9pnucE/fBuQvRx; path=/; Domain=.contentful.com',
+  'nlbi_673446=AEroXaT30x5/hNS9KsJtVwAAAAAfWSYwwJTBMtOQq/N5bBph; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=54OQYI3igVFlMg9OOoVtA1vmDl8AAAAApem/nUqNz/YFZSpxygtVBw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=9GwVC1zYngYRzStOOoVtA0/+Dl8AAAAAF5eeDdMUNzBDzFwZjAjoLg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-35999355-35999361 NNNN CT(92 90 0) RT(1594811995379 31) q(0 0 1 -1) r(3 3) U5'
+  '5-24172705-24172714 NNNN CT(86 87 0) RT(1594818127267 36) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3844,7 +3844,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "9c8f124a358d227817812198b3171c8f"
+  "requestId": "cf1aa9460eba598616ec6fa00068b92a"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -3868,9 +3868,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:56 GMT',
+  'Wed, 15 Jul 2020 13:02:08 GMT',
   'etag',
-  '"3514449655326400314"',
+  '"15835011196402125881"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -3888,15 +3888,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '9c8f124a358d227817812198b3171c8f',
+  'cf1aa9460eba598616ec6fa00068b92a',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=bFWFxXEfQ5q6ppMLq4Ad0FzmDl8AAAAAQUIPAAAAAACsmGzwrUs2oKiHcHB4lBwu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ElCl1IHuSTSvKIibNiJqt1D+Dl8AAAAAQUIPAAAAAABI3PqJA1o+Eltksbzr2RJu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GLyXMKOv3xVMfd4oKsJtVwAAAADhkgQ9GMloBcDIBoSKqRzx; path=/; Domain=.contentful.com',
+  'nlbi_673446=TIR8J1dSmhCYUVYkKsJtVwAAAAD5/fDJenrabyiPhU81FlyL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=FlF6FI7QWG2XMw9OOoVtA1zmDl8AAAAAY3QJWu0tJaq3hsKM9CnpnQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=YzOzXDGhLl2nzStOOoVtA1D+Dl8AAAAAlK0GqGsxL0TpneQr13JR2w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3904,7 +3904,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24187809-24187826 NNYN CT(87 87 0) RT(1594811995916 33) q(0 0 2 -1) r(3 3) U5'
+  '14-49419757-49419762 NNYN CT(86 88 0) RT(1594818127877 26) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -3941,7 +3941,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:57 GMT',
+  'Wed, 15 Jul 2020 13:02:09 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -3953,23 +3953,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'c5610c0be6a3b7ee0d31776867fb90f5',
+  '283d761df5b02a924ea4d345da4359b2',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=GfOsCsVOQXmiM+NWxlmE8VzmDl8AAAAAQUIPAAAAAADfYXq8EvMY2qJmHiA3gL7r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ZNlkkvaHQiSIT/v3Hj8UR1D+Dl8AAAAAQUIPAAAAAADpRrM7CqhST7DMgJgkN/Ex; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RuofXCSx6yAT5WL5KsJtVwAAAACd066WBV6S+0Njz312aoEB; path=/; Domain=.contentful.com',
+  'nlbi_673446=8uESMPuRsA2buvfWKsJtVwAAAAAb6JHGMzW2GpFoLwWeuvoP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=MIInblqRukkxNQ9OOoVtA1zmDl8AAAAAiXODT+DTiPb1Ywo/Wcp83g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=En8fXpVBYkRNzitOOoVtA1D+Dl8AAAAA4KYz2CMr6sfpy0+tGTZ7nA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -3977,7 +3977,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24187977-24187986 NNYN CT(89 85 0) RT(1594811996590 34) q(0 0 1 -1) r(3 3) U5'
+  '3-11288502-11288504 NNYN CT(92 95 0) RT(1594818128377 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4018,8 +4018,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -4049,9 +4049,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:58 GMT',
+  'Wed, 15 Jul 2020 13:02:10 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -4071,7 +4071,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '35faccc692e5f7e5dbf60629a93dfac1',
+  '104bd7a7d373b53ac9586013305e6262',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -4083,11 +4083,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=KIHhgoFVTdmlxjzquKTTc17mDl8AAAAAQUIPAAAAAAC31M8Q08mFiN2swx1tMOZo; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Yjqq4H85RXquJwR6rOSZT1H+Dl8AAAAAQUIPAAAAAABjdxUou7veDKrMYD0ndkM3; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=JQUYHPJ3Vgp7BVtVKsJtVwAAAAAnkD+3WlkZZMFyxwhsgux/; path=/; Domain=.contentful.com',
+  'nlbi_673446=g9UCCoJOHDBtvgCtKsJtVwAAAAAqzeKXzIKbM7eVkZwuqPTU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=HWgHIhQ+ol4COQ9OOoVtA17mDl8AAAAA9lOJUC6bh2emyNEX3JhBvw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=pmPJcp/4ATZdzytOOoVtA1H+Dl8AAAAAgvUn9jT2kTXbJ86qEBxPJg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4095,12 +4095,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '10-14422365-14422369 NNYN CT(93 94 0) RT(1594811998151 30) q(0 0 2 -1) r(3 3) U5'
+  '14-49420007-49420023 NNYN CT(88 89 0) RT(1594818128857 31) q(0 0 2 -1) r(9 9) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/dieatary-food', {"name":"Dieatary Food","fields":[{"id":"name","type":"Symbol","name":"name of the food","validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}]},{"id":"calories","type":"Link","linkType":"Asset","name":"amount of calories the food contains","validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}]}],"description":"Food with up to 500 calories"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-15T11:19:59.308Z","updatedAt":"2020-07-15T11:19:59.308Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"dieatary-food","type":"ContentType","createdAt":"2020-07-15T13:02:10.615Z","updatedAt":"2020-07-15T13:02:10.615Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Dieatary Food","description":"Food with up to 500 calories","fields":[{"id":"name","name":"name of the food","type":"Symbol","localized":false,"required":false,"validations":[{"unique":true},{"prohibitRegexp":{"pattern":"foo","flags":null},"message":"asdf"}],"disabled":false,"omitted":false},{"id":"calories","name":"amount of calories the food contains","type":"Link","localized":false,"required":false,"validations":[{"assetImageDimensions":{"width":{"min":1199,"max":null},"height":{"min":1343}}}],"disabled":false,"omitted":false,"linkType":"Asset"}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4122,9 +4122,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:19:59 GMT',
+  'Wed, 15 Jul 2020 13:02:10 GMT',
   'etag',
-  '"18322066142834842159"',
+  '"1510648745088776205"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4142,21 +4142,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b3e8c2ad7b4008dc0474e5ea0136a147',
+  'c354411a0cb2586d3445ffa81cc7b0c5',
   'Content-Length',
   '1783',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=lzcw/6K6TDS5I49SdLSUNV/mDl8AAAAAQUIPAAAAAACImbv64oJJtDvp/8PYcojE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qXuBWCJiRtypsIwj0YRqrVL+Dl8AAAAAQUIPAAAAAADqzSwIzNAKeN+e3X/2gbcs; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=0KXYcMRg2xyZUS8XKsJtVwAAAADzUEXMCz0psCTkefeKIYBf; path=/; Domain=.contentful.com',
+  'nlbi_673446=nzDPQK35VmLHnEupKsJtVwAAAACYti7R/56hlTRarqSeHppL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=mURmSM8ScxtbOg9OOoVtA1/mDl8AAAAAvPAJP8AoAb3HPq4dco7RNw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=8AZlKgGXcFIZ0CtOOoVtA1L+Dl8AAAAA7+976kyvXP1qZgAQAlXkgw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-4529385-4529387 NNNN CT(93 99 0) RT(1594811998600 37) q(0 0 2 -1) r(4 4) U5'
+  '9-9984167-9984173 NNNN CT(86 86 0) RT(1594818129819 29) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4172,8 +4172,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:59.308Z",
-    "updatedAt": "2020-07-15T11:19:59.940Z",
+    "createdAt": "2020-07-15T13:02:10.615Z",
+    "updatedAt": "2020-07-15T13:02:11.191Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4197,8 +4197,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:19:59.940Z",
-    "publishedAt": "2020-07-15T11:19:59.940Z",
+    "firstPublishedAt": "2020-07-15T13:02:11.191Z",
+    "publishedAt": "2020-07-15T13:02:11.191Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4282,9 +4282,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:00 GMT',
+  'Wed, 15 Jul 2020 13:02:11 GMT',
   'etag',
-  'W/"950984746461574053"',
+  'W/"12601256972110782014"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4294,29 +4294,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '856f24f7a4a8b9bf39f652b9aae34aca',
+  'f017adc121a850118c72c25948169c7b',
   'Content-Length',
-  '651',
+  '653',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=v+CoxdTMSo+3nqEg81Q1G1/mDl8AAAAAQUIPAAAAAACAJwDIexMJjI1+WnwzW8To; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=XER45J8hRXm6jctkXp0GA1L+Dl8AAAAAQUIPAAAAAABa7XXw20PtdcMPuLEck3Bh; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=298ZG7Qc8F4MBW4nKsJtVwAAAADLXVr4wMO9m0duy5oGG7QT; path=/; Domain=.contentful.com',
+  'nlbi_673446=RXn7NgsPYQ+WFuUUKsJtVwAAAACD7MPFQY1q6LJrGp1MH9S8; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=r2KpL1BQvVS8Ow9OOoVtA1/mDl8AAAAAhgFWZnns/U9X9Pp3SAr05A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=6RDIGMt5NQG00CtOOoVtA1L+Dl8AAAAADPzDovvGkTgDcPmwP7CrQw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14422595-14422597 NNNN CT(86 87 0) RT(1594811999190 20) q(0 0 1 -1) r(5 5) U5'
+  '13-37644275-37644286 NNNN CT(88 92 0) RT(1594818130541 22) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4332,8 +4332,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "dieatary-food",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:19:59.308Z",
-    "updatedAt": "2020-07-15T11:19:59.940Z",
+    "createdAt": "2020-07-15T13:02:10.615Z",
+    "updatedAt": "2020-07-15T13:02:11.191Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4342,8 +4342,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:19:59.940Z",
-    "firstPublishedAt": "2020-07-15T11:19:59.940Z",
+    "publishedAt": "2020-07-15T13:02:11.191Z",
+    "firstPublishedAt": "2020-07-15T13:02:11.191Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -4442,9 +4442,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:00 GMT',
+  'Wed, 15 Jul 2020 13:02:11 GMT',
   'etag',
-  'W/"17841477265352863197"',
+  'W/"412978154381311212"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4454,29 +4454,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'cc633d0b62ea0a83f7d1f6ec1c26c055',
+  '4e75d0068ac885751354a04455e70b3e',
   'Content-Length',
-  '651',
+  '653',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=S81HIokiTzW1JclghukhzWDmDl8AAAAAQUIPAAAAAABesAkOCT4rp/uxZi0pyk77; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=JvK2S3C2S02suydVIraKPVP+Dl8AAAAAQUIPAAAAAACev+/j4sNw8P88EY06RFKl; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=g0FcKCIbX2yBQ8edKsJtVwAAAABFTdTHHtOFwXqfk71GvBoJ; path=/; Domain=.contentful.com',
+  'nlbi_673446=lBKPdCLce1PV9RJ/KsJtVwAAAAB6b8/QS/XABJiliBDLset3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=/B5gBkIFc2sKPg9OOoVtA2DmDl8AAAAANZbsSPAu3z3trYrM+hdlNQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nw/xaUI8ZG590StOOoVtA1P+Dl8AAAAAZT75bt571qIdZdBCpCxwIA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14422758-14422766 NNNN CT(88 89 0) RT(1594812000014 31) q(0 0 2 -1) r(7 7) U5'
+  '14-49420719-49420741 NNNN CT(105 94 0) RT(1594818131131 89) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4513,7 +4513,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:01 GMT',
+  'Wed, 15 Jul 2020 13:02:12 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -4533,15 +4533,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'c9f4199cc29d0ba576d18b6bff93cbcd',
+  'dfe7cdecd72217833cd35e65fd46c90f',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=iQd0usnJQ/qNHzTFFM6apGHmDl8AAAAAQUIPAAAAAAAXiQNGZ80Y7Ga9y0dAgO23; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=y5Vdcj77Q2GfUrpOuF8cYlT+Dl8AAAAAQUIPAAAAAABS2V3G1oxkTp0fg9eg1M4o; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TlM/GgjHHU0wU7lPKsJtVwAAAAAQCtlGKtCI/BxbjAsl6lZf; path=/; Domain=.contentful.com',
+  'nlbi_673446=eXUdEO64GXk3/QgYKsJtVwAAAADqg2OSsYwq/D1TFeB6xens; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=xM53azQMO1jSPw9OOoVtA2HmDl8AAAAAvfbGHmBhQRcicFOVYeCLyg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=d88UI6kV5whu0itOOoVtA1T+Dl8AAAAAQFIFWtGbkmn+7Tz/dtTuAA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4549,7 +4549,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-47481922-47481934 NNYN CT(94 100 0) RT(1594812000836 36) q(0 0 2 -1) r(5 5) U5'
+  '12-31846141-31846172 NNYN CT(86 86 0) RT(1594818131959 99) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4590,8 +4590,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -4621,9 +4621,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:02 GMT',
+  'Wed, 15 Jul 2020 13:02:13 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -4643,7 +4643,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bdbd5ee90e9382c6e54491bc37603ce2',
+  '00998ea69d61562589565f5ef03e069c',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -4655,11 +4655,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=zPwcr1CYQH2Zm0GG5PNxS2HmDl8AAAAAQUIPAAAAAAC9XEFSUtgq7QmGINyBVnCP; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=YvRTW/rJQ3Ki2EpXkYXP8lX+Dl8AAAAAQUIPAAAAAACOYSLjF33eF593Wk51NI2I; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TZlGE9KCZx9E88ncKsJtVwAAAACIFmETn16uksnOkpKE8zJ1; path=/; Domain=.contentful.com',
+  'nlbi_673446=pz9JHNxn50YFpTOVKsJtVwAAAABOQ9txcCbmabYsB20ZOZ2U; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=5/LeNkkDqxoHQQ9OOoVtA2HmDl8AAAAAhE18HuJtxYGT4wPI40u8qg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Hcz4D2dWDHYm0ytOOoVtA1X+Dl8AAAAAEPE253DaKStq+r2TxgmuPA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -4667,12 +4667,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-9345138-9345147 NNYN CT(86 88 0) RT(1594812001648 52) q(0 0 1 -1) r(2 2) U5'
+  '14-49421174-49421226 NNYN CT(87 90 0) RT(1594818132787 116) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/food', {"name":"foooood","displayField":"taste","fields":[{"id":"taste","type":"Symbol","name":"what it tastes like"}],"description":" well, food"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-15T11:20:02.872Z","updatedAt":"2020-07-15T11:20:02.872Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"food","type":"ContentType","createdAt":"2020-07-15T13:02:14.028Z","updatedAt":"2020-07-15T13:02:14.028Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":"taste","name":"foooood","description":" well, food","fields":[{"id":"taste","name":"what it tastes like","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -4694,9 +4694,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:02 GMT',
+  'Wed, 15 Jul 2020 13:02:14 GMT',
   'etag',
-  '"3717530732025275517"',
+  '"7059500860902645450"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4714,21 +4714,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '93f8de08212e80ed1291c81d01f852b5',
+  'b64474866c5cc72daa2b70ecf5922b07',
   'Content-Length',
   '1064',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ZvOwWPyrSqWuZBu2afTlHGLmDl8AAAAAQUIPAAAAAABasTFJ9lphoDFqtm+xsOpN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=jWSkr0DiTG6ABroV0OovYFX+Dl8AAAAAQUIPAAAAAAAOilBakQBYj2ixjIjN93yV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LxMQH/XRQkQmFQPRKsJtVwAAAADaTgN2ht3LSWsW1bjv6Fnl; path=/; Domain=.contentful.com',
+  'nlbi_673446=UtKxLbydy3bzkjN7KsJtVwAAAABtoWwRINgid5I92xwyfQBw; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=0my/SWtp4yKvQg9OOoVtA2LmDl8AAAAApkosZzl4WXuHptVO+61iFw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=/QqyHbfbeU7J0ytOOoVtA1X+Dl8AAAAAUH+kxL0nzYQCQsQUnpId9Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '8-4529620-4529625 NNNN CT(87 87 0) RT(1594812002068 29) q(0 0 2 -1) r(6 6) U5'
+  '13-37644894-37644903 NNNN CT(96 94 0) RT(1594818133301 43) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4744,8 +4744,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:02.872Z",
-    "updatedAt": "2020-07-15T11:20:03.568Z",
+    "createdAt": "2020-07-15T13:02:14.028Z",
+    "updatedAt": "2020-07-15T13:02:14.591Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -4769,8 +4769,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
-    "publishedAt": "2020-07-15T11:20:03.568Z",
+    "firstPublishedAt": "2020-07-15T13:02:14.591Z",
+    "publishedAt": "2020-07-15T13:02:14.591Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -4820,9 +4820,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:03 GMT',
+  'Wed, 15 Jul 2020 13:02:14 GMT',
   'etag',
-  'W/"7569917411828058782"',
+  'W/"18227137841190198934"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4840,21 +4840,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '3f71d70163f05abb506168172e19c747',
+  '930b1e03e415cb5f9f59361aa57e8841',
   'Content-Length',
-  '452',
+  '445',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=0YCbm1KySwy2Ix5EbE/GpWPmDl8AAAAAQUIPAAAAAABd+bpAze7XnKtgoKXex+Dt; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=dp717JtaSd+cYPE0OrWAuFb+Dl8AAAAAQUIPAAAAAAD5Zm6jrUW/qxunatIhvyps; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LuUhdVxh6k8YLbmTKsJtVwAAAACutnF9UaZPqVCcaarzLWKn; path=/; Domain=.contentful.com',
+  'nlbi_673446=xPSsORNFPBosFMTFKsJtVwAAAAB3GXaYSxEmOAPV57w/Sy/Q; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=T9gBFSm8DACrRQ9OOoVtA2PmDl8AAAAAJi3DxS/cOTcVkyegBpIF3A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=UCcYdHrKRyxv1StOOoVtA1b+Dl8AAAAAX2hoTVGmkd/RlywuFmARrA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24189588-24189592 NNNN CT(90 89 0) RT(1594812002724 29) q(0 0 2 -1) r(8 8) U5'
+  '14-49421547-49421565 NNNN CT(96 95 0) RT(1594818133885 69) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -4879,8 +4879,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "food",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:20:02.872Z",
-        "updatedAt": "2020-07-15T11:20:03.568Z",
+        "createdAt": "2020-07-15T13:02:14.028Z",
+        "updatedAt": "2020-07-15T13:02:14.591Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -4889,8 +4889,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-15T11:20:03.568Z",
-        "firstPublishedAt": "2020-07-15T11:20:03.567Z",
+        "publishedAt": "2020-07-15T13:02:14.591Z",
+        "firstPublishedAt": "2020-07-15T13:02:14.591Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -4957,9 +4957,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:04 GMT',
+  'Wed, 15 Jul 2020 13:02:15 GMT',
   'etag',
-  'W/"5213400854561507595"',
+  'W/"7289368717355929291"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -4977,21 +4977,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'dde78d337bad7e8e202e37392f4f61eb',
+  '55b2baebfd47b8ce3456965d91ba641a',
   'Content-Length',
-  '517',
+  '512',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=nGjmRLRwSHO0Ks5QUOUX9WTmDl8AAAAAQUIPAAAAAADb2CPYtuM1h1++ygbOmc/m; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=suYxnXpTTta/HopHugv2TVf+Dl8AAAAAQUIPAAAAAACOq5iX+QECRA1eTLdquybq; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=26yAV29g1COg/1//KsJtVwAAAABpVs0HhrVHN6RTuYtA/xmq; path=/; Domain=.contentful.com',
+  'nlbi_673446=V9J8YEdwIQ1sp6KEKsJtVwAAAACTYH7VUK5zGo/7Bnzx9VOa; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=QNEjCyjiqRHpRg9OOoVtA2TmDl8AAAAAFMBN7dA1xc16HyLEoilngQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0VewMRLSLS721StOOoVtA1f+Dl8AAAAADoc4OLQ91UHmpa+lXeMVeg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24189887-24189893 NNNN CT(86 90 0) RT(1594812003697 36) q(0 0 2 -1) r(3 3) U5'
+  '7-13170445-13170452 NNNN CT(86 87 0) RT(1594818134637 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5032,8 +5032,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -5063,9 +5063,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:04 GMT',
+  'Wed, 15 Jul 2020 13:02:15 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -5085,7 +5085,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '9bf62bc8c5906db41c66f415b2b4d1fa',
+  '6bfebc07b018880ba75b7042c314ee5c',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -5097,11 +5097,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vWOdDKauQhirMbAOpDah0GTmDl8AAAAAQUIPAAAAAABmZU9Mq1OoIS3LF3UzRjyR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fLxFiGsaQiKuOne/LVNmglf+Dl8AAAAAQUIPAAAAAABSPbsEPTD2Xdn/sxOfjFot; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LBznDkj0aSsYn4VTKsJtVwAAAAC2Yr1qy9sW3bvEdRuR0rji; path=/; Domain=.contentful.com',
+  'nlbi_673446=wn6mKeAw+WScqUepKsJtVwAAAACrwkhnfnSL9w9oAWBm07W7; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=7N9BIchP23AqSA9OOoVtA2TmDl8AAAAAj3cbfVu6O+S165odFKT/Gw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TBceEc16XACM1itOOoVtA1f+Dl8AAAAAmWBfvDMKjcBfMqaN4gPRxg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5109,7 +5109,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '8-4529773-4529777 NNYN CT(86 86 0) RT(1594812004320 31) q(0 0 2 -1) r(3 3) U5'
+  '13-37645454-37645464 NNYN CT(94 94 0) RT(1594818135075 28) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5125,8 +5125,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:02.872Z",
-    "updatedAt": "2020-07-15T11:20:05.426Z",
+    "createdAt": "2020-07-15T13:02:14.028Z",
+    "updatedAt": "2020-07-15T13:02:16.333Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5135,8 +5135,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:20:03.568Z",
-    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
+    "publishedAt": "2020-07-15T13:02:14.591Z",
+    "firstPublishedAt": "2020-07-15T13:02:14.591Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5251,9 +5251,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:05 GMT',
+  'Wed, 15 Jul 2020 13:02:16 GMT',
   'etag',
-  'W/"15705685296220394012"',
+  'W/"3124554958373432794"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5271,21 +5271,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fc23fee1428480887c6bf9bcb96d746b',
+  'e445f8932160023f36c6bc2b4484ec74',
   'Content-Length',
-  '595',
+  '591',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=jOH9V5VrRHihh+8WaeOGFWXmDl8AAAAAQUIPAAAAAADWLhVR+GtmrISeSQUxNPYT; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=0WHSu7chSwqt+Z4wJbue/1j+Dl8AAAAAQUIPAAAAAAC7xU9CjHVjeA8lf+3FP6Fb; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=73GOH7rEOhOI92/CKsJtVwAAAAD8pJrQBT+KHOkgoeWv6I0y; path=/; Domain=.contentful.com',
+  'nlbi_673446=u7fZL6IkNSLxESUXKsJtVwAAAAADghUjAr3wwcxOlb94BUD4; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ERnRWrMU/GtJSQ9OOoVtA2XmDl8AAAAA4/oq1wxLQyElSTz2Ruw/yg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=snwHKiFcH11Z1ytOOoVtA1j+Dl8AAAAAd49YMJXRru5hMWP81nz3Dg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14423761-14423763 NNNN CT(94 94 0) RT(1594812004736 40) q(0 0 2 -1) r(4 4) U5'
+  '10-15252876-15252879 NNNN CT(87 87 0) RT(1594818135657 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5301,8 +5301,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:02.872Z",
-    "updatedAt": "2020-07-15T11:20:06.032Z",
+    "createdAt": "2020-07-15T13:02:14.028Z",
+    "updatedAt": "2020-07-15T13:02:17.049Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5311,8 +5311,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:06.032Z",
-    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
+    "publishedAt": "2020-07-15T13:02:17.049Z",
+    "firstPublishedAt": "2020-07-15T13:02:14.591Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5427,9 +5427,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:06 GMT',
+  'Wed, 15 Jul 2020 13:02:17 GMT',
   'etag',
-  'W/"2154243301793315147"',
+  'W/"1667057125296310311"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5447,21 +5447,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '59c25fa14197a1a8697211340d1e0a58',
+  'e74f7d2978837744d382864910d6ef11',
   'Content-Length',
-  '596',
+  '597',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=1uPHdRyBT5a9AjMiwmIyY2XmDl8AAAAAQUIPAAAAAAAuupnBq+Vcx3rbvw5WZ8nX; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=dc+2fjTeR92cFqzimdLzYlj+Dl8AAAAAQUIPAAAAAABdm74nYU5IFC9SxPVuLuoN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=z7ViIyCtyjDNssbMKsJtVwAAAACYDd2SThekNiqAYLPHcbgM; path=/; Domain=.contentful.com',
+  'nlbi_673446=WyHDOy92Lzj+uBuPKsJtVwAAAADY96PN8yb23Pc2WGIi6nvh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=zRcEfL6LxVWiSg9OOoVtA2XmDl8AAAAAApheIBn8HZWArn6HQgjZhA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=GkJWD7H07kpv2CtOOoVtA1j+Dl8AAAAAma2S/b6Qn4q5KTaCqBymwQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14423865-14423870 NNNN CT(93 94 0) RT(1594812005334 34) q(0 0 2 -1) r(5 5) U5'
+  '14-49422299-49422312 NNNN CT(88 89 0) RT(1594818136263 33) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5477,8 +5477,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "food",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:02.872Z",
-    "updatedAt": "2020-07-15T11:20:06.032Z",
+    "createdAt": "2020-07-15T13:02:14.028Z",
+    "updatedAt": "2020-07-15T13:02:17.049Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -5487,8 +5487,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:06.032Z",
-    "firstPublishedAt": "2020-07-15T11:20:03.567Z",
+    "publishedAt": "2020-07-15T13:02:17.049Z",
+    "firstPublishedAt": "2020-07-15T13:02:14.591Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -5603,9 +5603,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:06 GMT',
+  'Wed, 15 Jul 2020 13:02:17 GMT',
   'etag',
-  'W/"2154243301793315147"',
+  'W/"1667057125296310311"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5623,21 +5623,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '78fe2090b89b31123fbde199d9cfec33',
-  'Content-Length',
-  '596',
+  'a485cfcd2a0ee87b0b1ccb650556ed6b',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=IE4/CF1sT76E4ChFxbodJWbmDl8AAAAAQUIPAAAAAAAFsNlijCZp11G+InMZ5aQc; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=jIw8QDsuSpeWWNWGOhmXH1n+Dl8AAAAAQUIPAAAAAABhP4gHU0I1nnNbIvyl22XK; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=YG8aCRwKnnGDv9UoKsJtVwAAAADkMsSEuLCTtKDTLkJzngFN; path=/; Domain=.contentful.com',
+  'nlbi_673446=tomKJ59wNSBOpVPhKsJtVwAAAAC75LENpDkN/2TVk04xGylv; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=d0WZWE0Z0B3WSw9OOoVtA2bmDl8AAAAAVZtrLGXGID3CgEOwocda7Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+aJ4KzAjmnik2StOOoVtA1n+Dl8AAAAAK7IbCCmAWZCrYFN3tec//A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-23230472-23230476 NNNN CT(93 93 0) RT(1594812005952 34) q(0 0 2 -1) r(4 4) U5'
+  '10-15253078-15253081 NNNN CT(87 87 0) RT(1594818137028 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5674,7 +5674,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:07 GMT',
+  'Wed, 15 Jul 2020 13:02:18 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -5694,15 +5694,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5e8fefa2abb18f9202cb60de0bdd089c',
+  '6029a4d7a85978bb7a8eebd9eae888d3',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=uXjtw/P6S9OLQxmhNm8C8GbmDl8AAAAAQUIPAAAAAAAYKHU49gq9gNZPLYWFCB3E; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=soZJBPnbT1+hmZujzi2YOFn+Dl8AAAAAQUIPAAAAAABOV7vvajcSPSxpZ8bQAqWF; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RTkmfCpNlBoiw+1VKsJtVwAAAABHrPJMiB58CGxko1TDLVr+; path=/; Domain=.contentful.com',
+  'nlbi_673446=QgONU8rHkTQFgNG5KsJtVwAAAAAXUgYtOHtiHbo3d59kWyai; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=iz7XbJL4TC2RTQ9OOoVtA2bmDl8AAAAAEkq2YId3Cv/V6XhYHzNP3A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=jBUsd9/HKQMs2itOOoVtA1n+Dl8AAAAAXOWU4Z+c+B+v8soV4Nu8Yg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5710,7 +5710,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24190640-24190657 NNYN CT(88 87 0) RT(1594812006572 32) q(0 0 1 -1) r(3 3) U5'
+  '2-5488385-5488386 NNYN CT(93 94 0) RT(1594818137467 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5745,7 +5745,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:07 GMT',
+  'Wed, 15 Jul 2020 13:02:18 GMT',
   'etag',
   '"9177491833369070274"',
   'Server',
@@ -5765,15 +5765,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '8481905d96125310ff33ac510a8784be',
+  '8a6dc1eb8ad0842be5f6223396d72cf1',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=LrlEWdjARxibCU7fq2uQt2fmDl8AAAAAQUIPAAAAAAAuqCwNgV8Z99cPITVIzvQa; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=IH3qAr1OQj+iVMvrKTJIMFr+Dl8AAAAAQUIPAAAAAADQ6B1uWttKWl2r0A0Bh20A; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AMWqQ6sgjW0KLIMaKsJtVwAAAACvdtxOXGvMr57LiNWWhUe0; path=/; Domain=.contentful.com',
+  'nlbi_673446=n2uQZXX8/BEBf81eKsJtVwAAAABjmgFM4LLNrax8svdB8zUc; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=nzgRGXN9YEwCTw9OOoVtA2fmDl8AAAAAf7d+bOZcUj4tU6UgsqHaiQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=pkvFUdH+Phuj2itOOoVtA1r+Dl8AAAAArhYKs5WRYXiJ1wWeEPjzNg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5781,7 +5781,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24190879-24190884 NNYN CT(93 94 0) RT(1594812007182 32) q(0 0 2 -1) r(3 3) U5'
+  '10-15253177-15253181 NNYN CT(89 88 0) RT(1594818137912 26) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5822,8 +5822,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -5853,9 +5853,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:08 GMT',
+  'Wed, 15 Jul 2020 13:02:19 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -5875,7 +5875,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '3901bb0ba8f7a2dc183f157f10ce923e',
+  'de9a922c59132fa3762c5448cf0b1fcb',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -5887,11 +5887,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=11i//yMtT5mFqFM284qdmGjmDl8AAAAAQUIPAAAAAABadF/8r2RWuRkroeSZUBdU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/NNGNyUeQgOgqHdHI+t4V1r+Dl8AAAAAQUIPAAAAAABHqVZX5TtVlitFb0vDW5bR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=uAG1R9qMVSVen8wYKsJtVwAAAADvz7s5OBgVkHmf1Flw8nSn; path=/; Domain=.contentful.com',
+  'nlbi_673446=D7LdWhjHNWBs/cJLKsJtVwAAAABu1RVc5FTAA83h0tl/NosY; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=r0EvC1wLvl4pUA9OOoVtA2jmDl8AAAAA9FXqMJckT75tfbrQxnrW2g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=MWQDGJ6vJQsv2ytOOoVtA1r+Dl8AAAAAijQ/qHN0Mvaf7EXBGU3aSQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -5899,12 +5899,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '4-15464546-15464550 NNYN CT(93 98 0) RT(1594812007798 28) q(0 0 2 -1) r(3 3) U5'
+  '9-9985326-9985334 NNYN CT(93 94 0) RT(1594818138525 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/person', {"name":"Person","fields":[{"id":"age","name":"Age","type":"Number","required":true},{"id":"fullName","name":"Full name","type":"Symbol","required":true,"localized":true}],"description":"A content type for a person"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-15T11:20:08.929Z","updatedAt":"2020-07-15T11:20:08.929Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"person","type":"ContentType","createdAt":"2020-07-15T13:02:19.785Z","updatedAt":"2020-07-15T13:02:19.785Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Person","description":"A content type for a person","fields":[{"id":"age","name":"Age","type":"Number","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"fullName","name":"Full name","type":"Symbol","localized":true,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -5926,9 +5926,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:09 GMT',
+  'Wed, 15 Jul 2020 13:02:19 GMT',
   'etag',
-  '"5959611084888124152"',
+  '"12135527368835509795"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -5946,21 +5946,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '0adfb9eaa09f1642df0833a56c15749b',
+  'a228d85399ee9cf5bfee439ca1ce617c',
   'Content-Length',
   '1269',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=OGX9Y0uZQrKU111bQCV42GjmDl8AAAAAQUIPAAAAAADMqEw/hehgDSIQ+Rl16S9F; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Z8++e75oSqmxbFoqvFD871v+Dl8AAAAAQUIPAAAAAADwDX3CahmFdVOSDVM22ZF2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qvsLEpwVpgY9/ULaKsJtVwAAAADb+icqYSTi4LKyPGoPtUsh; path=/; Domain=.contentful.com',
+  'nlbi_673446=24L6bKZjXEb0+JXAKsJtVwAAAAATZgJyGsvc41MygeP0RPo/; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=LoI9dCf1AxOGUQ9OOoVtA2jmDl8AAAAAL39rpb5UX2TatSu1BIz44w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=24SzZjs0zQ4O3CtOOoVtA1v+Dl8AAAAAmoj3LfWoicBAGoJRzZJNTw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36002750-36002761 NNNN CT(86 87 0) RT(1594812008224 29) q(0 0 2 -1) r(5 5) U5'
+  '14-49422980-49422986 NNNN CT(87 86 0) RT(1594818138949 31) q(0 0 2 -1) r(7 7) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -5976,8 +5976,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:08.929Z",
-    "updatedAt": "2020-07-15T11:20:09.464Z",
+    "createdAt": "2020-07-15T13:02:19.785Z",
+    "updatedAt": "2020-07-15T13:02:20.378Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6001,8 +6001,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
-    "publishedAt": "2020-07-15T11:20:09.464Z",
+    "firstPublishedAt": "2020-07-15T13:02:20.378Z",
+    "publishedAt": "2020-07-15T13:02:20.378Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -6062,9 +6062,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:09 GMT',
+  'Wed, 15 Jul 2020 13:02:20 GMT',
   'etag',
-  'W/"291918392709008713"',
+  'W/"7948984258688487659"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6082,26 +6082,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '32ec926b13ca4ce9b6cd09fdd187085b',
-  'transfer-encoding',
-  'chunked',
+  '691d402765ea41ca47417f540b382a84',
+  'Content-Length',
+  '481',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=mRE5CgFdSoqsffyGDGo/yWnmDl8AAAAAQUIPAAAAAADmN5KdPf7slSPejdbbew7m; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=hdYjtIjtSFmcUDNPZ9vdxlz+Dl8AAAAAQUIPAAAAAADV22o1qH3pzy67rF+pkfxd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=AbHhc0tJEnl5gBEoKsJtVwAAAACbjO86QoB/zasEDls91h4m; path=/; Domain=.contentful.com',
+  'nlbi_673446=13cudnKaJUeloJY5KsJtVwAAAADqERMgYGbtMDuuuiBOIEve; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=+JRzKzzi4gW4Ug9OOoVtA2nmDl8AAAAArCz4oCYNOta4Xh7BtV6+iQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Je71AGghvGy13CtOOoVtA1z+Dl8AAAAActesMVZiDbms0ihQYIYm4Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15464655-15464660 NNNN CT(87 86 0) RT(1594812008826 27) q(0 0 2 -1) r(4 4) U5'
+  '8-4811040-4811044 NNNN CT(93 93 0) RT(1594818139707 26) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/animal', {"name":"Animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","required":true},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","required":false}],"description":"An animal"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-15T11:20:10.043Z","updatedAt":"2020-07-15T11:20:10.043Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"animal","type":"ContentType","createdAt":"2020-07-15T13:02:20.956Z","updatedAt":"2020-07-15T13:02:20.956Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Animal","description":"An animal","fields":[{"id":"species","name":"The species of the animal","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false},{"id":"isFurry","name":"Is this a furry animal","type":"Boolean","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -6123,9 +6123,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:10 GMT',
+  'Wed, 15 Jul 2020 13:02:21 GMT',
   'etag',
-  '"9570763304851875678"',
+  '"7726654324493584050"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6143,21 +6143,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '8dfd1bedd0ae81bed2dc35490b46bc64',
+  '37245f8a435d8dbfc974e7656f6aad9f',
   'Content-Length',
   '1292',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=JPjJAcDATDSwP6vlNJ6StWnmDl8AAAAAQUIPAAAAAADxassKqLZnUYftbJ7MyW2P; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/0Jit6B6S5GH9H4lAhcJGlz+Dl8AAAAAQUIPAAAAAAAQY0+wEiEfzZdNUXCAbAhR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=EXmgSGtm3TpdBCQpKsJtVwAAAACH2Pv7DeCE3FAa8QIMk0TW; path=/; Domain=.contentful.com',
+  'nlbi_673446=QgIzUZ+05huFtJnZKsJtVwAAAAAe/8vFfUHVia1PvjkLtLPc; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=q3IKbixCm0YVVA9OOoVtA2nmDl8AAAAARW1IpPsNcS/nzhB7d9Houg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=K/zXPONKhC9B3StOOoVtA1z+Dl8AAAAABNBW7NygF/Gq3wQPEHJ5OQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15464710-15464714 NNNN CT(93 94 0) RT(1594812009328 36) q(0 0 2 -1) r(5 5) U5'
+  '9-9985592-9985602 NNNN CT(86 86 0) RT(1594818140269 32) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6173,8 +6173,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:10.043Z",
-    "updatedAt": "2020-07-15T11:20:10.719Z",
+    "createdAt": "2020-07-15T13:02:20.956Z",
+    "updatedAt": "2020-07-15T13:02:21.492Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6198,8 +6198,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
-    "publishedAt": "2020-07-15T11:20:10.719Z",
+    "firstPublishedAt": "2020-07-15T13:02:21.492Z",
+    "publishedAt": "2020-07-15T13:02:21.492Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -6259,9 +6259,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:10 GMT',
+  'Wed, 15 Jul 2020 13:02:21 GMT',
   'etag',
-  'W/"7527256497393373562"',
+  'W/"723265815501465976"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6279,26 +6279,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '3e0655fed0c4480847edc6c818c397c8',
+  'bd564a6d995ec4cbeb9f97a4159655b0',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=HZOwP3cpQQWpcTi0Ie8LwGrmDl8AAAAAQUIPAAAAAABHRMOIVuOEBXgAx1hSPP+z; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=uK10QtWrTLmCiGGy6vzynl3+Dl8AAAAAQUIPAAAAAADHvkO5+nq46HrS/c0ecOUU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=X0zjWd8NnE9E/lHHKsJtVwAAAADhykgUiQWyBsg5wxg4NVul; path=/; Domain=.contentful.com',
+  'nlbi_673446=AVRxewZCpDDSzbo+KsJtVwAAAABjOEFbLQWvGAl8l7ToAFvQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=OddTWEXyIUKpVQ9OOoVtA2rmDl8AAAAAVtTnvFiFfnMXxnQl87eO4w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0vJKQx49jj+83StOOoVtA13+Dl8AAAAAaA+9xbLOesfcj1aODXPg4Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30374249-30374254 NNNN CT(93 87 0) RT(1594812010064 38) q(0 0 1 -1) r(4 4) U5'
+  '4-16160506-16160508 NNNN CT(92 88 0) RT(1594818140825 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/longexampletag', {"sys":{"id":"longexampletag","version":0},"name":"long example marketing"})
-  .reply(201, {"sys":{"id":"longexampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-15T11:20:11.344Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T11:20:11.344Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"long example marketing"}, [
+  .reply(201, {"sys":{"id":"longexampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-15T13:02:22.024Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T13:02:22.024Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"long example marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -6320,9 +6320,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:11 GMT',
+  'Wed, 15 Jul 2020 13:02:22 GMT',
   'etag',
-  '"18067423180685085321"',
+  '"3415582162521720568"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6332,29 +6332,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'ba7b0be5ce629b582c35ad02793ba3a0',
+  '53c867dd38f3dbe60f4879cfccdbcc8a',
   'Content-Length',
   '758',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=75oWYn1bRpSdjbYYGCuPrWvmDl8AAAAAQUIPAAAAAAAf2XNFWdQs3J1UrwABtnhY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Sh1cD3aITEeAIhShziW0ZV3+Dl8AAAAAQUIPAAAAAACJhVyzEJJXL9gFhLhx3uOO; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=VfypXGMeVD+9q6zXKsJtVwAAAACzHBodeEm2KL/W12pY6G3C; path=/; Domain=.contentful.com',
+  'nlbi_673446=IaqsEUdiy0P0tjL4KsJtVwAAAABNBqq11hKPeKCybWBwGtFh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=lbQKYQe3SSPZVg9OOoVtA2vmDl8AAAAAcDlOFx1WXAHv3iX6MKrZ3Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=rAjVcQFBiwdF3itOOoVtA13+Dl8AAAAASKxRQwW7TeB0ueLxNJ6Kvg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30374454-30374464 NNNN CT(93 93 0) RT(1594812010664 30) q(0 0 2 -1) r(4 4) U5'
+  '12-31848122-31848127 NNNN CT(94 94 0) RT(1594818141351 27) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6370,8 +6370,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:08.929Z",
-    "updatedAt": "2020-07-15T11:20:11.978Z",
+    "createdAt": "2020-07-15T13:02:19.785Z",
+    "updatedAt": "2020-07-15T13:02:22.695Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6380,8 +6380,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:20:09.464Z",
-    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
+    "publishedAt": "2020-07-15T13:02:20.378Z",
+    "firstPublishedAt": "2020-07-15T13:02:20.378Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6467,9 +6467,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:12 GMT',
+  'Wed, 15 Jul 2020 13:02:22 GMT',
   'etag',
-  'W/"16198056543532702191"',
+  'W/"4582105973935918236"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6479,29 +6479,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '102d77551bcb6e9a6e655d434bdc9f87',
+  'b78af2bdacc05ed658357892525de99a',
   'Content-Length',
   '520',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4E4y8oBMSs+wAf/UHmF3UGvmDl8AAAAAQUIPAAAAAADVYjyC2pvIYzhSc9ti+L8J; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sFFtBWXYTzWJX0uUAznt0l7+Dl8AAAAAQUIPAAAAAABKc4boe4gUdpRnZwUp9KdV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=HTtzZD9Z61EnsOA+KsJtVwAAAAB0uUxcChVvj7k0/+DtyAO6; path=/; Domain=.contentful.com',
+  'nlbi_673446=edi8HFNW7C09sJwsKsJtVwAAAADHuqwHk+FWfy3J7WYngd4C; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=glw7c6Nkb1Q0WA9OOoVtA2vmDl8AAAAA56TZ06TOHTKqLLNv1D3kDQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=NPbxaY7pAj4V3ytOOoVtA17+Dl8AAAAAwx5iBrXTeQBe9X0MAYoGjw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47485449-47485475 NNNN CT(90 89 0) RT(1594812011280 32) q(0 0 1 -1) r(4 4) U5'
+  '13-37647049-37647058 NNNN CT(87 87 0) RT(1594818142017 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6517,8 +6517,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:08.929Z",
-    "updatedAt": "2020-07-15T11:20:12.491Z",
+    "createdAt": "2020-07-15T13:02:19.785Z",
+    "updatedAt": "2020-07-15T13:02:23.275Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6527,8 +6527,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:12.491Z",
-    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
+    "publishedAt": "2020-07-15T13:02:23.275Z",
+    "firstPublishedAt": "2020-07-15T13:02:20.378Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6614,9 +6614,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:12 GMT',
+  'Wed, 15 Jul 2020 13:02:23 GMT',
   'etag',
-  'W/"11806803488069972852"',
+  'W/"17602000136126885945"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6634,21 +6634,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '573f1b24880e52a41d4750c29c70a442',
-  'Content-Length',
-  '526',
+  'fab7a503559531c5cdda45e2f1930079',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=21A1cuewT5eSxM3ug4kft2zmDl8AAAAAQUIPAAAAAACl3ndmNxU65EKOlH5vYOZC; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kwPjRuurR/CG8v1yavUBC1/+Dl8AAAAAQUIPAAAAAACBqVALYgD+4F8ZYBUNde1Z; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GTViWLBs/XEjB+7jKsJtVwAAAACha3Efdz6ltOYkvRXcJpqL; path=/; Domain=.contentful.com',
+  'nlbi_673446=yybaRFC+n1IyE6z8KsJtVwAAAABWfz763GVhSEsskyPh9EWe; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=t1V+Ys5jvmFfWQ9OOoVtA2zmDl8AAAAAfymfKoyjoYIIrDs0N7gCkA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ZWraBB1D8W3C3ytOOoVtA1/+Dl8AAAAA4+Yui2GmtxKtjMVz3+JbFg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '1-2861662-2861663 NNNN CT(93 94 0) RT(1594812011833 29) q(0 0 2 -1) r(4 4) U5'
+  '12-31848443-31848448 NNNN CT(86 87 0) RT(1594818142627 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6664,8 +6664,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:10.043Z",
-    "updatedAt": "2020-07-15T11:20:13.213Z",
+    "createdAt": "2020-07-15T13:02:20.956Z",
+    "updatedAt": "2020-07-15T13:02:23.852Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6674,8 +6674,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:20:10.719Z",
-    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
+    "publishedAt": "2020-07-15T13:02:21.492Z",
+    "firstPublishedAt": "2020-07-15T13:02:21.492Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6760,9 +6760,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:13 GMT',
+  'Wed, 15 Jul 2020 13:02:23 GMT',
   'etag',
-  'W/"15004543883460504939"',
+  'W/"11916790135775598039"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6772,29 +6772,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '45554341ca56d79c37cb295fe1d9ee60',
+  '9b976892b0b3adf505fd4eb9f98e7cf9',
   'Content-Length',
-  '508',
+  '511',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=9gJFt9tgTISmJ+gQH+9UVGzmDl8AAAAAQUIPAAAAAAAfbM2DUgbdL4jzPsnIpoqg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qxuy/QKXQtmsHHiGDY5ICF/+Dl8AAAAAQUIPAAAAAABcZ0mpDk/W7doX8xgQfQOd; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=qkFcBhhcLER8JuGWKsJtVwAAAAC+KBxeBN0y57I5+Od55dN7; path=/; Domain=.contentful.com',
+  'nlbi_673446=Q+X7ARJKXT158icXKsJtVwAAAACe7qm+nt2EnS/IMm/8NCwL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=SzduGMz44UQnWw9OOoVtA2zmDl8AAAAAjZ4M9E9Ret2xssv5lplhNQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=k481f5b9fRFr4CtOOoVtA1/+Dl8AAAAA5KqsIvUONlF4SNFtcrv7ng==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47485947-47485961 NNNN CT(97 89 0) RT(1594812012502 31) q(0 0 2 -1) r(4 4) U5'
+  '5-24174390-24174401 NNNN CT(93 94 0) RT(1594818143145 39) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6810,8 +6810,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:10.043Z",
-    "updatedAt": "2020-07-15T11:20:13.796Z",
+    "createdAt": "2020-07-15T13:02:20.956Z",
+    "updatedAt": "2020-07-15T13:02:24.645Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6820,8 +6820,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:13.796Z",
-    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
+    "publishedAt": "2020-07-15T13:02:24.645Z",
+    "firstPublishedAt": "2020-07-15T13:02:21.492Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -6906,9 +6906,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:13 GMT',
+  'Wed, 15 Jul 2020 13:02:24 GMT',
   'etag',
-  'W/"17502525284640369912"',
+  'W/"7268528354024221690"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -6918,29 +6918,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '50a27dfa638d427ae1ea08efaa46d047',
+  '056d938277dfe453e9538f3448233549',
   'Content-Length',
-  '516',
+  '517',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=7rTJJkL9Tm69rc54Pjw+B23mDl8AAAAAQUIPAAAAAAD8DRgQhv/Yn0RQgxTD9d3l; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=nlKX06AIQfe5LkVvdT7loWD+Dl8AAAAAQUIPAAAAAACzxR/RjqCo0S5jhfHDcA14; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=hfzdBSWq+WEToxUVKsJtVwAAAABxxzlxbA3mFKCvEIgweZ8I; path=/; Domain=.contentful.com',
+  'nlbi_673446=b59fa/ghS3NyD3HFKsJtVwAAAAC1SKL6YrKh0EFXZ3B+Y6IH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=esyHCFv6LSuEXA9OOoVtA23mDl8AAAAAHWP1OwPdtzVxbss1hcD2yQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=oS6xMEt26C9K4StOOoVtA2D+Dl8AAAAAblea1AQ/R8AiGh8BLWtyiA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36004235-36004244 NNNN CT(88 91 0) RT(1594812013128 32) q(0 0 2 -1) r(5 5) U5'
+  '7-13171320-13171322 NNNN CT(87 87 0) RT(1594818143992 32) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -6956,8 +6956,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "person",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:08.929Z",
-    "updatedAt": "2020-07-15T11:20:12.491Z",
+    "createdAt": "2020-07-15T13:02:19.785Z",
+    "updatedAt": "2020-07-15T13:02:23.275Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -6966,8 +6966,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:12.491Z",
-    "firstPublishedAt": "2020-07-15T11:20:09.464Z",
+    "publishedAt": "2020-07-15T13:02:23.275Z",
+    "firstPublishedAt": "2020-07-15T13:02:20.378Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -7053,9 +7053,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:14 GMT',
+  'Wed, 15 Jul 2020 13:02:25 GMT',
   'etag',
-  'W/"11806803488069972852"',
+  'W/"17602000136126885945"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7073,21 +7073,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '62c4f3537ad50bf4da9f3816278abd23',
+  '308a4d70626db24c4c25cba9c1278e7d',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ATIElFNqRb+gur9rRVG1oW7mDl8AAAAAQUIPAAAAAAAtDu7xxDz0rcPbgO9dJWq8; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=FoamjM/rQ8GMpDO6d1nUlmH+Dl8AAAAAQUIPAAAAAABhjFXvT+BI210obD2gSgaj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Jcj7DFlaVUIJ7dzAKsJtVwAAAAAFz7JeylLziAngdG3vHEr6; path=/; Domain=.contentful.com',
+  'nlbi_673446=ajmqbMNMuSrkOivHKsJtVwAAAAAGCobPT5jj2NTsdJy3l1mj; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Ak5fYlOMWHquXQ9OOoVtA27mDl8AAAAAIYuhcVXshCuER4+hDlz7Ew==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=uZR8C1ASPnza4StOOoVtA2H+Dl8AAAAARN+H9ToSGlsn779a3ywBhg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9347233-9347237 NNNN CT(86 87 0) RT(1594812013738 29) q(0 0 2 -1) r(4 4) U5'
+  '9-9986158-9986163 NNNN CT(85 88 0) RT(1594818144671 25) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7103,8 +7103,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "animal",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:10.043Z",
-    "updatedAt": "2020-07-15T11:20:13.796Z",
+    "createdAt": "2020-07-15T13:02:20.956Z",
+    "updatedAt": "2020-07-15T13:02:24.645Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7113,8 +7113,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:13.796Z",
-    "firstPublishedAt": "2020-07-15T11:20:10.719Z",
+    "publishedAt": "2020-07-15T13:02:24.645Z",
+    "firstPublishedAt": "2020-07-15T13:02:21.492Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -7199,9 +7199,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:15 GMT',
+  'Wed, 15 Jul 2020 13:02:25 GMT',
   'etag',
-  'W/"17502525284640369912"',
+  'W/"7268528354024221690"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7219,21 +7219,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '6ac6c554e41d2a29dc9b849b50b50223',
-  'Content-Length',
-  '516',
+  'e52504831bd2055125936335280296a3',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Kz1WBE5NQM+k9VSvAPDn6G7mDl8AAAAAQUIPAAAAAADBYiz0uQdbTfvv+TL5IEty; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=DS9QWFLkRruf1+30aUKZkGH+Dl8AAAAAQUIPAAAAAAAZ4hSxcyGJH3yfFPJea/0G; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=n0NretSQyg1SNrfOKsJtVwAAAAAabj0kQojzUMKGxtMEfMSR; path=/; Domain=.contentful.com',
+  'nlbi_673446=OaGUfmp5wDWO8/mPKsJtVwAAAAAwoedvp8j+VdcEmyoPk+eO; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ZFX4FKlWBm5WXw9OOoVtA27mDl8AAAAAowPcQQsIj0XComwNyEVltQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=tJy9dr6lGG9R4itOOoVtA2H+Dl8AAAAA6Q8z55Z9B7cQbPxusiG6xw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9347322-9347330 NNNN CT(93 94 0) RT(1594812014350 28) q(0 0 2 -1) r(5 5) U5'
+  '14-49424797-49424801 NNNN CT(96 89 0) RT(1594818145119 37) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7270,8 +7270,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-15T11:20:11.344Z",
-    "updatedAt": "2020-07-15T11:20:11.344Z",
+    "createdAt": "2020-07-15T13:02:22.024Z",
+    "updatedAt": "2020-07-15T13:02:22.024Z",
     "version": 1
   },
   "name": "long example marketing"
@@ -7298,9 +7298,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:15 GMT',
+  'Wed, 15 Jul 2020 13:02:26 GMT',
   'etag',
-  '"11042076232677178575"',
+  '"1015709951502253148"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7318,15 +7318,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '67982c1076afb344d2f89ce909c37826',
+  '9ee260bb16b9459e093fb4df081b2707',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=zUX0YMHMTu2T1T3HZDQI52/mDl8AAAAAQUIPAAAAAAADintyrkLxLXhMkMBvkr/G; expires=Wed, 14 Jul 2021 14:42:28 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=GR4Ob/tQRuC4G19uyCMKvWL+Dl8AAAAAQUIPAAAAAAAq9EjRCcaHkjJv/lHK6frB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=IplIXOY5ahBFra7OKsJtVwAAAADXe3DZqPXmRluTdRy9SeTB; path=/; Domain=.contentful.com',
+  'nlbi_673446=OCsjSUXNAg0WR1gOKsJtVwAAAABazxUFRI8jSLjd5HUdJyGL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=3t9xWorniXuQYA9OOoVtA2/mDl8AAAAAcAiVYkGlGRJc1j8EiOeQqg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=23+/aAMlByfZ4itOOoVtA2L+Dl8AAAAAl5IH4sezi5V/CI3iirqcWA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7334,7 +7334,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '0-1831915-1831916 NNYN CT(93 94 0) RT(1594812014972 30) q(0 0 1 -1) r(3 3) U5'
+  '12-31849081-31849092 NNYN CT(86 87 0) RT(1594818145695 31) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7359,8 +7359,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "person",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:20:08.929Z",
-        "updatedAt": "2020-07-15T11:20:12.491Z",
+        "createdAt": "2020-07-15T13:02:19.785Z",
+        "updatedAt": "2020-07-15T13:02:23.275Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7369,8 +7369,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-15T11:20:12.491Z",
-        "firstPublishedAt": "2020-07-15T11:20:09.464Z",
+        "publishedAt": "2020-07-15T13:02:23.275Z",
+        "firstPublishedAt": "2020-07-15T13:02:20.378Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -7458,9 +7458,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:16 GMT',
+  'Wed, 15 Jul 2020 13:02:27 GMT',
   'etag',
-  'W/"13870320801103358832"',
+  'W/"1748795674730001863"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7470,34 +7470,34 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'ffff1d76f5bf1cca5db5eba52560f9b2',
+  'e7efd608816d78193a477ec53a4f7f9c',
   'Content-Length',
-  '589',
+  '587',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=dOAveraBTau7aDwtk11/p2/mDl8AAAAAQUIPAAAAAABu05tSXJJDPTSRnDuR5ONN; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rHn46PYXTuy89bUsGTQG/mL+Dl8AAAAAQUIPAAAAAABZeDgv2ZY/VkKCvu8ibNBU; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=mX50XbIuZmbMKxjuKsJtVwAAAACluQudndUM77JDSz/6Ygcq; path=/; Domain=.contentful.com',
+  'nlbi_673446=W43KY6YZgWssafT4KsJtVwAAAAB7rsgVXiNetKmNI1h8xLLw; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=LSKEQmvgIk0hYg9OOoVtA2/mDl8AAAAASxMH13GkSrT/XcKmmBmk3w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ACPhXzj7rFpz4ytOOoVtA2L+Dl8AAAAAyBBeUNMcpHjECKPKRAqAjg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47487004-47487015 NNNN CT(88 110 0) RT(1594812015577 38) q(0 0 2 -1) r(3 3) U5'
+  '5-24174655-24174662 NNNN CT(94 96 0) RT(1594818146309 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogpost', {"name":"blog post","fields":[{"name":"title","id":"title","type":"Symbol"},{"name":"category","id":"category","type":"Symbol"}]})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-15T11:20:16.967Z","updatedAt":"2020-07-15T11:20:16.967Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogpost","type":"ContentType","createdAt":"2020-07-15T13:02:27.642Z","updatedAt":"2020-07-15T13:02:27.642Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"blog post","description":null,"fields":[{"id":"title","name":"title","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false},{"id":"category","name":"category","type":"Symbol","localized":false,"required":false,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -7519,9 +7519,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:17 GMT',
+  'Wed, 15 Jul 2020 13:02:27 GMT',
   'etag',
-  '"2075389067367576010"',
+  '"8871983452790024519"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7531,29 +7531,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'ccd988b45d1e6178cb2ce0ac0b43ccc2',
+  'a55ddc4c83a4c995b10b033da233fc78',
   'Content-Length',
   '1255',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=UwE+gf6mTzCvBQ217HJITnDmDl8AAAAAQUIPAAAAAABndGN6B0wamNJF9oFKYgVF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lxKw2THbT7KP2AnRUg0dGGP+Dl8AAAAAQUIPAAAAAAB02ENcJdLCOup90T3Wx5ri; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=h1eeVmh8xli6XYevKsJtVwAAAAAn2mZ/zfqSOAHrt1QATkK4; path=/; Domain=.contentful.com',
+  'nlbi_673446=61HOcMyO6ydPsY9+KsJtVwAAAABnJXj6mfdHzvtR4bOU5X3+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=VSiKcHM8z3rLYw9OOoVtA3DmDl8AAAAAXmCTLBCGYUEVgW8qjBSTlw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=MSeYakHLqEkX5CtOOoVtA2P+Dl8AAAAA5bm2Br5ek9bsNu+D3dJtlA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30375942-30375952 NNNN CT(94 115 0) RT(1594812016207 43) q(0 0 2 -1) r(5 5) U5'
+  '8-4811548-4811549 NNNN CT(86 87 0) RT(1594818146929 28) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7569,8 +7569,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogpost",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:16.967Z",
-    "updatedAt": "2020-07-15T11:20:17.577Z",
+    "createdAt": "2020-07-15T13:02:27.642Z",
+    "updatedAt": "2020-07-15T13:02:28.204Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7594,8 +7594,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:20:17.577Z",
-    "publishedAt": "2020-07-15T11:20:17.577Z",
+    "firstPublishedAt": "2020-07-15T13:02:28.204Z",
+    "publishedAt": "2020-07-15T13:02:28.204Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -7655,9 +7655,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:17 GMT',
+  'Wed, 15 Jul 2020 13:02:28 GMT',
   'etag',
-  'W/"1280240300566591262"',
+  'W/"18094724980261240706"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7675,21 +7675,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5800d66aa431dac3348635cd5c0359a1',
+  'c0920475cc63bd707d5da5f07cb8b21a',
   'Content-Length',
   '445',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=qHqTU7L6TM+ZmyCaIn/UrnHmDl8AAAAAQUIPAAAAAADIXKhpOU31hiXjw21kigAC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=scpqwORrT+S//X4tJ3Q0omT+Dl8AAAAAQUIPAAAAAAAUqB+C/po47vCirds/U9zH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=+hs+E2hwel7fRtuQKsJtVwAAAACZ1ovNQYjkCsNLgtWMzXzh; path=/; Domain=.contentful.com',
+  'nlbi_673446=/bkBFY/wxEFeao4iKsJtVwAAAABvsZqIfx5e3UU+ZQe9yqcd; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=fdZoK8WgFVEaZQ9OOoVtA3HmDl8AAAAAgtVles9A4fW9SKzicS3u9Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=7gd4QWOzbgS+5CtOOoVtA2T+Dl8AAAAAAK6ZxSD2ItshDOjHlZjbbg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36005389-36005403 NNNN CT(93 88 0) RT(1594812016916 35) q(0 0 2 -1) r(4 4) U5'
+  '11-25368706-25368725 NNNN CT(93 94 0) RT(1594818147541 29) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7706,10 +7706,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "5ACaSqp8quE2VUdm4ti00Z",
+    "id": "6ZAsrS64KnVmoij5lpKuV7",
     "type": "Entry",
-    "createdAt": "2020-07-15T11:20:18.319Z",
-    "updatedAt": "2020-07-15T11:20:18.320Z",
+    "createdAt": "2020-07-15T13:02:28.969Z",
+    "updatedAt": "2020-07-15T13:02:28.969Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -7769,125 +7769,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:18 GMT',
+  'Wed, 15 Jul 2020 13:02:29 GMT',
   'etag',
-  '"17304987540903161622"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '9',
-  'X-Contentful-Request-Id',
-  'a4ad3085edc92b48c90c2135b5cec4ef',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=tjKFWfIhRNWD2j368U6o+XLmDl8AAAAAQUIPAAAAAACl9fma1B9KilJq54prme1q; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=0XazKKbIzhp9VpSJKsJtVwAAAADv+UWAyUcSBvySZJ9zyi7b; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=46jDYfu2VDiqZg9OOoVtA3LmDl8AAAAAycOOLXpx6AzgjlsoLZONjQ==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  
-  
-  'Transfer-Encoding',
-  'chunked',
-  'X-Iinfo',
-  '13-36005567-36005573 NNYN CT(86 92 0) RT(1594812017520 33) q(0 0 2 -1) r(6 6) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .post('/spaces/bohepdihyxin/environments/env-integration/entries', {"fields":{"title":{"en-US":"hello!"}}})
-  .reply(201, {
-  "metadata": {
-    "tags": []
-  },
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "551boZKK9dmBDwpfWaQmd5",
-    "type": "Entry",
-    "createdAt": "2020-07-15T11:20:19.041Z",
-    "updatedAt": "2020-07-15T11:20:19.041Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 0,
-    "version": 1,
-    "contentType": {
-      "sys": {
-        "type": "Link",
-        "linkType": "ContentType",
-        "id": "blogpost"
-      }
-    }
-  },
-  "fields": {
-    "title": {
-      "en-US": "hello!"
-    }
-  }
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 15 Jul 2020 11:20:19 GMT',
-  'etag',
-  '"1435225799643613627"',
+  '"4064637692568559922"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -7905,15 +7789,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'e5c84dae3c60b4603df124273c8f500a',
+  '3be1115d7e93eab8264d53e211975eb8',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Etvsb6O8Q1e5AixlGsa8OXLmDl8AAAAAQUIPAAAAAABoN0xvtFMO6t7hiiI0KYqx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=I0zB7OuEQC2qxMqBVqtSZWT+Dl8AAAAAQUIPAAAAAAAls3EW8UVR+wx7yFGzy/5m; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=SntZO2fdOW7vwwbOKsJtVwAAAADS3xamOVzwVR2S7PNU3oEQ; path=/; Domain=.contentful.com',
+  'nlbi_673446=JflhScQTPgCQqGh5KsJtVwAAAABuCJmFZIHHUb6SHiQqHyPU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=h+TKVh2T+VZGaA9OOoVtA3LmDl8AAAAAq8+mh5bA7MOtf6xU09s9+w==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1bQFaRc6uh6a5StOOoVtA2T+Dl8AAAAANNfpQcyQDTNNPt607a8Dvg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -7921,7 +7805,123 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-36005780-36005790 NNYN CT(86 87 0) RT(1594812018350 32) q(0 0 2 -1) r(5 5) U5'
+  '10-15254535-15254539 NNYN CT(93 93 0) RT(1594818148152 28) q(0 0 2 -1) r(6 6) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .post('/spaces/bohepdihyxin/environments/env-integration/entries', {"fields":{"title":{"en-US":"hello!"}}})
+  .reply(201, {
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "Kl6v7ODtfswKoFdnMpVDI",
+    "type": "Entry",
+    "createdAt": "2020-07-15T13:02:29.668Z",
+    "updatedAt": "2020-07-15T13:02:29.668Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 0,
+    "version": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "blogpost"
+      }
+    }
+  },
+  "fields": {
+    "title": {
+      "en-US": "hello!"
+    }
+  }
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 13:02:29 GMT',
+  'etag',
+  '"154668046613230628"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  'e606e5551ca5ebc13874a6b536ecd033',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=OeORsMzQTMmOq0tRq/8e5GX+Dl8AAAAAQUIPAAAAAACy1MfhZtC3iozDS58I9mVY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=kw7qRHpRpSWamxo+KsJtVwAAAACN34D/axK4Iu0bowgTslYO; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=nm/6G44M3DZs5itOOoVtA2X+Dl8AAAAA+75nk08+T7EXgB4MdsL6ow==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  
+  
+  'Transfer-Encoding',
+  'chunked',
+  'X-Iinfo',
+  '14-49425837-49425847 NNYN CT(93 94 0) RT(1594818148861 29) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -7946,8 +7946,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogpost",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:20:16.967Z",
-        "updatedAt": "2020-07-15T11:20:17.577Z",
+        "createdAt": "2020-07-15T13:02:27.642Z",
+        "updatedAt": "2020-07-15T13:02:28.204Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -7956,8 +7956,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-15T11:20:17.577Z",
-        "firstPublishedAt": "2020-07-15T11:20:17.577Z",
+        "publishedAt": "2020-07-15T13:02:28.204Z",
+        "firstPublishedAt": "2020-07-15T13:02:28.204Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8034,9 +8034,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:19 GMT',
+  'Wed, 15 Jul 2020 13:02:30 GMT',
   'etag',
-  'W/"10960682778969613798"',
+  'W/"17558057478257365994"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8054,21 +8054,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '72d21e47b46d95fc091e4d0c6f5c8836',
-  'Content-Length',
-  '516',
+  '0e1caa8deb7b05081b464fcc8f623b65',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=iKGOrSNHR3uTL0aHc7mML3PmDl8AAAAAQUIPAAAAAABy1hrkmpWIt15W7FgsEst1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=qZh0JOazQX2ESHd4E5BcX2X+Dl8AAAAAQUIPAAAAAABgvHdq+lBgAyFsGY9qD+T1; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=DmrPYOboUHfayJkQKsJtVwAAAAAPPYNo0HIlARZaRzjrLLzp; path=/; Domain=.contentful.com',
+  'nlbi_673446=IagidbtvjyFBmzQOKsJtVwAAAADWORzdd2hHX2idb6EgH/s2; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=AuNGPywGNENcaQ9OOoVtA3PmDl8AAAAAwl4Csllt/tpqwbU1kK1IIA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ZrK6PlosyFzv5itOOoVtA2X+Dl8AAAAALkASDQ9dWtMxRgcSPchcSg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47488189-47488195 NNNN CT(87 87 0) RT(1594812018972 37) q(0 0 1 -1) r(3 3) U5'
+  '11-25369095-25369099 NNNN CT(87 86 0) RT(1594818149529 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8094,10 +8094,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "5ACaSqp8quE2VUdm4ti00Z",
+        "id": "6ZAsrS64KnVmoij5lpKuV7",
         "type": "Entry",
-        "createdAt": "2020-07-15T11:20:18.319Z",
-        "updatedAt": "2020-07-15T11:20:18.320Z",
+        "createdAt": "2020-07-15T13:02:28.969Z",
+        "updatedAt": "2020-07-15T13:02:28.969Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8147,10 +8147,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "551boZKK9dmBDwpfWaQmd5",
+        "id": "Kl6v7ODtfswKoFdnMpVDI",
         "type": "Entry",
-        "createdAt": "2020-07-15T11:20:19.041Z",
-        "updatedAt": "2020-07-15T11:20:19.041Z",
+        "createdAt": "2020-07-15T13:02:29.668Z",
+        "updatedAt": "2020-07-15T13:02:29.668Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8214,9 +8214,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:20 GMT',
+  'Wed, 15 Jul 2020 13:02:30 GMT',
   'etag',
-  'W/"14800598204800972611"',
+  'W/"17886444803173761713"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8226,29 +8226,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'd831905786fba24895bb28bc3b1ab084',
+  'f15ea49306eadcc298f78db099270c25',
   'Content-Length',
-  '480',
+  '478',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=+cZB+uUZQWOrHod1/D2ZnXPmDl8AAAAAQUIPAAAAAABbijqZzAD5Yu0NJcj+UCJP; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=be/9J4/8QQujRCTmURBKRWb+Dl8AAAAAQUIPAAAAAAArL6NOpKS21vMJVKmJ93Dd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=h6IrY5YviwsEPLyzKsJtVwAAAABJxdmvqxPB5n2lGZX5IVSJ; path=/; Domain=.contentful.com',
+  'nlbi_673446=Q+auVOEwbh2xsBZ7KsJtVwAAAAABG120lZPiKquWgRzWt9Yb; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=d6lveGYcUE68ag9OOoVtA3PmDl8AAAAAbLuoTqdH025A3sHLO470QQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=mnHKUyS5ykKN5ytOOoVtA2b+Dl8AAAAAVFeseK+67KTkK82n2ngD9w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36006147-36006164 NNNN CT(88 89 0) RT(1594812019469 35) q(0 0 1 -1) r(4 4) U5'
+  '14-49426146-49426158 NNNN CT(93 101 0) RT(1594818149997 60) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8289,8 +8289,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -8320,9 +8320,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:20 GMT',
+  'Wed, 15 Jul 2020 13:02:31 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -8334,15 +8334,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  'd9e7ddea77c386e2ebd9a79172c77bae',
+  '3143cc38d30cfb8f927d2c08565bb616',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -8354,11 +8354,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Co8GGFhpQoKdXpbbPKPS/HTmDl8AAAAAQUIPAAAAAAC4jwSiWl0BIh6fsv4Cs5e9; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lxMxgfaQR7GJte6ZHp9CcGb+Dl8AAAAAQUIPAAAAAAALuBQectAivIT1u9OUTGkW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Ww5peaHnoyQpvEt3KsJtVwAAAAAanOdenLBysAu5w38nsFIO; path=/; Domain=.contentful.com',
+  'nlbi_673446=Gyz1HbcapRbr7792KsJtVwAAAABO1VfbGGHaRAiZmB1S/wsu; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=quQjSPWKuSbJaw9OOoVtA3TmDl8AAAAAtgUWQz/1TQc1q13AGlKcQw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=L1RIVemctgY56CtOOoVtA2b+Dl8AAAAA9PcW8OzMFdH4TtOQI4RdBw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -8366,11 +8366,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24193980-24193991 NNYN CT(86 86 0) RT(1594812020186 35) q(0 0 1 -1) r(2 2) U5'
+  '11-25369306-25369310 NNYN CT(93 95 0) RT(1594818150605 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/5ACaSqp8quE2VUdm4ti00Z', {"sys":{"id":"5ACaSqp8quE2VUdm4ti00Z","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/6ZAsrS64KnVmoij5lpKuV7', {"sys":{"id":"6ZAsrS64KnVmoij5lpKuV7","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8383,10 +8383,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "5ACaSqp8quE2VUdm4ti00Z",
+    "id": "6ZAsrS64KnVmoij5lpKuV7",
     "type": "Entry",
-    "createdAt": "2020-07-15T11:20:18.319Z",
-    "updatedAt": "2020-07-15T11:20:21.235Z",
+    "createdAt": "2020-07-15T13:02:28.969Z",
+    "updatedAt": "2020-07-15T13:02:31.716Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8451,9 +8451,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:21 GMT',
+  'Wed, 15 Jul 2020 13:02:31 GMT',
   'etag',
-  'W/"3045145916106052823"',
+  'W/"10969531000775168979"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8463,33 +8463,33 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '6970d621a655fd6d2f86842c6dd22c42',
+  '7e9ad74b492f8f7a15bbbbbb68829b80',
   'Content-Length',
-  '386',
+  '388',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=FmekybhvRE6a+Mgwuw2PAnTmDl8AAAAAQUIPAAAAAADr/277nLwlXOCc0QZ+oXMv; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=xw13XtaJS9qcks/YKfdC/Wf+Dl8AAAAAQUIPAAAAAABZKgHiXhX8v40E12eKL/Va; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=kPnxbEKQvGWrhnRCKsJtVwAAAACZY1qx6nXzyrk+LPoHUDfF; path=/; Domain=.contentful.com',
+  'nlbi_673446=G4smIZDmiFiNPpMrKsJtVwAAAADT2HKEnqlnjA7+qQaof8Iz; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=DJh8EgLo0FLUbA9OOoVtA3TmDl8AAAAACWpoqojgf/r9a4P69qsRyw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ikKbOgxvVwsE6StOOoVtA2f+Dl8AAAAAy5GQ3R4GAfEtSKsMTMF1oQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '1-2861848-2861850 NNNN CT(88 88 0) RT(1594812020568 27) q(0 0 2 -1) r(4 4) U5'
+  '13-37648961-37648977 NNNN CT(94 93 0) RT(1594818151019 35) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/5ACaSqp8quE2VUdm4ti00Z/published')
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/6ZAsrS64KnVmoij5lpKuV7/published')
   .reply(200, {
   "metadata": {
     "tags": []
@@ -8502,10 +8502,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "bohepdihyxin"
       }
     },
-    "id": "5ACaSqp8quE2VUdm4ti00Z",
+    "id": "6ZAsrS64KnVmoij5lpKuV7",
     "type": "Entry",
-    "createdAt": "2020-07-15T11:20:18.319Z",
-    "updatedAt": "2020-07-15T11:20:21.715Z",
+    "createdAt": "2020-07-15T13:02:28.969Z",
+    "updatedAt": "2020-07-15T13:02:32.592Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -8514,8 +8514,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 2,
-    "publishedAt": "2020-07-15T11:20:21.715Z",
-    "firstPublishedAt": "2020-07-15T11:20:21.715Z",
+    "publishedAt": "2020-07-15T13:02:32.592Z",
+    "firstPublishedAt": "2020-07-15T13:02:32.592Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -8580,128 +8580,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:21 GMT',
+  'Wed, 15 Jul 2020 13:02:32 GMT',
   'etag',
-  'W/"12097007725014896026"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '8',
-  'X-Contentful-Request-Id',
-  '8db7a0766c002953728d459e6dfbca89',
-  'Content-Length',
-  '415',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=wSWkvw2EQN62y293Mv4O73XmDl8AAAAAQUIPAAAAAADNXIHOhUbRz7j2C57vHBXw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=jaq+V/f+xWEamRP+KsJtVwAAAADLAZXoy7p12HYkoxbn8zfS; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=9phQYmYFdBn8bQ9OOoVtA3XmDl8AAAAAdcNzjzyGxehazDJgUREliw==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '13-36006609-36006616 NNNN CT(89 87 0) RT(1594812021040 34) q(0 0 2 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/551boZKK9dmBDwpfWaQmd5', {"sys":{"id":"551boZKK9dmBDwpfWaQmd5","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
-  .reply(200, {
-  "metadata": {
-    "tags": []
-  },
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "551boZKK9dmBDwpfWaQmd5",
-    "type": "Entry",
-    "createdAt": "2020-07-15T11:20:19.041Z",
-    "updatedAt": "2020-07-15T11:20:22.321Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 0,
-    "version": 2,
-    "contentType": {
-      "sys": {
-        "type": "Link",
-        "linkType": "ContentType",
-        "id": "blogpost"
-      }
-    }
-  },
-  "fields": {
-    "title": {
-      "en-US": "hello!"
-    },
-    "category": {
-      "en-US": "hello!"
-    }
-  }
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 15 Jul 2020 11:20:22 GMT',
-  'etag',
-  'W/"12812563658042893928"',
+  'W/"18048731619830252277"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -8719,150 +8600,269 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '69f265db5fc5ae0f868b9d8d333c1215',
-  'Content-Length',
-  '387',
-  'Connection',
-  'Close',
-  'Set-Cookie',
-  'visid_incap_673446=uedokmXGQ+CyQ97qQ5xEZ3bmDl8AAAAAQUIPAAAAAABMjpjHpvrH6PNJtkhEJTor; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'nlbi_673446=KtPEbr+2L3hdqgqoKsJtVwAAAABARTjbZ8oGi6IVDvDiAtfQ; path=/; Domain=.contentful.com',
-  'Set-Cookie',
-  'incap_ses_247_673446=1zWbWseHC0oqbw9OOoVtA3bmDl8AAAAAD8iKhMt+Willd7+r1zhacg==; path=/; Domain=.contentful.com',
-  'X-CDN',
-  'Incapsula',
-  'X-Iinfo',
-  '9-9348488-9348492 NNNN CT(88 89 0) RT(1594812021627 31) q(0 0 2 -1) r(4 4) U5'
-]);
-
-nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .put('/spaces/bohepdihyxin/environments/env-integration/entries/551boZKK9dmBDwpfWaQmd5/published')
-  .reply(200, {
-  "metadata": {
-    "tags": []
-  },
-  "sys": {
-    "space": {
-      "sys": {
-        "type": "Link",
-        "linkType": "Space",
-        "id": "bohepdihyxin"
-      }
-    },
-    "id": "551boZKK9dmBDwpfWaQmd5",
-    "type": "Entry",
-    "createdAt": "2020-07-15T11:20:19.041Z",
-    "updatedAt": "2020-07-15T11:20:22.826Z",
-    "environment": {
-      "sys": {
-        "id": "env-integration",
-        "type": "Link",
-        "linkType": "Environment"
-      }
-    },
-    "publishedVersion": 2,
-    "publishedAt": "2020-07-15T11:20:22.826Z",
-    "firstPublishedAt": "2020-07-15T11:20:22.826Z",
-    "createdBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "updatedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "publishedCounter": 1,
-    "version": 3,
-    "publishedBy": {
-      "sys": {
-        "type": "Link",
-        "linkType": "User",
-        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
-      }
-    },
-    "contentType": {
-      "sys": {
-        "type": "Link",
-        "linkType": "ContentType",
-        "id": "blogpost"
-      }
-    }
-  },
-  "fields": {
-    "title": {
-      "en-US": "hello!"
-    },
-    "category": {
-      "en-US": "hello!"
-    }
-  }
-}
-, [
-  'Access-Control-Allow-Headers',
-  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
-  'Access-Control-Allow-Methods',
-  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
-  'Access-Control-Allow-Origin',
-  '*',
-  'Access-Control-Expose-Headers',
-  'Etag',
-  'Access-Control-Max-Age',
-  '1728000',
-  'cf-environment-id',
-  'env-integration',
-  'cf-environment-uuid',
-  'env-integration',
-  'cf-space-id',
-  'bohepdihyxin',
-  
-  
-  'Content-Type',
-  'application/vnd.contentful.management.v1+json',
-  'Contentful-Api',
-  'cma',
-  'Date',
-  'Wed, 15 Jul 2020 11:20:22 GMT',
-  'etag',
-  'W/"16019902109207386826"',
-  'Server',
-  'Contentful',
-  'Strict-Transport-Security',
-  'max-age=15768000',
-  'X-Content-Type-Options',
-  'nosniff',
-  'X-Contentful-RateLimit-Hour-Limit',
-  '36000',
-  'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
-  'X-Contentful-RateLimit-Reset',
-  '0',
-  'X-Contentful-RateLimit-Second-Limit',
-  '10',
-  'X-Contentful-RateLimit-Second-Remaining',
-  '8',
-  'X-Contentful-Request-Id',
-  '9c4bc8561c34c4329fbbd46e87e50143',
+  '9fdac052e1534b41806cda632ecefe2a',
   'Content-Length',
   '417',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=5i614lhsSX2z3ce+S3cDY3bmDl8AAAAAQUIPAAAAAACsJM7DhQBA/yWasfsYhv2h; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sO9Xb0I4R9y4AHaWJtBSNWj+Dl8AAAAAQUIPAAAAAADEuSbbSz/MG68ztcYW3LmY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=ITv0dl1R4nIME+q/KsJtVwAAAAC2UtenwHHrf76U2Ixjd0Qr; path=/; Domain=.contentful.com',
+  'nlbi_673446=0R/BOXA0NEhUbbxfKsJtVwAAAABcWMViNlVF+BYLcQrct+SE; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=H/wnVa3wz29NcA9OOoVtA3bmDl8AAAAAcj1XWAL8ZdvQvk6jAQH2KQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=x3qbTwtQOSK36StOOoVtA2j+Dl8AAAAA1X/+vTrX+mtGHGpUCBB8ew==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '5-23233195-23233204 NNNN CT(93 93 0) RT(1594812022140 37) q(0 0 2 -1) r(5 5) U5'
+  '14-49426681-49426691 NNNN CT(92 88 0) RT(1594818151835 30) q(0 0 2 -1) r(6 6) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/Kl6v7ODtfswKoFdnMpVDI', {"sys":{"id":"Kl6v7ODtfswKoFdnMpVDI","version":1,"contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"blogpost"}}},"fields":{"title":{"en-US":"hello!"},"category":{"en-US":"hello!"}}})
+  .reply(200, {
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "Kl6v7ODtfswKoFdnMpVDI",
+    "type": "Entry",
+    "createdAt": "2020-07-15T13:02:29.668Z",
+    "updatedAt": "2020-07-15T13:02:33.181Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 0,
+    "version": 2,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "blogpost"
+      }
+    }
+  },
+  "fields": {
+    "title": {
+      "en-US": "hello!"
+    },
+    "category": {
+      "en-US": "hello!"
+    }
+  }
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 13:02:33 GMT',
+  'etag',
+  'W/"12404986790987890134"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35999',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '9',
+  'X-Contentful-Request-Id',
+  '3867660c59b82e5891b68184f5413e53',
+  'Content-Length',
+  '389',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=wH0+8LRdQsa+9kLh+GY6+Gj+Dl8AAAAAQUIPAAAAAAAtHhLjFnf4E+l9q7YU34gJ; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=0V0qeaLBnWhsZTaNKsJtVwAAAAAy+gr2xbjZ35sbhezxSoy2; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=mAhIB2FS8B1t6itOOoVtA2j+Dl8AAAAAnxleKgpT9XO2ujCX48biaA==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '5-24175279-24175280 NNNN CT(94 93 0) RT(1594818152480 24) q(0 0 1 -1) r(4 4) U5'
+]);
+
+nock('https://api.contentful.com:443', {"encodedQueryParams":true})
+  .put('/spaces/bohepdihyxin/environments/env-integration/entries/Kl6v7ODtfswKoFdnMpVDI/published')
+  .reply(200, {
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "bohepdihyxin"
+      }
+    },
+    "id": "Kl6v7ODtfswKoFdnMpVDI",
+    "type": "Entry",
+    "createdAt": "2020-07-15T13:02:29.668Z",
+    "updatedAt": "2020-07-15T13:02:33.758Z",
+    "environment": {
+      "sys": {
+        "id": "env-integration",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "publishedVersion": 2,
+    "publishedAt": "2020-07-15T13:02:33.758Z",
+    "firstPublishedAt": "2020-07-15T13:02:33.758Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "publishedCounter": 1,
+    "version": 3,
+    "publishedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1Y7O5FbAkPYgNvD0MpQoAE"
+      }
+    },
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "blogpost"
+      }
+    }
+  },
+  "fields": {
+    "title": {
+      "en-US": "hello!"
+    },
+    "category": {
+      "en-US": "hello!"
+    }
+  }
+}
+, [
+  'Access-Control-Allow-Headers',
+  'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
+  'Access-Control-Allow-Methods',
+  'DELETE,GET,HEAD,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Expose-Headers',
+  'Etag',
+  'Access-Control-Max-Age',
+  '1728000',
+  'cf-environment-id',
+  'env-integration',
+  'cf-environment-uuid',
+  'env-integration',
+  'cf-space-id',
+  'bohepdihyxin',
+  
+  
+  'Content-Type',
+  'application/vnd.contentful.management.v1+json',
+  'Contentful-Api',
+  'cma',
+  'Date',
+  'Wed, 15 Jul 2020 13:02:33 GMT',
+  'etag',
+  'W/"1377598696055119622"',
+  'Server',
+  'Contentful',
+  'Strict-Transport-Security',
+  'max-age=15768000',
+  'X-Content-Type-Options',
+  'nosniff',
+  'X-Contentful-RateLimit-Hour-Limit',
+  '36000',
+  'X-Contentful-RateLimit-Hour-Remaining',
+  '35998',
+  'X-Contentful-RateLimit-Reset',
+  '0',
+  'X-Contentful-RateLimit-Second-Limit',
+  '10',
+  'X-Contentful-RateLimit-Second-Remaining',
+  '8',
+  'X-Contentful-Request-Id',
+  '04bc3244bad75c4cc6384ecef52467be',
+  'Content-Length',
+  '418',
+  'Connection',
+  'Close',
+  'Set-Cookie',
+  'visid_incap_673446=ng/v7wxfSjq55Q7dNdssk2n+Dl8AAAAAQUIPAAAAAADqxZWhCdiBXMdyHGWKegVt; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'nlbi_673446=8fPzHTGj1X8pNHkCKsJtVwAAAAA+0d6kk6hIdVKNNPI+Su3V; path=/; Domain=.contentful.com',
+  'Set-Cookie',
+  'incap_ses_247_673446=ZAZhTwhLm11D6ytOOoVtA2n+Dl8AAAAAf1hsPSE+7yEq3iGG5scxWA==; path=/; Domain=.contentful.com',
+  'X-CDN',
+  'Incapsula',
+  'X-Iinfo',
+  '9-9987326-9987329 NNNN CT(93 93 0) RT(1594818153057 27) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -8888,10 +8888,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "551boZKK9dmBDwpfWaQmd5",
+        "id": "Kl6v7ODtfswKoFdnMpVDI",
         "type": "Entry",
-        "createdAt": "2020-07-15T11:20:19.041Z",
-        "updatedAt": "2020-07-15T11:20:22.826Z",
+        "createdAt": "2020-07-15T13:02:29.668Z",
+        "updatedAt": "2020-07-15T13:02:33.758Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8900,8 +8900,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-15T11:20:22.826Z",
-        "firstPublishedAt": "2020-07-15T11:20:22.826Z",
+        "publishedAt": "2020-07-15T13:02:33.758Z",
+        "firstPublishedAt": "2020-07-15T13:02:33.758Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -8954,10 +8954,10 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "bohepdihyxin"
           }
         },
-        "id": "5ACaSqp8quE2VUdm4ti00Z",
+        "id": "6ZAsrS64KnVmoij5lpKuV7",
         "type": "Entry",
-        "createdAt": "2020-07-15T11:20:18.319Z",
-        "updatedAt": "2020-07-15T11:20:21.715Z",
+        "createdAt": "2020-07-15T13:02:28.969Z",
+        "updatedAt": "2020-07-15T13:02:32.592Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -8966,8 +8966,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 2,
-        "publishedAt": "2020-07-15T11:20:21.715Z",
-        "firstPublishedAt": "2020-07-15T11:20:21.715Z",
+        "publishedAt": "2020-07-15T13:02:32.592Z",
+        "firstPublishedAt": "2020-07-15T13:02:32.592Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -9034,9 +9034,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:23 GMT',
+  'Wed, 15 Jul 2020 13:02:34 GMT',
   'etag',
-  'W/"11432752330253039410"',
+  'W/"14352487624285471145"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9054,21 +9054,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'e916782d934246be166f4d7eb14a723c',
+  '32c8ae1361f7c086d2856f41bcb901c4',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=6n14jWrrQ5eK8gqnBX8jinfmDl8AAAAAQUIPAAAAAABOk2mW1JAuxgoieX5W+xuV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=8X2waCrtQRuZdBCFHrR9IGr+Dl8AAAAAQUIPAAAAAAANma6w1IUQ4MIyzdYk08RO; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=0RC4LGb+1kBDVz7gKsJtVwAAAAAaCzWgnqFTMNCFlGcrgU3m; path=/; Domain=.contentful.com',
+  'nlbi_673446=9aHwPtHM0hFbB38fKsJtVwAAAACqAz011nOgqAoSv1KE7SeH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=jLDVL8U7GHt4cQ9OOoVtA3fmDl8AAAAAPXos60t7+PpRPXv4mk5mAw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=VD18d1OiOkPn6ytOOoVtA2r+Dl8AAAAAwXUOCXC57RSy3qbkCeO3Eg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14426992-14427001 NNNN CT(86 89 0) RT(1594812022852 34) q(0 0 2 -1) r(4 4) U5'
+  '14-49427199-49427212 NNNN CT(85 87 0) RT(1594818153745 36) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9105,7 +9105,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:24 GMT',
+  'Wed, 15 Jul 2020 13:02:34 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -9117,23 +9117,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'e7fbcd4f8e02cb57497598dce9327af1',
+  'd121336d8f8c107c584c647aa963e137',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MmBgqAO/QfqHoJW93oH8kXfmDl8AAAAAQUIPAAAAAABFlzdRbVU0BnHdfllpvDYM; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=cpReh0aXRaaWm01miItbSmr+Dl8AAAAAQUIPAAAAAABZ53MiGFgVYaqk3dqKtoAa; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Dm9pCUff6kjLEVKYKsJtVwAAAACXDGwPM0PcyrCYO06ZB2Dj; path=/; Domain=.contentful.com',
+  'nlbi_673446=erg2IQD6UX40XkIkKsJtVwAAAAAQWOeC2bbI1wHqZAITYfj+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=O6iUe2XyFz7bcg9OOoVtA3fmDl8AAAAAYLfipk4WooaddBFJbvWDqg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=gEEQP/3Yq3uZ7CtOOoVtA2r+Dl8AAAAAElOOJ+N8Fuid+s98HfBTsQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9141,7 +9141,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24194974-24194981 NNYN CT(86 86 0) RT(1594812023465 35) q(0 0 1 -1) r(3 3) U5'
+  '5-24175467-24175469 NNYN CT(92 95 0) RT(1594818154303 38) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9158,7 +9158,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "56295f486fa2dfc63add6576fcc70f6f"
+  "requestId": "822f519a392de63d87eb60f965768fb7"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -9182,9 +9182,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:24 GMT',
+  'Wed, 15 Jul 2020 13:02:35 GMT',
   'etag',
-  '"4326466516401107974"',
+  '"4686608035390429265"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9194,23 +9194,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '56295f486fa2dfc63add6576fcc70f6f',
+  '822f519a392de63d87eb60f965768fb7',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=tL1ljN+FSrGykdGqOr/Ca3jmDl8AAAAAQUIPAAAAAABQzzz7fsqPmeo3QaKaBSnc; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WOcCKcPmRoOyC/3BOJQGyGv+Dl8AAAAAQUIPAAAAAADBoZUd1CtNUhzSXojv9Kbg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=pPIxBpnm2GG5uo4PKsJtVwAAAAAuIdrAS3caiJgI1MrYjV1S; path=/; Domain=.contentful.com',
+  'nlbi_673446=KyicLTygIT9MTHJdKsJtVwAAAADOP7xbwDItXcbsbnO452hG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=jbWFdQ+TJi/Ccw9OOoVtA3jmDl8AAAAAghetfT4aGzn3kyACZGX9Cw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=yl6tPKythQMj7StOOoVtA2v+Dl8AAAAAmTAVmo5omzVQIFJ9vNapFQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9218,7 +9218,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '12-30378001-30378015 NNYN CT(88 88 0) RT(1594812023907 37) q(0 0 2 -1) r(3 3) U5'
+  '13-37649668-37649684 NNYN CT(87 89 0) RT(1594818154761 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9259,8 +9259,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -9290,9 +9290,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:25 GMT',
+  'Wed, 15 Jul 2020 13:02:35 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -9304,15 +9304,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35997',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '7',
+  '8',
   'X-Contentful-Request-Id',
-  '18e8146921d6110dee676d4ecd6fe6f3',
+  'e6b9934f6768cb3e4a53e807edce86c5',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -9324,11 +9324,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=rOZx+kcZS0CTuQYKzbrDi3jmDl8AAAAAQUIPAAAAAAA1EZwwcBjruQB+ZZv82cvG; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=rpXcjgIfQX6vHrRfcqWQp2v+Dl8AAAAAQUIPAAAAAADoR6RQzkQFXOHTDhPDV/+2; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=oDMSYS7301W5xOdrKsJtVwAAAACnaLzbYmRV1Bg2gZpeMpid; path=/; Domain=.contentful.com',
+  'nlbi_673446=O9qTIGboIiy29F9rKsJtVwAAAAB4iXM7MjQLGCzieuhpKHX0; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=sW4rBR2vsEy6dA9OOoVtA3jmDl8AAAAA+j9ngbD40UmkihYcdX23SQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0Ewifq3gyi2I7StOOoVtA2v+Dl8AAAAAPMbHW99+d+6nSb39dxJdfA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -9336,12 +9336,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '7-12574428-12574439 NNYN CT(86 87 0) RT(1594812024410 33) q(0 0 2 -1) r(3 3) U5'
+  '10-15255421-15255425 NNYN CT(86 86 0) RT(1594818155177 26) q(0 0 1 -1) r(2 2) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost', {"name":"Blog post","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","required":true}],"description":"super angry"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-15T11:20:25.720Z","updatedAt":"2020-07-15T11:20:25.720Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"blogPost","type":"ContentType","createdAt":"2020-07-15T13:02:36.239Z","updatedAt":"2020-07-15T13:02:36.239Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Blog post","description":"super angry","fields":[{"id":"slug","name":"URL Slug","type":"Symbol","localized":false,"required":true,"validations":[],"disabled":false,"omitted":false}]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -9363,9 +9363,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:25 GMT',
+  'Wed, 15 Jul 2020 13:02:36 GMT',
   'etag',
-  '"9571140362493432271"',
+  '"13226640593104195650"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9383,21 +9383,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'a24393c564a29b63b07df21e214eb5ac',
+  'ca16154a8ad74091075a1c6067cea4e8',
   'Content-Length',
   '1054',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=E9wafwnTQfuvnZhR2tFC0HnmDl8AAAAAQUIPAAAAAACrWgcNM9Ba0YNbXPK5nkQH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=JNHmSFtBQQOPCWXXL/NngGz+Dl8AAAAAQUIPAAAAAAAn+zPrjHPHZ7DvG7CaQn95; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FHHmIQA7lhhZTYuCKsJtVwAAAACXhzOEzqbckHTr+taoMCQH; path=/; Domain=.contentful.com',
+  'nlbi_673446=+PZrHTtPDio7B8kLKsJtVwAAAABd/Do1eE0qjxgBXiyg0ExU; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=O8Y0GqL/C1h5dg9OOoVtA3nmDl8AAAAA0xIHO4sAsruJdjJ35EA1Ow==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=p3+pCrxCRgwA7itOOoVtA2z+Dl8AAAAALA60Kj835fr3/oMSe1K0ig==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36008004-36008019 NNNN CT(87 87 0) RT(1594812024914 35) q(0 0 2 -1) r(6 6) U5'
+  '12-31851384-31851391 NNNN CT(87 91 0) RT(1594818155551 33) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9413,8 +9413,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:25.720Z",
-    "updatedAt": "2020-07-15T11:20:26.403Z",
+    "createdAt": "2020-07-15T13:02:36.239Z",
+    "updatedAt": "2020-07-15T13:02:36.791Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -9438,8 +9438,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
-    "publishedAt": "2020-07-15T11:20:26.403Z",
+    "firstPublishedAt": "2020-07-15T13:02:36.791Z",
+    "publishedAt": "2020-07-15T13:02:36.791Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -9489,9 +9489,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:26 GMT',
+  'Wed, 15 Jul 2020 13:02:37 GMT',
   'etag',
-  'W/"5140207975816893466"',
+  'W/"5789026031312750653"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9501,29 +9501,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'd4ef405593681c819c4460f5677b9430',
+  'd5f59efa0e6c3cc938e0c9093fcae03d',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=sYA+l4CRTvWWJpTrUtrYWnrmDl8AAAAAQUIPAAAAAAD2wL1x/zc3D3290T3ZVaQV; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=duF5ZOnuSwypT1+k+EDNfWz+Dl8AAAAAQUIPAAAAAAD2t7iQ04Soqq8FTpcD7ujC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=aLC9Yb4q2gvriAIWKsJtVwAAAAAd0R0Sfz+QUABCPg2OSh9/; path=/; Domain=.contentful.com',
+  'nlbi_673446=oVrYCwNW/ng49cQWKsJtVwAAAAAc6l4ElHog296loAY2Yixc; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=xK+hYgJfElzweA9OOoVtA3rmDl8AAAAApj8uwNMH4bg/PFO0ykeuqA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=F8BAP2JtTnm27itOOoVtA2z+Dl8AAAAAppkSgsGccvMZIleYWZmKlQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-12574715-12574719 NNNN CT(92 94 0) RT(1594812025724 36) q(0 0 2 -1) r(4 4) U5'
+  '10-15255562-15255567 NNNN CT(88 88 0) RT(1594818156139 33) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9550,7 +9550,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9558,7 +9558,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:27.007Z",
+    "updatedAt": "2020-07-15T13:02:37.484Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -9606,9 +9606,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:27 GMT',
+  'Wed, 15 Jul 2020 13:02:37 GMT',
   'etag',
-  'W/"12054685273160273957"',
+  'W/"3152898801735795447"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9618,29 +9618,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '15c62fdb544d5b9cb8610b07d23b35e5',
+  '84c8728fb00945ea716f506e07cda9f2',
   'Content-Length',
-  '383',
+  '385',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=niPLp4ejTO+7wXnM4Sk5UnrmDl8AAAAAQUIPAAAAAAD7yJV0BWNETumrp1gqp66A; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=mw4vx5giSAulhUgcv1bc6W3+Dl8AAAAAQUIPAAAAAAAKf3WocWL+AjJ7yhZD0SCu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=QPYdan+smxjrBBR4KsJtVwAAAABGKvdAvG8zrtenq8AtuK9c; path=/; Domain=.contentful.com',
+  'nlbi_673446=kHCWYHfN8BNguaOmKsJtVwAAAAAOx4H0PMXtu9EGTIa1FuXg; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=JixFbLdqmFcFeg9OOoVtA3rmDl8AAAAAt1Yz36GKMnLR4xDaUs+OBg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TzJmZRUvejYz7ytOOoVtA23+Dl8AAAAAYhaiaqH7sTCqfoH21323NA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24195769-24195775 NNNN CT(93 96 0) RT(1594812026320 30) q(0 0 2 -1) r(4 4) U5'
+  '4-16161669-16161673 NNNN CT(86 87 0) RT(1594818156825 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9657,7 +9657,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9665,7 +9665,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:27.007Z",
+    "updatedAt": "2020-07-15T13:02:37.484Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9723,9 +9723,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:27 GMT',
+  'Wed, 15 Jul 2020 13:02:38 GMT',
   'etag',
-  'W/"10198323548035316952"',
+  'W/"5395564671256997003"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9735,29 +9735,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '9b53da1b0ec27daf69e6ac65879d4a88',
-  'Content-Length',
-  '370',
+  '51233b69295f6877792323afea1257ff',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NdHerjNzSKC2tEiafXWK5nvmDl8AAAAAQUIPAAAAAAD+BMJUIllwKfOtntixIaer; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=CHfJH/MoT1KTP16J+7CHZG3+Dl8AAAAAQUIPAAAAAAA3jJc2Elwmt1Jr/tIYd9cO; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=tddxTlc1IUYv2GreKsJtVwAAAACuFHsYrSAeajxiuFJ58Q6b; path=/; Domain=.contentful.com',
+  'nlbi_673446=3OkqSTqS/hqOCzx8KsJtVwAAAADWqiQAdjVB26E3STm4yhI3; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=NjafJB87MBYJew9OOoVtA3vmDl8AAAAAaumoRzRhpQPf84h/ulTkzw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=f0pxJb/OVFfb7ytOOoVtA23+Dl8AAAAASdxqZzkVQUSVnykfWjcV4Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47490592-47490609 NNNN CT(89 89 0) RT(1594812026844 28) q(0 0 2 -1) r(3 3) U5'
+  '11-25370520-25370528 NNNN CT(85 88 0) RT(1594818157365 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9782,8 +9782,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:20:25.720Z",
-        "updatedAt": "2020-07-15T11:20:26.403Z",
+        "createdAt": "2020-07-15T13:02:36.239Z",
+        "updatedAt": "2020-07-15T13:02:36.791Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -9792,8 +9792,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 1,
-        "publishedAt": "2020-07-15T11:20:26.403Z",
-        "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+        "publishedAt": "2020-07-15T13:02:36.791Z",
+        "firstPublishedAt": "2020-07-15T13:02:36.791Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -9860,9 +9860,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:27 GMT',
+  'Wed, 15 Jul 2020 13:02:38 GMT',
   'etag',
-  'W/"902835408233017923"',
+  'W/"13050661760497413281"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9872,29 +9872,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '437d6a0fc7aa76a711b6cc08742e4a99',
+  'de0ca421a9c7e37e4834ff12b75266c9',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vQF9fwzhQbGXyByEttKC13vmDl8AAAAAQUIPAAAAAACBNW7NOQ32LwFV17uLo3j3; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Ed/id6mIQTmk5Q6otsnxy27+Dl8AAAAAQUIPAAAAAACurH0m7sEB3WY209+u1wco; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=fJ5oTalz2Qe4zKGpKsJtVwAAAAD9kf/i8fEzBfu4pAJHCBT1; path=/; Domain=.contentful.com',
+  'nlbi_673446=VX7BRfgp3QCMRnT/KsJtVwAAAADqelQhrdjo80g5NPUVGWOM; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=7L+pUlL7eTf+ew9OOoVtA3vmDl8AAAAAhXofNuWR7qoLu9ZdaJ2fSQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=S9lCekDuNn+Q8CtOOoVtA27+Dl8AAAAAISOCafsNjCPCB4JXDAE8sw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47490800-47490813 NNNN CT(96 97 0) RT(1594812027268 28) q(0 0 2 -1) r(4 4) U5'
+  '11-25370651-25370652 NNNN CT(85 86 0) RT(1594818157977 24) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -9911,7 +9911,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9919,7 +9919,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:27.007Z",
+    "updatedAt": "2020-07-15T13:02:37.484Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -9977,9 +9977,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:28 GMT',
+  'Wed, 15 Jul 2020 13:02:39 GMT',
   'etag',
-  'W/"10198323548035316952"',
+  'W/"5395564671256997003"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -9997,21 +9997,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'cbfc66bdd99092e90226fb1aa56fc708',
+  '11849cc226466bf848d200835b400c4f',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3GVasBz8Re24aaAe7l2VAHzmDl8AAAAAQUIPAAAAAABTVBZ//QmrpoWXvmBzHmGr; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=AJiLhJXpThmS0fkWAzfJ027+Dl8AAAAAQUIPAAAAAACCe/zW7EvDokluOcnCDwb6; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=8Qlke2i6UkK9uOV1KsJtVwAAAACgWHcHvZK3+nfGPjuqSnfl; path=/; Domain=.contentful.com',
+  'nlbi_673446=v3cNAdzCYy4v6109KsJtVwAAAACLSrwB3Gt5GAIRUysp6LKn; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=FuJDd/D3szf8fA9OOoVtA3zmDl8AAAAA9VJaVVYl/HGJoumyZbtJQw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=RHcRLibFkHNW8StOOoVtA27+Dl8AAAAA7fNdsKFq1nwqnf3Dyo1Y7Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9349485-9349496 NNNN CT(93 94 0) RT(1594812027769 35) q(0 0 1 -1) r(3 3) U5'
+  '14-49428546-49428555 NNNN CT(94 95 0) RT(1594818158597 34) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10052,8 +10052,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -10083,9 +10083,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:28 GMT',
+  'Wed, 15 Jul 2020 13:02:39 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -10105,7 +10105,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'a503d9b2d2e83ca4c984c045a912f062',
+  'cb9a985b72de7910419a718eefc9253d',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -10117,11 +10117,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=pyjecqE3SAyTi5rCN2heinzmDl8AAAAAQUIPAAAAAACeIIcYmdwJzXlPSCVJVosC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=EXafVpCkRi6I0sg7hVR3Im/+Dl8AAAAAQUIPAAAAAAAzb5OJ6bP2yyqcLyYa5K4x; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=O0SjZ2yyZXB9DXG+KsJtVwAAAADPiTZnAebrgru+XXW0Cf8o; path=/; Domain=.contentful.com',
+  'nlbi_673446=StuSB1iPiUTjlBw0KsJtVwAAAABZfR4zw1mJsDQAuCT8xu1F; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=IhVgDmOVwwsbfg9OOoVtA3zmDl8AAAAA6/J/BqpHQJbNrnL9wwh3Nw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=bXxmMo+LJAH18StOOoVtA2/+Dl8AAAAAl/MGrDzTPtsASTyz0aa5TQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10129,7 +10129,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24196247-24196259 NNYN CT(88 89 0) RT(1594812028378 33) q(0 0 1 -1) r(2 2) U5'
+  '14-49428701-49428710 NNYN CT(94 87 0) RT(1594818159211 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10145,8 +10145,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:25.720Z",
-    "updatedAt": "2020-07-15T11:20:29.456Z",
+    "createdAt": "2020-07-15T13:02:36.239Z",
+    "updatedAt": "2020-07-15T13:02:40.281Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10155,8 +10155,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 1,
-    "publishedAt": "2020-07-15T11:20:26.403Z",
-    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+    "publishedAt": "2020-07-15T13:02:36.791Z",
+    "firstPublishedAt": "2020-07-15T13:02:36.791Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10221,9 +10221,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:29 GMT',
+  'Wed, 15 Jul 2020 13:02:40 GMT',
   'etag',
-  'W/"8197350643571311752"',
+  'W/"16837918431733965326"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10241,21 +10241,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f59e9a3000491d38cb7332d2ef43f85f',
-  'Content-Length',
-  '452',
+  '2ee452f72516be7dcb29541c513fc05b',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=D89n9uEuSI+LR/7S/W3nyX3mDl8AAAAAQUIPAAAAAAD/nEog0MIUYYb16bgxUd3/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BpCEO4c1SaOHIR058lIyWnD+Dl8AAAAAQUIPAAAAAABlIHWTQN5JAmKaJor18y0N; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=D15THue6aF19HyzSKsJtVwAAAAAillYLMIAalgOdC3JvIdDr; path=/; Domain=.contentful.com',
+  'nlbi_673446=k0ShOFvbRRkTC6fOKsJtVwAAAABitbYdZ1dab6utjmeD46KW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=tEUNT1pn63Mtfw9OOoVtA33mDl8AAAAAyTq0TiDzmQZ1OQZhS90Slw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=HxOZSZ04CmV78itOOoVtA3D+Dl8AAAAA6jHaP1HQeiOxJiftgNFFOg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14428086-14428092 NNNN CT(86 87 0) RT(1594812028788 33) q(0 0 1 -1) r(3 3) U5'
+  '10-15255983-15255990 NNNN CT(86 87 0) RT(1594818159619 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10271,8 +10271,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:25.720Z",
-    "updatedAt": "2020-07-15T11:20:30.042Z",
+    "createdAt": "2020-07-15T13:02:36.239Z",
+    "updatedAt": "2020-07-15T13:02:40.890Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -10281,8 +10281,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:30.042Z",
-    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+    "publishedAt": "2020-07-15T13:02:40.890Z",
+    "firstPublishedAt": "2020-07-15T13:02:36.791Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -10347,9 +10347,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:30 GMT',
+  'Wed, 15 Jul 2020 13:02:40 GMT',
   'etag',
-  'W/"6126344861331558714"',
+  'W/"4396864392882705478"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10367,26 +10367,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '52d10b478bc9b8522b1f07fe902e4b8d',
-  'Content-Length',
-  '461',
+  '6a886523a9786c08d2c58f627998215d',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=v6eHWDhvTpW7b7NFymJw4X3mDl8AAAAAQUIPAAAAAADdPb6G9qRLdeEWVlKE8wJg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SPF/CkBTTaahsI13sSgSdHD+Dl8AAAAAQUIPAAAAAABX8TzTt+Aub9+sVktt+MDV; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=6G2GRnQPaCqlroURKsJtVwAAAAAcD4P+iK6dJcFLDSthZBeE; path=/; Domain=.contentful.com',
+  'nlbi_673446=4eU1QoexWCtX8IDfKsJtVwAAAADzaVwshkWskAwgvnXCgLzO; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=T5TNawHdDk56gA9OOoVtA33mDl8AAAAAbzf0apGg2N01Z5scioGwow==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TwfPesAfGHZM8ytOOoVtA3D+Dl8AAAAAKPVkklXI2gCrPuaj9002ig==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-12575224-12575227 NNNN CT(86 87 0) RT(1594812029398 33) q(0 0 2 -1) r(4 4) U5'
+  '1-2967108-2967110 NNNN CT(93 93 0) RT(1594818160237 29) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[]})
-  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-15T11:20:26.475Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T11:20:30.671Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":4,"createdAt":"2020-07-15T13:02:36.862Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T13:02:41.411Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -10408,9 +10408,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:30 GMT',
+  'Wed, 15 Jul 2020 13:02:41 GMT',
   'etag',
-  '"5202440968502403685"',
+  '"4756794946749869277"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10428,26 +10428,26 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'efaddacd8fd3749aae3bab36d5c9bfee',
+  '6e24ae61446638a7d4d10c0122023b83',
   'Content-Length',
   '880',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=uvJYEpWPTBWnbbtyaVpOUn7mDl8AAAAAQUIPAAAAAACcx9mEMgdN5ruulCOsdIf7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=PAOkoyFOQiq47WMHQDdgmHH+Dl8AAAAAQUIPAAAAAABYIuOIf4zpxvxJo9mpPuiv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=GzleK9S5fSPppvFLKsJtVwAAAABnG6qFAWXebGQ9WrGjCuoz; path=/; Domain=.contentful.com',
+  'nlbi_673446=3Q0eRDTOpldHdE8fKsJtVwAAAABvuXnbNef/wqLddCMZhMQG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=HbFrNwZhzQGXgQ9OOoVtA37mDl8AAAAAk/hZhwgQZKdM8Hilyg39Ow==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=v88AFwPJIDPG8ytOOoVtA3H+Dl8AAAAAn+7rllTMGWbQkwCp4dc02g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-10883465-10883472 NNNN CT(87 87 0) RT(1594812030022 26) q(0 0 2 -1) r(3 3) U5'
+  '6-7771340-7771341 NNNN CT(85 87 0) RT(1594818160753 31) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/blogPost/editor_interface', {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}]})
-  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-15T11:20:26.475Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T11:20:31.279Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
+  .reply(200, {"controls":[{"fieldId":"slug","widgetId":"singleLine","widgetNamespace":"builtin"}],"sys":{"id":"default","type":"EditorInterface","space":{"sys":{"id":"bohepdihyxin","type":"Link","linkType":"Space"}},"version":5,"createdAt":"2020-07-15T13:02:36.862Z","createdBy":{"sys":{"id":"1Y7O5FbAkPYgNvD0MpQoAE","type":"Link","linkType":"User"}},"updatedAt":"2020-07-15T13:02:41.897Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"contentType":{"sys":{"id":"blogPost","type":"Link","linkType":"ContentType"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}}}}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -10469,9 +10469,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:31 GMT',
+  'Wed, 15 Jul 2020 13:02:41 GMT',
   'etag',
-  '"6959354504976781302"',
+  '"16335014643602120978"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10481,29 +10481,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '0894ec5d438667ac9d589744c24166ca',
+  '882611b3b96792ce947830b27fe1ff2e',
   'Content-Length',
   '987',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fBiSDsAHRraL39Aet6bvfX7mDl8AAAAAQUIPAAAAAACh0NZ6v3CDHQQLdkHvlJ97; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=6U6CfShqToizCGrsUJ01xHH+Dl8AAAAAQUIPAAAAAADqVQY0SIMYZWCQ8nZ0nj9/; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Ytm3TWql+AFXZB2lKsJtVwAAAADTuQY6x99C8GUvwBAqZP3/; path=/; Domain=.contentful.com',
+  'nlbi_673446=pzQQB+DBbl3OicjlKsJtVwAAAADecN00XV//+N0YYHCBPQH+; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=4xdZC/pIskXLgg9OOoVtA37mDl8AAAAAt2FBOnmMDiJebB2QfTu6qQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=QQSzad3W8gJI9CtOOoVtA3H+Dl8AAAAAjWVswNu8IkcrWp1xuVhxJA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15466771-15466775 NNNN CT(87 87 0) RT(1594812030638 30) q(0 0 2 -1) r(3 3) U5'
+  '14-49429271-49429277 NNNN CT(88 86 0) RT(1594818161254 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10520,7 +10520,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10528,7 +10528,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:31.279Z",
+    "updatedAt": "2020-07-15T13:02:41.897Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10581,9 +10581,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:31 GMT',
+  'Wed, 15 Jul 2020 13:02:42 GMT',
   'etag',
-  '"17156288789629272913"',
+  '"16275241546395941231"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10593,23 +10593,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '18271ad07c5ddc115f10b1c3b3580c95',
+  '89f395c22e83da59ac0e819b8906bfea',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Gg6K+TpqQimbp+LZLxLOY3/mDl8AAAAAQUIPAAAAAAAqaXendJEeZIkJIsYkRdfd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=vD7nJwYFT6uVFBrVV29ocXL+Dl8AAAAAQUIPAAAAAAACx0sxZ1Uh8Rlsq108cwcd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=O+IqI+AKx1mrwVJSKsJtVwAAAABwOTJ9Ksdg2Abkug5tvg+y; path=/; Domain=.contentful.com',
+  'nlbi_673446=3jiaF+14/H8PGwKMKsJtVwAAAACumyyBdVURmtONZMUteu+1; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=Lb5hfB3+Fi0mhA9OOoVtA3/mDl8AAAAAkN0vtHcsveBCpxdBBluBug==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=evI2We/6lwhl9StOOoVtA3L+Dl8AAAAAgErgeaoDlrNZ7I4AMWr+jQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10617,7 +10617,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-36009994-36010011 NNYN CT(86 88 0) RT(1594812031250 31) q(0 0 2 -1) r(4 4) U5'
+  '13-37651292-37651304 NNYN CT(88 87 0) RT(1594818161871 34) q(0 0 1 -1) r(8 8) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10642,8 +10642,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         },
         "id": "blogPost",
         "type": "ContentType",
-        "createdAt": "2020-07-15T11:20:25.720Z",
-        "updatedAt": "2020-07-15T11:20:30.042Z",
+        "createdAt": "2020-07-15T13:02:36.239Z",
+        "updatedAt": "2020-07-15T13:02:40.890Z",
         "environment": {
           "sys": {
             "id": "env-integration",
@@ -10652,8 +10652,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
           }
         },
         "publishedVersion": 3,
-        "publishedAt": "2020-07-15T11:20:30.042Z",
-        "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+        "publishedAt": "2020-07-15T13:02:40.890Z",
+        "firstPublishedAt": "2020-07-15T13:02:36.791Z",
         "createdBy": {
           "sys": {
             "type": "Link",
@@ -10720,9 +10720,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:32 GMT',
+  'Wed, 15 Jul 2020 13:02:43 GMT',
   'etag',
-  'W/"7534781789484185536"',
+  'W/"1021600620937472081"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10740,21 +10740,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'c2a3e37f92d8eb72277d7283ba5203bc',
+  '0874c943c3fcca6ed352c0f81c3dbac1',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=crVsezucR8SsbbGOLa51FYDmDl8AAAAAQUIPAAAAAADe68DaNrjcpcE68aH03O9x; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=JqefCtbkRvKJTVjaqzPWAXP+Dl8AAAAAQUIPAAAAAACX+osF1zfqQg1UwWSQK8BI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Tbs4W86c6nvl0zAsKsJtVwAAAAChycAtGW7edFqMECkroC2x; path=/; Domain=.contentful.com',
+  'nlbi_673446=tfUfEKAfBVYSz92HKsJtVwAAAAByGC+mE4/VHZPud0q8dj27; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=J38NO9XflkS7hQ9OOoVtA4DmDl8AAAAAg0Gmc+Uhojc8MfhrYm7RPA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=NJ7RZ36+JHUA9itOOoVtA3P+Dl8AAAAATQJg02GZu0N8tdffM8Fviw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '7-12575534-12575536 NNNN CT(87 88 0) RT(1594812031867 37) q(0 0 1 -1) r(4 4) U5'
+  '10-15256452-15256456 NNNN CT(95 94 0) RT(1594818162777 23) q(0 1 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10771,7 +10771,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10779,7 +10779,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:31.279Z",
+    "updatedAt": "2020-07-15T13:02:41.897Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -10832,9 +10832,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:33 GMT',
+  'Wed, 15 Jul 2020 13:02:45 GMT',
   'etag',
-  '"17156288789629272913"',
+  '"16275241546395941231"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -10852,15 +10852,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '6b02b803b753f39d1fb3bde27eac8f6b',
+  '4d15ae709702019a091d880406e96c14',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=YfdqPRLdS7mfFKm6FehxJ4DmDl8AAAAAQUIPAAAAAAB+/816Yvpsu1aYCtNuMTSt; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=PnOcir8DQeOO/iIKIeP9jXT+Dl8AAAAAQUIPAAAAAACPDi/UvdrnknAfcjJfOSnq; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=lghReXJOqUSh/JrbKsJtVwAAAACEFNRSZPrAHIjM0YD9w0eJ; path=/; Domain=.contentful.com',
+  'nlbi_673446=TwJYC/IGBQav8WWIKsJtVwAAAAA+YTk28m+r1axIfbRDIuIG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=q/mPPJhnRG4Ahw9OOoVtA4DmDl8AAAAALaK3rOiD1k1w/0XRugRscw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=vY/vF+kLonB7+CtOOoVtA3T+Dl8AAAAAUt0LbTTfSd+5viBTsbvWUA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10868,7 +10868,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-36010361-36010374 NNYN CT(87 88 0) RT(1594812032474 29) q(0 0 1 -1) r(3 3) U5'
+  '12-31853337-31853345 NNYN CT(93 105 0) RT(1594818164202 32) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -10909,8 +10909,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -10940,9 +10940,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:33 GMT',
+  'Wed, 15 Jul 2020 13:02:45 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -10954,15 +10954,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '8b8b94f0b42ca16edd8a175b5a72893a',
+  '0d0c1dbea1c806fa19983725ff4043e6',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -10974,11 +10974,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=X/jWEYCQRtWtFBd52FP6LoHmDl8AAAAAQUIPAAAAAAB3EaNfZfRx+EAPx4rA9If5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=hyXrDPFxT7ehstF4SWBFmHX+Dl8AAAAAQUIPAAAAAACbzUj5RqcWyqyaKAOiyexr; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=F5RUPcAajDRuzIpNKsJtVwAAAADDnI6ZkIkr3o8p58eDeksm; path=/; Domain=.contentful.com',
+  'nlbi_673446=IzTDYKJjs11014uGKsJtVwAAAAD3K6c/cwJrmTSEpR8xfh3h; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=PoUJAALWa19ciA9OOoVtA4HmDl8AAAAANXfP/CgpBEORDqNJ5f9Nog==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ViE4MQ4BmQgY+StOOoVtA3X+Dl8AAAAAoX9sChDNHN6rPl7PWoJToA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -10986,7 +10986,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-36010553-36010567 NNYN CT(87 92 0) RT(1594812033096 37) q(0 0 2 -1) r(3 3) U5'
+  '9-9989104-9989107 NNYN CT(93 159 0) RT(1594818164977 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11002,8 +11002,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:25.720Z",
-    "updatedAt": "2020-07-15T11:20:34.382Z",
+    "createdAt": "2020-07-15T13:02:36.239Z",
+    "updatedAt": "2020-07-15T13:02:46.333Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -11012,8 +11012,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 3,
-    "publishedAt": "2020-07-15T11:20:30.042Z",
-    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+    "publishedAt": "2020-07-15T13:02:40.890Z",
+    "firstPublishedAt": "2020-07-15T13:02:36.791Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -11078,9 +11078,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:34 GMT',
+  'Wed, 15 Jul 2020 13:02:46 GMT',
   'etag',
-  'W/"7815567457951041915"',
+  'W/"5473761643140320502"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11098,21 +11098,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b772a4e0f80b956dc1613b74fc03b85e',
+  '57d0dfe4370451d161863f283f7cdf1f',
   'Content-Length',
-  '466',
+  '463',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=3n0A5HeKSE+OB9/84Z2gHoLmDl8AAAAAQUIPAAAAAAA3DiQtysb1w8Ic2KvQ9xvv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=v52/hqqsQ66nfvQBRi1lz3b+Dl8AAAAAQUIPAAAAAABbLMb89/Mm/XdXLaqcq5aO; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=juynTqdcjV3ZL2l8KsJtVwAAAABorRFOvJM96colkzRR+sUo; path=/; Domain=.contentful.com',
+  'nlbi_673446=1E7yCSYOISjITpOFKsJtVwAAAADjFgNiysrkht4qhfVueMRI; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=G8qVBQ41CzXDiQ9OOoVtA4LmDl8AAAAA4/LlRXMVP65KXZ1cfyMulw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=WkMCSD9qVHrp+StOOoVtA3b+Dl8AAAAANHVgU7fw9labbuqazwk8Pw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36010660-36010680 NNNN CT(86 175 0) RT(1594812033504 38) q(0 0 3 -1) r(6 6) U5'
+  '7-13172810-13172811 NNNN CT(87 87 0) RT(1594818165569 27) q(0 0 2 -1) r(5 5) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11128,8 +11128,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "blogPost",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:25.720Z",
-    "updatedAt": "2020-07-15T11:20:35.000Z",
+    "createdAt": "2020-07-15T13:02:36.239Z",
+    "updatedAt": "2020-07-15T13:02:46.842Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -11138,8 +11138,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "publishedVersion": 5,
-    "publishedAt": "2020-07-15T11:20:35.000Z",
-    "firstPublishedAt": "2020-07-15T11:20:26.403Z",
+    "publishedAt": "2020-07-15T13:02:46.842Z",
+    "firstPublishedAt": "2020-07-15T13:02:36.791Z",
     "createdBy": {
       "sys": {
         "type": "Link",
@@ -11204,9 +11204,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:35 GMT',
+  'Wed, 15 Jul 2020 13:02:46 GMT',
   'etag',
-  'W/"12807943782668852324"',
+  'W/"7539973064405296740"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11224,21 +11224,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'ac8eeb946fa79f2d06041d730c631a0f',
-  'Content-Length',
-  '460',
+  '12f02758921b4be6c524aecb2836d90c',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=wT62ykJuR7C4ywtWa15vUILmDl8AAAAAQUIPAAAAAACZfUtmlPjOsn22cTAOe4GE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ntZTLup7QEO+ZhIVtIa95Hb+Dl8AAAAAQUIPAAAAAAC2LdrhrxMH9FfCCfIp9B4m; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=72nsXkDeMX7jCivGKsJtVwAAAADOtm5QRmxN6uaZG0Za2MhV; path=/; Domain=.contentful.com',
+  'nlbi_673446=Rhfwe4uEiQ5XYgWCKsJtVwAAAAA1/lqfBYcxPB/b537dhqha; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=d05GL2V5RzMjjA9OOoVtA4LmDl8AAAAA2veOJ9gNUYfiC0uP14GYeA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=o4+1S2K/JH95+itOOoVtA3b+Dl8AAAAA8iSvyi/MGn0Bj4vo3cEfPA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30380826-30380833 NNNN CT(100 94 0) RT(1594812034334 26) q(0 0 2 -1) r(5 5) U5'
+  '13-37652338-37652346 NNNN CT(98 94 0) RT(1594818166175 31) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11265,7 +11265,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11273,7 +11273,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:35.616Z",
+    "updatedAt": "2020-07-15T13:02:47.575Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -11321,9 +11321,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:35 GMT',
+  'Wed, 15 Jul 2020 13:02:47 GMT',
   'etag',
-  'W/"8868377458383301141"',
+  'W/"15214381151367520415"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11341,21 +11341,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '21031e7f39848d5f018ad44442840bb3',
+  'c740c6a4481869b2ac60497eaf50735e',
   'Content-Length',
-  '420',
+  '422',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=34aNG/4eQQOyCO+ryONLo4PmDl8AAAAAQUIPAAAAAACqUd6H/JpCocnd+qmwDWLB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=SERIzGvfSjunT7MUjxqUBHf+Dl8AAAAAQUIPAAAAAAA/hPe68DQnPypt0yKBedBY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=KmEqNXO4gTY341dWKsJtVwAAAADCBojKyJjnXMK3S55o2Kxl; path=/; Domain=.contentful.com',
+  'nlbi_673446=968qAJ5vThIRDAOPKsJtVwAAAAAnW73f/OCx57yNAV/3mq+i; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=1lofN2/loARmjQ9OOoVtA4PmDl8AAAAASD1tzgJS4eikK50stTWtJg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=UgUXFp0wrAEa+ytOOoVtA3f+Dl8AAAAAM7FC1G5An6rV5Gf1wGDWHA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9350466-9350471 NNNN CT(97 94 0) RT(1594812034930 32) q(0 0 2 -1) r(4 4) U5'
+  '6-7771554-7771556 NNNN CT(93 93 0) RT(1594818166795 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11372,7 +11372,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 7,
-    "createdAt": "2020-07-15T11:20:26.475Z",
+    "createdAt": "2020-07-15T13:02:36.862Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11380,7 +11380,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:35.616Z",
+    "updatedAt": "2020-07-15T13:02:47.575Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11438,9 +11438,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:36 GMT',
+  'Wed, 15 Jul 2020 13:02:48 GMT',
   'etag',
-  'W/"11663115142137028786"',
+  'W/"15118307305043613106"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11450,29 +11450,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '0fced3543c9d0ff75e3eb91dea1ec3e1',
-  'transfer-encoding',
-  'chunked',
+  '89289d5e9c26ecbda53932145eccad02',
+  'Content-Length',
+  '408',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Q9S58vnoTWaf9+lgCmzb14PmDl8AAAAAQUIPAAAAAAACNF98teoxsCa6GOtgYvVu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=tHJsqeTRReuXk6FXbUM+UXf+Dl8AAAAAQUIPAAAAAAAl8DrzNJVsOMFwvr28g402; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=LRjDY/rlokUfoy5UKsJtVwAAAAA+SH1leS37DtCw8Imzvl0A; path=/; Domain=.contentful.com',
+  'nlbi_673446=+hI9QLkQ3QCBB/GQKsJtVwAAAADHNLl9NVtOWe2Z484+eTkb; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=HcOoLLmnyneWjg9OOoVtA4PmDl8AAAAA/cKZaO2OQXvuT0UcNXaebQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=dbm4N62K1TZW/CtOOoVtA3f+Dl8AAAAA8ZvxkkxcL00U/7aeFCELRg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9350559-9350566 NNNN CT(87 90 0) RT(1594812035550 32) q(0 0 2 -1) r(4 4) U5'
+  '14-49430802-49430807 NNNN CT(86 86 0) RT(1594818167405 26) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11509,7 +11509,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:36 GMT',
+  'Wed, 15 Jul 2020 13:02:48 GMT',
   'etag',
   '"10440568906820546102"',
   'Server',
@@ -11521,23 +11521,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '6d25a7a5e10a11c7b9743779d6749897',
+  'abb228d91f758cc8b5b99ec41da3c744',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=AhDRPPOeRhqwMXOYTtNdSITmDl8AAAAAQUIPAAAAAACyJCAaUrd2F0mmT2fWzthM; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=iTzJWhyUQ/mBxKm6uqeF4nj+Dl8AAAAAQUIPAAAAAAB4buHdJ/FTqVgWcZaJtpqi; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=EY2FGj8HcwwUZIdKKsJtVwAAAADykTwUvSLuzz+XkDzmTFGe; path=/; Domain=.contentful.com',
+  'nlbi_673446=Y4pJQnUyQwXNbdEFKsJtVwAAAABjEYXmFlO03C0BbfIN8vBi; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=5cfmJqSJ1kfvjw9OOoVtA4TmDl8AAAAAy5bMijuGBJlv6bKdJwFalA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=zy+kIhWA0Rk0/StOOoVtA3j+Dl8AAAAA6Ig0iFjVtpJXJazhBO8gvg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11545,7 +11545,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-47493498-47493515 NNYN CT(86 88 0) RT(1594812036164 31) q(0 0 2 -1) r(4 4) U5'
+  '14-49430960-49430966 NNYN CT(88 98 0) RT(1594818168021 37) q(0 0 2 -1) r(6 6) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11562,7 +11562,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "5ec99f6153fe80bec0c0595f253605ee"
+  "requestId": "675a3c25d63a26dcd565a1e0d8af63e8"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -11586,9 +11586,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:37 GMT',
+  'Wed, 15 Jul 2020 13:02:49 GMT',
   'etag',
-  '"5653506158891860887"',
+  '"5755000378900739830"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11606,15 +11606,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5ec99f6153fe80bec0c0595f253605ee',
+  '675a3c25d63a26dcd565a1e0d8af63e8',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=keuHXYoPRDyVzJoSSX/FJYXmDl8AAAAAQUIPAAAAAABZR6a6gtv0cwBvZCPideXA; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=EAuiFpOIT1G+FG3AmGK6Bnn+Dl8AAAAAQUIPAAAAAABucZ2BOMm8j38ZAzY0x5Xd; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=Z9UXByJP8BDS0qazKsJtVwAAAAAhj2TE53LDHVrW1cQJ9tgP; path=/; Domain=.contentful.com',
+  'nlbi_673446=0pyVeaSk0iftWPkxKsJtVwAAAABaXCDeNEz5HE+quXbiS+El; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=fisLTp54lDEqkQ9OOoVtA4XmDl8AAAAAWg1xcCb7CZbw7JHP4oG93Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=MVe+G4D4/mXF/StOOoVtA3n+Dl8AAAAAWZeJUSI2a1YSoVKo3uulHg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11622,7 +11622,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-47493712-47493726 NNYN CT(87 175 0) RT(1594812036768 35) q(0 0 2 -1) r(4 4) U5'
+  '12-31854319-31854327 NNYN CT(87 88 0) RT(1594818168839 35) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11663,8 +11663,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -11694,9 +11694,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:38 GMT',
+  'Wed, 15 Jul 2020 13:02:50 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -11716,7 +11716,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f03f632f384fd3d818e278c66aaa491f',
+  '7548dda37b941cd00033e54ffd39c3fd',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -11728,11 +11728,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NoNbBl/AQrCwmEE6RfplUobmDl8AAAAAQUIPAAAAAABVHSTwYzSSwQg8spIVidNx; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=ulvQAPpORhKy45wzrSYDnXn+Dl8AAAAAQUIPAAAAAADnXTCTPEC9X+/IMMMWJsj6; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=QcBzTwnIYHM8EfX3KsJtVwAAAABqE3xqoV/Z+h5+IfzB8xBR; path=/; Domain=.contentful.com',
+  'nlbi_673446=MYsxYJxxVRjXbI31KsJtVwAAAAD9w4AFcDhWfKOUxd3z5v85; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=CzZuGkU8FBwylA9OOoVtA4bmDl8AAAAAv9BWrM2AA76JGYHH6HQcHw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=v4WuGBY2HydZ/itOOoVtA3n+Dl8AAAAAe2o/7MepTwfPBwhrXV45Qg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -11740,12 +11740,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '14-47493979-47493992 NNYN CT(87 960 0) RT(1594812037404 39) q(0 0 10 -1) r(12 12) U5'
+  '14-49431350-49431360 NNYN CT(95 94 0) RT(1594818169449 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/content_types/customSidebar', {"name":"Custom sidebar","fields":[],"description":"How to add, remove and update widgets"})
-  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-15T11:20:39.661Z","updatedAt":"2020-07-15T11:20:39.661Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
+  .reply(201, {"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"id":"customSidebar","type":"ContentType","createdAt":"2020-07-15T13:02:50.587Z","updatedAt":"2020-07-15T13:02:50.587Z","environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"publishedCounter":0,"version":1},"displayField":null,"name":"Custom sidebar","description":"How to add, remove and update widgets","fields":[]}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -11767,9 +11767,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:39 GMT',
+  'Wed, 15 Jul 2020 13:02:50 GMT',
   'etag',
-  '"4914214561177050231"',
+  '"10801311369350471948"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11779,29 +11779,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '07fea76d609de0753e9b70b0a8badd61',
+  'da54ea8ce11080ec2f8c3a6708716069',
   'Content-Length',
   '882',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fQlSu/VBQViZb6U1VMSSe4fmDl8AAAAAQUIPAAAAAACnym0Z5YUufVeT2LLKZsyL; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=hUy3F7l0Qpe+UZkaNG2Nvnr+Dl8AAAAAQUIPAAAAAACFI9Y/s8x4qdOel32y/xyw; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=7YlNMCqhYW7YqOcnKsJtVwAAAAAMNSw+/a38f/7AdGdrZPTb; path=/; Domain=.contentful.com',
+  'nlbi_673446=NmDGQBOxcTVpqSY1KsJtVwAAAABMPg3dCRgIuBw0UAouL4KP; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=mq9MVx8TU3u1lQ9OOoVtA4fmDl8AAAAA4JGJIi+9dGV/zmvsenMFrQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=F21YcP9J6Q32/itOOoVtA3r+Dl8AAAAAqCOSc3GKXk2VoFBdEH8fTA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30381994-30382001 NNNN CT(87 90 0) RT(1594812038836 32) q(0 0 2 -1) r(6 6) U5'
+  '10-15257482-15257492 NNNN CT(93 97 0) RT(1594818169869 36) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11817,8 +11817,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "id": "customSidebar",
     "type": "ContentType",
-    "createdAt": "2020-07-15T11:20:39.661Z",
-    "updatedAt": "2020-07-15T11:20:40.300Z",
+    "createdAt": "2020-07-15T13:02:50.587Z",
+    "updatedAt": "2020-07-15T13:02:51.123Z",
     "environment": {
       "sys": {
         "id": "env-integration",
@@ -11842,8 +11842,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     },
     "publishedCounter": 1,
     "version": 2,
-    "firstPublishedAt": "2020-07-15T11:20:40.300Z",
-    "publishedAt": "2020-07-15T11:20:40.300Z",
+    "firstPublishedAt": "2020-07-15T13:02:51.123Z",
+    "publishedAt": "2020-07-15T13:02:51.123Z",
     "publishedBy": {
       "sys": {
         "type": "Link",
@@ -11882,9 +11882,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:40 GMT',
+  'Wed, 15 Jul 2020 13:02:51 GMT',
   'etag',
-  'W/"17868315011244829329"',
+  'W/"1138045804777501759"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -11902,21 +11902,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '9a4cd031c64b197355b31ea5d4e20511',
+  '3a529bb5b7cb0391206930ec8fc6fc67',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=sHygekRTQ2KENBLOhKc3uIjmDl8AAAAAQUIPAAAAAAAUEQ3kmX1M5V8QM25pZmZg; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=5Z4O55yHQ+yPacCt0YRPbXr+Dl8AAAAAQUIPAAAAAADdqxh0+JXc/og7G6ZPLnvC; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=rh7WASloiypY6FThKsJtVwAAAAAtYOwgAYVBC1cufvibkosi; path=/; Domain=.contentful.com',
+  'nlbi_673446=58q8RyV1XXNB6J4/KsJtVwAAAAC4IIBhBe2HoBDnODXb0AhQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=iPX+aTfOQCQnlw9OOoVtA4jmDl8AAAAAPxQ1p5NOVft4LzxLFzOAew==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=nlhgclVgkRWh/ytOOoVtA3r+Dl8AAAAAtkXqVWmmKoG2CwcIucqWMQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47494376-47494384 NNNN CT(94 97 0) RT(1594812039638 32) q(0 0 2 -1) r(6 6) U5'
+  '11-25373369-25373376 NNNN CT(89 89 0) RT(1594818170479 26) q(0 0 1 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -11957,7 +11957,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 2,
-    "createdAt": "2020-07-15T11:20:40.502Z",
+    "createdAt": "2020-07-15T13:02:51.189Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -11965,7 +11965,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:41.053Z",
+    "updatedAt": "2020-07-15T13:02:51.654Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12013,9 +12013,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:41 GMT',
+  'Wed, 15 Jul 2020 13:02:51 GMT',
   'etag',
-  'W/"5351772243695509863"',
+  'W/"16416250126289607297"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12033,21 +12033,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '6153b1b52a56a3ade8b2daa39f3319e7',
+  '7c49bf159bfffa2add659cee3f0390eb',
   'Content-Length',
-  '460',
+  '459',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kcW4qXGGQUCVBOPhOpb+9YjmDl8AAAAAQUIPAAAAAAAs62s0X6V12BeyNzwdpa7F; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=kUihL+daTcSbpplP71W/sXv+Dl8AAAAAQUIPAAAAAAADTGN8ajlVmWmW8WrLsiQt; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=PoeYHGQ45TdYbcAWKsJtVwAAAABOmS0AOlQRp55J2+jIovcM; path=/; Domain=.contentful.com',
+  'nlbi_673446=sNd8P1c01FiSmE84KsJtVwAAAADva4Yd6Q0tqey/utfWYaoj; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=XJ22Xt4EDnRSmA9OOoVtA4jmDl8AAAAA8CUConbybFw/sJWkuHbRBQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=H6HgSM5USx8NACxOOoVtA3v+Dl8AAAAAmAHlUBfAe5llTI+DNRp8Aw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9351332-9351339 NNNN CT(87 86 0) RT(1594812040386 34) q(0 0 1 -1) r(3 3) U5'
+  '14-49431713-49431721 NNNN CT(94 93 0) RT(1594818170985 25) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12088,7 +12088,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 3,
-    "createdAt": "2020-07-15T11:20:40.502Z",
+    "createdAt": "2020-07-15T13:02:51.189Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12096,7 +12096,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:41.581Z",
+    "updatedAt": "2020-07-15T13:02:52.183Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12144,9 +12144,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:41 GMT',
+  'Wed, 15 Jul 2020 13:02:52 GMT',
   'etag',
-  'W/"2388484434711758909"',
+  'W/"10866200904573003277"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12164,21 +12164,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'aa9dada961986608a0f45a98a7feb9ae',
+  '0a21e263b5557386550180829f40fe2b',
   'Content-Length',
-  '460',
+  '459',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=HzvaNLPlQUeyRhJ6AoSE1YnmDl8AAAAAQUIPAAAAAAD7dEkbqpuKDNZYvj0NU2VI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=loarlxhfR0yztIin9YIGnHv+Dl8AAAAAQUIPAAAAAAA5v01prizvykbgJ7oymekU; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=+aIta3B4h2bf3Yb8KsJtVwAAAAAxFG1p0om4mdGcjXm0GlN2; path=/; Domain=.contentful.com',
+  'nlbi_673446=mDL/RTcjVTFtLSiZKsJtVwAAAADEvURFk0AjIBsk28tbkh2T; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=XgxSE/4NsntzmQ9OOoVtA4nmDl8AAAAAo3b3YxQlipHfT8BnqeWHFg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ivYoFrFQokedACxOOoVtA3v+Dl8AAAAAxx4Lp2YKRzYFtv0Qxnm1qQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '3-10884145-10884152 NNNN CT(93 100 0) RT(1594812040882 31) q(0 0 2 -1) r(4 4) U5'
+  '7-13173203-13173205 NNNN CT(94 94 0) RT(1594818171500 35) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12219,7 +12219,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 4,
-    "createdAt": "2020-07-15T11:20:40.502Z",
+    "createdAt": "2020-07-15T13:02:51.189Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12227,7 +12227,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:43.054Z",
+    "updatedAt": "2020-07-15T13:02:52.659Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12275,9 +12275,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:43 GMT',
+  'Wed, 15 Jul 2020 13:02:52 GMT',
   'etag',
-  'W/"7320513427971703336"',
+  'W/"7699653855840119255"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12287,29 +12287,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '090d090b86ab936b189ee55c17238e3a',
+  '6e4aa0ebcfa89626d3b01551b0cb78ef',
   'Content-Length',
   '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=CbR+HcBkRUifko98WdwrhYrmDl8AAAAAQUIPAAAAAADVlu9RnGIyAhjpmxFuKTAS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=b98OlC0oQlWLjj0VlgaN2Xz+Dl8AAAAAQUIPAAAAAACoslyGWMxCtWEk1pVMZUEj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=4RCbJsVbhGeIuOXFKsJtVwAAAAA07d0pwm3wC56UqbczZ+2Q; path=/; Domain=.contentful.com',
+  'nlbi_673446=0SbVKWEeLlQthHrlKsJtVwAAAADSszzNjdX2tOOQpBBE+uqS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=OK6TKaRwvGbFnA9OOoVtA4rmDl8AAAAAg1q46UaZ90BzwKeMKVX6Nw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=+3+zKzQpnlowASxOOoVtA3z+Dl8AAAAAfNZfEZieHx1qpF8dNEQzZQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47494995-47495055 NNNN CT(86 87 0) RT(1594812041380 1049) q(0 0 2 -1) r(3 3) U5'
+  '14-49432042-49432058 NNNN CT(88 86 0) RT(1594818172008 37) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12350,7 +12350,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 5,
-    "createdAt": "2020-07-15T11:20:40.502Z",
+    "createdAt": "2020-07-15T13:02:51.189Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12358,7 +12358,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:43.669Z",
+    "updatedAt": "2020-07-15T13:02:53.273Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12406,9 +12406,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:43 GMT',
+  'Wed, 15 Jul 2020 13:02:53 GMT',
   'etag',
-  'W/"15842520626996732315"',
+  'W/"11447616930947989638"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12426,21 +12426,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '860e8583155fee6bfa0f109051f7977f',
+  '0d7323f5817d2fd55f0eb6023bbfe33f',
   'Content-Length',
-  '461',
+  '460',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=fwbQe/ltTpOJmzdQ757ng4vmDl8AAAAAQUIPAAAAAADwSTV6UQ2c9yqTuCQHKjkj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=sP3PYtBQQviPZqY6QAAUjHz+Dl8AAAAAQUIPAAAAAAAp54FjEkIkY1o3Rkybktsz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xKEFZyL0yUX8Rb1XKsJtVwAAAAADqYZtCCLuQX2oAZ9ibMXl; path=/; Domain=.contentful.com',
+  'nlbi_673446=LW7TVJMx8Hj/fSlDKsJtVwAAAAApXMtzxL8CgBlMx255rp4P; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=qASVSmHtumoUng9OOoVtA4vmDl8AAAAA0XKF7qT5PNQZsBzGjukRjw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=AqugPpSr+HPkASxOOoVtA3z+Dl8AAAAA/tcmEcauOg2HiJEI5uIqAQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47495211-47495235 NNNN CT(94 179 0) RT(1594812042922 29) q(0 0 3 -1) r(4 4) U5'
+  '14-49432200-49432203 NNNN CT(91 88 0) RT(1594818172537 30) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12475,7 +12475,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-15T11:20:40.502Z",
+    "createdAt": "2020-07-15T13:02:51.189Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12483,7 +12483,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:44.373Z",
+    "updatedAt": "2020-07-15T13:02:53.778Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -12531,9 +12531,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:44 GMT',
+  'Wed, 15 Jul 2020 13:02:53 GMT',
   'etag',
-  'W/"5550279822272295734"',
+  'W/"3762647122089499610"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12543,29 +12543,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '8d79104b7e6a6f0f8ef0e8d44c0d7223',
+  'c615d48b7f4858b4c9bb895024caec28',
   'Content-Length',
-  '447',
+  '448',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=Pmyoq8YETRy9RH71f8ggTYzmDl8AAAAAQUIPAAAAAADfYG4mR48dqleBI2z5y/gS; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=pgrkkTj6Q+ebNKmQ4oFgCH3+Dl8AAAAAQUIPAAAAAADCm9L12K1VD+xR8m1cV97Z; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=elcUXWrrGgk2Q7nKKsJtVwAAAACATJDmwvbvFSDEtO5GHevs; path=/; Domain=.contentful.com',
+  'nlbi_673446=Ad8PMmcrnXoDqfD4KsJtVwAAAAC0K5xnvMWr767VWlmROLiK; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=CrHZTJddvmd+nw9OOoVtA4zmDl8AAAAAtfzCPqBNq8J8bmi7TjG/SQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=kkoTAbBtNQV+AixOOoVtA33+Dl8AAAAA6ial13xAr5EzWgJuUCIg4A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36013822-36013833 NNNN CT(88 87 0) RT(1594812043715 36) q(0 0 2 -1) r(4 4) U5'
+  '12-31855211-31855216 NNNN CT(92 87 0) RT(1594818173131 27) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12582,7 +12582,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
       }
     },
     "version": 6,
-    "createdAt": "2020-07-15T11:20:40.502Z",
+    "createdAt": "2020-07-15T13:02:51.189Z",
     "createdBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12590,7 +12590,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:44.373Z",
+    "updatedAt": "2020-07-15T13:02:53.778Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -12656,9 +12656,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:45 GMT',
+  'Wed, 15 Jul 2020 13:02:54 GMT',
   'etag',
-  'W/"2549979886228979859"',
+  'W/"818393047346919624"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -12668,29 +12668,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '30c7f1889270653cb938321ef15847d2',
-  'Content-Length',
-  '435',
+  '78798bd839a09118d18504ca02a703fd',
+  'transfer-encoding',
+  'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=aIOaqgPDRAq4deGDeBKX9ozmDl8AAAAAQUIPAAAAAABSuHGTPa6ABiwEIpy/cO9r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=LfyEbH9eSJuXqgWhPC94N37+Dl8AAAAAQUIPAAAAAAB08gsj+uNbr5BxMy0uIzm4; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=bthKSfaFGXyccdGnKsJtVwAAAAD+CcOWnxUrmpk+4NV2Jomk; path=/; Domain=.contentful.com',
+  'nlbi_673446=VmGGMsJzckTD5PnDKsJtVwAAAAAm0L2bcNc0hBGEyoAy/d9P; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=irxYOGLaigWtoA9OOoVtA4zmDl8AAAAA8FqUH32Pc9S7PTarlIswFw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=TxZWavG7CyFPAyxOOoVtA37+Dl8AAAAA4WTF3usMQXIVQqUuUHMG+w==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47495659-47495670 NNNN CT(94 97 0) RT(1594812044350 35) q(0 0 2 -1) r(4 4) U5'
+  '14-49432473-49432476 NNNN CT(93 94 0) RT(1594818173755 41) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12775,7 +12775,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:45 GMT',
+  'Wed, 15 Jul 2020 13:02:55 GMT',
   'etag',
   'W/"9102674631899357591"',
   'Server',
@@ -12787,29 +12787,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '915207304ad8c3368e6b9399a162eaf4',
-  'transfer-encoding',
-  'chunked',
+  'ec64020b0afeb80eda6c592a0adec8f1',
+  'Content-Length',
+  '375',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=x4qRHoimSuC8JGs2hJOChY3mDl8AAAAAQUIPAAAAAADgCJjfe5Fo3ftpQyULKnh7; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MkVAGg4zSpK/G1701M0XM37+Dl8AAAAAQUIPAAAAAABRKPz90FpL669EFkV6UBvc; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=DSA6Q3Hohgn7TeXjKsJtVwAAAACs4Y14T8VdR3qY5h72VLpO; path=/; Domain=.contentful.com',
+  'nlbi_673446=cp7YGS4lTmGarWzeKsJtVwAAAAC1qoLiEkAG+TwQ/ZRkWj2c; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=6fCfeIHTp2gIog9OOoVtA43mDl8AAAAA1tvAr043z3ucH7qJGWj2ow==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=m+sFRy4XnGfZAyxOOoVtA37+Dl8AAAAAZioJejL8mZvexZV/3Ez/zw==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '9-9351974-9351979 NNNN CT(86 86 0) RT(1594812044978 39) q(0 0 1 -1) r(3 3) U5'
+  '11-25374217-25374220 NNNN CT(85 88 0) RT(1594818174375 30) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12850,8 +12850,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -12881,9 +12881,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:46 GMT',
+  'Wed, 15 Jul 2020 13:02:55 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -12903,7 +12903,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '1aaf5cb33a10b88e6747417821171314',
+  'c0ef4fafdc9f824339acfe47c7197145',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -12915,11 +12915,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=vLLmksM3SECQMw4bPm9cDI3mDl8AAAAAQUIPAAAAAABiZV0NJTbVT0ve3CGJ4lyQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=tcxy18tWS5e34/U7SwXf23/+Dl8AAAAAQUIPAAAAAADHjTRmp0rCZibp02etfY+B; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=/FREAGWA7CxWWi1aKsJtVwAAAAChseS8t3v3XV69bGt4iWtX; path=/; Domain=.contentful.com',
+  'nlbi_673446=zImJEbqyK03awwhbKsJtVwAAAACvFVJyiezS9XrFlsgSiCpL; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=8stwLqxIwG7cog9OOoVtA43mDl8AAAAA6sznKKLJuBlazPIzl/1ftQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=cgSkdNyTqWJLBCxOOoVtA3/+Dl8AAAAAiqbSS8o7FZEr1oP1a02vbQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -12927,7 +12927,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24200822-24200833 NNYN CT(87 87 0) RT(1594812045412 31) q(0 0 2 -1) r(3 3) U5'
+  '10-15258221-15258229 NNYN CT(88 89 0) RT(1594818174791 27) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -12987,7 +12987,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:46.662Z",
+    "updatedAt": "2020-07-15T13:02:55.852Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13035,9 +13035,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:46 GMT',
+  'Wed, 15 Jul 2020 13:02:55 GMT',
   'etag',
-  'W/"6300795379564271779"',
+  'W/"4499226611754722291"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13055,21 +13055,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'a3ba8bdb7099db0ae1d45f9ec14e694d',
+  'd66591ee8c278ba6c62a0b1e2cf87d5a',
   'Content-Length',
-  '541',
+  '540',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=SH3qipzoSpyGgnZdwhk8jY7mDl8AAAAAQUIPAAAAAAD7t/vEQmZcp5UAJTwEOmov; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=J7Y6HtF3S++mYe6wxV4Ak3/+Dl8AAAAAQUIPAAAAAAD/Lda+pth3nq4k9Al4OTXz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=TsuDZUru1BF7MRidKsJtVwAAAACkOKCxJqMx/Ta7H3l4yFCW; path=/; Domain=.contentful.com',
+  'nlbi_673446=buDjbFLBokZjZ7keKsJtVwAAAADOM1S5ZBnJg/vz1Onwa7AN; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=4uoLbaeCPV5NpA9OOoVtA47mDl8AAAAAP0tZeuHzLgBgCGEd+iiALw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=3gTaChTiZRPQBCxOOoVtA3/+Dl8AAAAAig/WqT7e2bdeZcbCPurJ7A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24200947-24200954 NNNN CT(96 94 0) RT(1594812045992 28) q(0 0 2 -1) r(3 3) U5'
+  '12-31855633-31855642 NNNN CT(88 88 0) RT(1594818175193 36) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13129,7 +13129,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:47.365Z",
+    "updatedAt": "2020-07-15T13:02:56.486Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13177,9 +13177,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:47 GMT',
+  'Wed, 15 Jul 2020 13:02:56 GMT',
   'etag',
-  'W/"12246231550174047110"',
+  'W/"13568929678516717374"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13197,21 +13197,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'f4686ee9529b64d9a6a228367777bdd0',
+  '2f1659858326c472a533be369d58aa6f',
   'Content-Length',
-  '540',
+  '541',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=SYWQeZ9cTRSDwEJA+pWAPY/mDl8AAAAAQUIPAAAAAACBFDOq1jkVPdU/dc5lsaMb; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=QRusJu9jTQGtC0Z9BnySq4D+Dl8AAAAAQUIPAAAAAAC4+p70EsE2X6iCAQNvIstj; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=UGCsPYEnZCNUypprKsJtVwAAAABHrT462yhR3soQdSZ8Gp0h; path=/; Domain=.contentful.com',
+  'nlbi_673446=77lbWoxxBWQ8iBLQKsJtVwAAAADN7wEXdTD07NPSDW0gis8M; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=1xT9QF9GOR7CpQ9OOoVtA4/mDl8AAAAAx/heQ6jCHUYo2yAX6hSl1A==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=ovH9chVwXUihBSxOOoVtA4D+Dl8AAAAAyMLEH40O/mQaI4lxdji2XA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47496472-47496481 NNNN CT(88 89 0) RT(1594812046618 31) q(0 0 2 -1) r(4 4) U5'
+  '11-25374435-25374442 NNNN CT(93 95 0) RT(1594818175799 39) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13271,7 +13271,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:47.859Z",
+    "updatedAt": "2020-07-15T13:02:57.031Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13319,9 +13319,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:47 GMT',
+  'Wed, 15 Jul 2020 13:02:57 GMT',
   'etag',
-  'W/"13579519715100886220"',
+  'W/"10619391741830936985"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13339,21 +13339,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '30e39315c9a9942e4c097df002798cd2',
+  'd5d02aef6808ffa2ea51676b19852b8a',
   'Content-Length',
-  '541',
+  '540',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=hj9nKZ83QxawcjbK8eO7JY/mDl8AAAAAQUIPAAAAAAA1P19Q/yD0pBmHhIaIiv4r; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=3oR1QdXORhaW3wnFP8yhP4D+Dl8AAAAAQUIPAAAAAAAWPOrAKBmyvwtvsPE/OCFY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WNWqRJfqBVm8gJArKsJtVwAAAAAQIzjENbVrDnvzk0r4bl1c; path=/; Domain=.contentful.com',
+  'nlbi_673446=dLuLCciTiAP+5RaPKsJtVwAAAADOcXS8B6xmRz5LCkTQa2to; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=ScDkUlOIGnPGpg9OOoVtA4/mDl8AAAAAXelYHTvmRcBvWT1masWDig==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=zIuzeIwCkUREBixOOoVtA4D+Dl8AAAAAE3etneJJ1YrrBTTojKn4hg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-7443372-7443381 NNNN CT(86 87 0) RT(1594812047210 30) q(0 0 2 -1) r(4 4) U5'
+  '7-13173528-13173529 NNNN CT(88 89 0) RT(1594818176383 25) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13413,7 +13413,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:48.345Z",
+    "updatedAt": "2020-07-15T13:02:57.575Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13461,9 +13461,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:48 GMT',
+  'Wed, 15 Jul 2020 13:02:57 GMT',
   'etag',
-  'W/"2585629672618438490"',
+  'W/"12597896201008085464"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13481,21 +13481,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '5e766863b89d1e3ed4ba90276cc41db2',
+  '0865e1e7b402c4603bf3e93eca74d997',
   'Content-Length',
-  '541',
+  '540',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=is0u/qoOTV+iSTgp6DCiR5DmDl8AAAAAQUIPAAAAAAA6kTPm7jCF1CM3NiFjp6to; expires=Wed, 14 Jul 2021 14:42:28 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=VwzGZ9upQq6Hti0SeLoxfoH+Dl8AAAAAQUIPAAAAAACI6DdiJsFOAdvpleTH11OR; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=UUPnJSLUEiWtozagKsJtVwAAAAB1koNk/D3bBaoWByoRXANz; path=/; Domain=.contentful.com',
+  'nlbi_673446=BbiVUqkgETmIkfvRKsJtVwAAAACA2m00+wFUbJ/5anUpdt7z; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=nnO/HUM7Rwuwpw9OOoVtA5DmDl8AAAAAgj0St4qWu0Aaw1ZZO3Yofw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=yoHFEJ+i0CnDBixOOoVtA4H+Dl8AAAAAKK0+b56jODW0dctiSIoM1g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '0-1832221-1832222 NNNN CT(93 94 0) RT(1594812047682 28) q(0 0 1 -1) r(4 4) U5'
+  '10-15258547-15258553 NNNN CT(86 86 0) RT(1594818176929 33) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13549,7 +13549,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:49.219Z",
+    "updatedAt": "2020-07-15T13:02:58.077Z",
     "updatedBy": {
       "sys": {
         "type": "Link",
@@ -13597,9 +13597,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:49 GMT',
+  'Wed, 15 Jul 2020 13:02:58 GMT',
   'etag',
-  'W/"17085535333605885126"',
+  'W/"14419499485752191714"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13617,21 +13617,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '1c1c9f52bfb11a2222e9b214f318de6c',
+  'f883237bd979d9a2b991626618b66233',
   'Content-Length',
   '524',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=ImwXYbUpTwePEWMEJ5V9i5DmDl8AAAAAQUIPAAAAAABoBqCz49Ij4Oqva4CoGHst; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=fEMc+CzJQyqzqdFP7Dg954H+Dl8AAAAAQUIPAAAAAACGLyHfwP/xqHRCub7vgnrE; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=WDjQZ+iv4Ggr/bc6KsJtVwAAAACq5NEa92o3AhIaxfJDk8W+; path=/; Domain=.contentful.com',
+  'nlbi_673446=8clSdK3xoSdcDcRlKsJtVwAAAADqYPgXsf85QKfJz7AmZh6C; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=vbNdTorH91t7qQ9OOoVtA5DmDl8AAAAAWE0U4u6LTi3i5N6e6eot4g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=AlnWQUvf5iVcByxOOoVtA4H+Dl8AAAAAXy5mLSskSSeH2p3+WtronQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47496986-47496994 NNNN CT(90 90 0) RT(1594812048243 28) q(0 0 2 -1) r(7 7) U5'
+  '5-24178048-24178050 NNNN CT(87 86 0) RT(1594818177432 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13656,7 +13656,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "linkType": "User"
       }
     },
-    "updatedAt": "2020-07-15T11:20:49.219Z",
+    "updatedAt": "2020-07-15T13:02:58.077Z",
     "updatedBy": {
       "sys": {
         "id": "1Y7O5FbAkPYgNvD0MpQoAE",
@@ -13733,9 +13733,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:49 GMT',
+  'Wed, 15 Jul 2020 13:02:59 GMT',
   'etag',
-  'W/"16753442353884750983"',
+  'W/"13101617569297844199"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13745,29 +13745,29 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '879e756df7c16142f9944b5aae54b715',
-  'transfer-encoding',
-  'chunked',
+  '28a2cbd4dcf941b15ebd231c0efe2c8b',
+  'Content-Length',
+  '519',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=1/7XMCVaTj+QNKFWfAS/T5HmDl8AAAAAQUIPAAAAAABmdp1uU6YdFffAaHMrMY0p; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=GRVZNx2HTnixQYc3RB0MEYP+Dl8AAAAAQUIPAAAAAAAwCmR/1aV2ORU5eb4Yqys3; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=t0A2W/9zpHeZgejSKsJtVwAAAADRS9t1xtf1rEWszy0KUMRP; path=/; Domain=.contentful.com',
+  'nlbi_673446=O12ZKNkvKRJFSKtVKsJtVwAAAAA+YXQSJ8jJTU0LeKTAbQpS; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=EhCkANbrXxSIqg9OOoVtA5HmDl8AAAAAfiTzJu+4dQL642deJuw/tw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Y7ZTfdpN+HrACCxOOoVtA4P+Dl8AAAAAiYCqzL/emRzT66HeLoviTQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '11-24201625-24201635 NNNN CT(93 94 0) RT(1594812049060 39) q(0 0 2 -1) r(4 4) U5'
+  '13-37655234-37655240 NNNN CT(88 88 0) RT(1594818178845 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13811,8 +13811,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-15T11:20:11.344Z",
-        "updatedAt": "2020-07-15T11:20:11.344Z",
+        "createdAt": "2020-07-15T13:02:22.024Z",
+        "updatedAt": "2020-07-15T13:02:22.024Z",
         "version": 1
       },
       "name": "long example marketing"
@@ -13841,9 +13841,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:50 GMT',
+  'Wed, 15 Jul 2020 13:03:00 GMT',
   'etag',
-  '"235608248538559367"',
+  '"6384273142753892014"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -13861,15 +13861,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '9f7dbc746a35c2ef0c8bdb965e57af7e',
+  '84cca67e85dba96cb57cade33a84ba4c',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=C4DSJFXzRy+bSJs3BnUPdJLmDl8AAAAAQUIPAAAAAADZUly6qc3laNEGotz6mmvW; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=WwrnIJFyQkKV9wrUmtGbsoP+Dl8AAAAAQUIPAAAAAAAwI2+oflyv+5orBljHKmAI; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=RfwcF6So60fEZrluKsJtVwAAAABltBb+EvJxPOh2heOexy30; path=/; Domain=.contentful.com',
+  'nlbi_673446=/6LJNWECPz0aBWYKKsJtVwAAAAA5fUGdbBC8isZvOwISTiQW; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=zdZaSQmChXISrA9OOoVtA5LmDl8AAAAAzMyYDkuZJfglIk7Q2KUKow==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=l2tOWISpDyVdCSxOOoVtA4P+Dl8AAAAAtTffpAI3vkt2PdmrxXbMhQ==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13877,7 +13877,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '9-9352597-9352599 NNYN CT(88 88 0) RT(1594812049672 29) q(0 0 1 -1) r(4 4) U5'
+  '9-9991236-9991241 NNYN CT(93 107 0) RT(1594818179499 32) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -13918,8 +13918,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -13949,9 +13949,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:50 GMT',
+  'Wed, 15 Jul 2020 13:03:00 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -13971,7 +13971,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '3ea795fde2fe731a70621049017c2c60',
+  'fbf94f8c89f9c28c70ef175e6a10fa65',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -13983,11 +13983,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=NfOldbhuTwWitVXjzYyxQpLmDl8AAAAAQUIPAAAAAABZIi/SDR7xZblJck3UJ+en; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=QmDkS5+JQoy7IHp2BBe8vIT+Dl8AAAAAQUIPAAAAAABVTTtMKweGaONNYLxZHtI3; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=a83TCAu0XXF/vGO6KsJtVwAAAAA2yeFi1ds/gi60ERYmxagi; path=/; Domain=.contentful.com',
+  'nlbi_673446=4iEEXbszM2r2+SzuKsJtVwAAAAAKKwZheY9KibPIUSHbFTjH; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=WPFeNE8ypxcBrQ9OOoVtA5LmDl8AAAAAKeW0xnfXxcZczUR26c0gFg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=htZCXEd5NCeyCSxOOoVtA4T+Dl8AAAAAHIrG4ynoNkn239G9x4fdAA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -13995,12 +13995,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-36015878-36015901 NNYN CT(93 95 0) RT(1594812050288 35) q(0 0 2 -1) r(3 3) U5'
+  '11-25375242-25375251 NNYN CT(94 94 0) RT(1594818179947 28) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":0},"name":"marketing"})
-  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-15T11:20:51.359Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T11:20:51.359Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
+  .reply(201, {"sys":{"id":"sampletag","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"type":"Tag","createdAt":"2020-07-15T13:03:01.197Z","createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedAt":"2020-07-15T13:03:01.197Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}}},"name":"marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -14022,9 +14022,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:51 GMT',
+  'Wed, 15 Jul 2020 13:03:01 GMT',
   'etag',
-  '"15929164439664930325"',
+  '"7287126510657505518"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14042,21 +14042,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'b9c460c0556907e43262f5f687023e9e',
+  '2aaec2638815d4e9902414a29ee6db97',
   'Content-Length',
   '740',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=akc65/HXTuaqQbToHfym85PmDl8AAAAAQUIPAAAAAAA03WR0H0vhSAhUqiXPlRBE; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=/cea3GXVScOoh1K8DOq45IT+Dl8AAAAAQUIPAAAAAAB1EhFFnkuGCbvvM8pqmdlB; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=FecONtKPqCUVAkezKsJtVwAAAAB2JFJrX8BwJlI7HhFnSdgG; path=/; Domain=.contentful.com',
+  'nlbi_673446=zvK4DLkrJSmKoaFyKsJtVwAAAACiO2ArtOZsrFoZZxohhLvR; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=nWxTBNToFF39rQ9OOoVtA5PmDl8AAAAAIDJNrKRhp9ykaMH8uAUXJQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=qHquC5CdIVpiCixOOoVtA4T+Dl8AAAAAlsvDWeQrZuJOOx1O2k9RZg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '14-47497856-47497870 NNNN CT(87 87 0) RT(1594812050720 30) q(0 0 2 -1) r(3 3) U5'
+  '8-4813525-4813529 NNNN CT(86 87 0) RT(1594818180542 28) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14093,8 +14093,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-15T11:20:51.359Z",
-    "updatedAt": "2020-07-15T11:20:51.359Z",
+    "createdAt": "2020-07-15T13:03:01.197Z",
+    "updatedAt": "2020-07-15T13:03:01.197Z",
     "version": 1
   },
   "name": "marketing"
@@ -14121,9 +14121,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:51 GMT',
+  'Wed, 15 Jul 2020 13:03:01 GMT',
   'etag',
-  '"14972952534566751389"',
+  '"10814838849760543173"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14141,15 +14141,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '87fc2419a3481198e62e95c97f463d23',
+  '49022b8f554df176ec12e1e1ad90b776',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=WWgpIPsiQgi7nkcHtQDp9pPmDl8AAAAAQUIPAAAAAAAB97zZtmGTXjMbJxz+B7Mv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=OKJCM6ewTb2buWMuu9JZvIX+Dl8AAAAAQUIPAAAAAAA7JjFESbCsTl9X5yQRK6Iu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gfAgHirljWrVzDcpKsJtVwAAAAD/Jv+IRqp2vwDbC3e4W4y8; path=/; Domain=.contentful.com',
+  'nlbi_673446=5Ap9StPSHkosujmpKsJtVwAAAACNNUHCdK5ZpXxEveZ32YZG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=GFxyZ+tpOk41rw9OOoVtA5PmDl8AAAAA99kcbmRIOsHP9xtQUXV3pA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=sEv6KXfpuBIkCyxOOoVtA4X+Dl8AAAAA1SozcReIlgezSVhjwo+O3A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14157,7 +14157,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '11-24202170-24202179 NNYN CT(93 93 0) RT(1594812051334 28) q(0 0 2 -1) r(4 4) U5'
+  '13-37655779-37655789 NNYN CT(101 95 0) RT(1594818181133 42) q(0 0 2 -1) r(4 4) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14201,8 +14201,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-15T11:20:51.359Z",
-        "updatedAt": "2020-07-15T11:20:51.359Z",
+        "createdAt": "2020-07-15T13:03:01.197Z",
+        "updatedAt": "2020-07-15T13:03:01.197Z",
         "version": 1
       },
       "name": "marketing"
@@ -14239,8 +14239,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-15T11:20:11.344Z",
-        "updatedAt": "2020-07-15T11:20:11.344Z",
+        "createdAt": "2020-07-15T13:02:22.024Z",
+        "updatedAt": "2020-07-15T13:02:22.024Z",
         "version": 1
       },
       "name": "long example marketing"
@@ -14271,9 +14271,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:52 GMT',
+  'Wed, 15 Jul 2020 13:03:02 GMT',
   'etag',
-  'W/"1725391273288666372"',
+  'W/"10463404004260034275"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14291,21 +14291,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '1ef0760148841d757be4bfc617a9285e',
+  'd8121d5e0a8d637d5aafaddc2b116fd3',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=anphh0ReTsCxQYDhjkpX3JTmDl8AAAAAQUIPAAAAAAAuQ0Yry0zDhECe62vS6Ufh; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=83oC0UMpQfaTEqirfSylXoX+Dl8AAAAAQUIPAAAAAACwTCzmeTQSq5kAFbYbgvYv; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=6/tgKibcZnZXLvpjKsJtVwAAAACLMPaTRfCvpN3HqoN5JDzB; path=/; Domain=.contentful.com',
+  'nlbi_673446=AM0fC+lNlHQFyTaiKsJtVwAAAAA6mDCvaoj/IR4WWajuF6f0; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=MKk5BwbfknQqsA9OOoVtA5TmDl8AAAAADs/lIz4wKz0EKQkC3gukAQ==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=0ifxNnK0VFDqCyxOOoVtA4X+Dl8AAAAAhe+n49WJKfWRI49Kb4qT7A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '13-36016322-36016349 NNNN CT(94 113 0) RT(1594812051929 37) q(0 0 2 -1) r(4 4) U5'
+  '8-4813599-4813603 NNNN CT(89 88 0) RT(1594818181617 29) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14346,8 +14346,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -14377,9 +14377,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:53 GMT',
+  'Wed, 15 Jul 2020 13:03:02 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -14391,15 +14391,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  'b568ea7d916d5c26a99e0d756a9cd9b7',
+  'a9ca7809dbaba640d65099f2a51089b7',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -14411,11 +14411,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=aMUFwvNbQJKTDhnEGt6Dc5XmDl8AAAAAQUIPAAAAAADHWBVarF5tIbgd95qgrQjH; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=aPTAbhlSSROuG2ibaj1jI4b+Dl8AAAAAQUIPAAAAAADnp5dQjqSZsHGcCTkPSV7i; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=5G90AC7MexjAIiNzKsJtVwAAAABj0HC0tmpg75obwrCxGA65; path=/; Domain=.contentful.com',
+  'nlbi_673446=GQRzdeWc4mtPcTZkKsJtVwAAAACg6skgZoXqRzI28sgxd6eX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=/FqYLrVaRlmNsg9OOoVtA5XmDl8AAAAAT8MdKeyOCTC4QCIND26Kbw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=4pR7CfSOR3eUDCxOOoVtA4b+Dl8AAAAA079pzfB7NbdJu3zoT0BMgg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14423,12 +14423,12 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '13-36016544-36016562 NNYN CT(93 93 0) RT(1594812052542 33) q(0 0 2 -1) r(9 9) U5'
+  '12-31857017-31857019 NNYN CT(87 89 0) RT(1594818182153 36) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   .put('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":1},"name":"better marketing"})
-  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-15T11:20:51.359Z","updatedAt":"2020-07-15T11:20:54.241Z","version":2},"name":"better marketing"}, [
+  .reply(200, {"sys":{"type":"Tag","id":"sampletag","space":{"sys":{"type":"Link","linkType":"Space","id":"bohepdihyxin"}},"environment":{"sys":{"id":"env-integration","type":"Link","linkType":"Environment"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"updatedBy":{"sys":{"type":"Link","linkType":"User","id":"1Y7O5FbAkPYgNvD0MpQoAE"}},"createdAt":"2020-07-15T13:03:01.197Z","updatedAt":"2020-07-15T13:03:03.438Z","version":2},"name":"better marketing"}, [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
   'Access-Control-Allow-Methods',
@@ -14450,9 +14450,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:54 GMT',
+  'Wed, 15 Jul 2020 13:03:03 GMT',
   'etag',
-  '"2965724126806960779"',
+  '"4858739171092033580"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14470,21 +14470,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'fe7cf5647f84e485e68319ca9a8427d0',
+  '41ba3ba920b835dc3c2b08902177d69f',
   'Content-Length',
   '747',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=BtJ/ZWjXR4KMLtqc4qlXSJXmDl8AAAAAQUIPAAAAAACh0yq9YGWuUKxrYLtnW5uu; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=lZhzM9uVRde82WEY6/VuSof+Dl8AAAAAQUIPAAAAAACci1cRS/9hGKMI0kwULnCp; expires=Wed, 14 Jul 2021 14:42:27 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=VHaIEYKBXirFFL99KsJtVwAAAAAR5WFi940cIL1DoPut7nq7; path=/; Domain=.contentful.com',
+  'nlbi_673446=wQZfIWHgbGoeBOo7KsJtVwAAAAALYdhzo/dbwWnVy4YLS/sh; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=gLUGFdx5rh+dsw9OOoVtA5XmDl8AAAAAZaLiBRby8nrbYMqwatRaDA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=Lyj1SGx3uzSBDSxOOoVtA4f+Dl8AAAAAns1pfit09FesaAFEJciIAg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '10-14431620-14431629 NNNN CT(93 93 0) RT(1594812053577 30) q(0 0 1 -1) r(3 3) U5'
+  '5-24178588-24178590 NNNN CT(93 94 0) RT(1594818182779 28) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14521,8 +14521,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
         "id": "1Y7O5FbAkPYgNvD0MpQoAE"
       }
     },
-    "createdAt": "2020-07-15T11:20:51.359Z",
-    "updatedAt": "2020-07-15T11:20:54.241Z",
+    "createdAt": "2020-07-15T13:03:01.197Z",
+    "updatedAt": "2020-07-15T13:03:03.438Z",
     "version": 2
   },
   "name": "better marketing"
@@ -14549,9 +14549,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:54 GMT',
+  'Wed, 15 Jul 2020 13:03:04 GMT',
   'etag',
-  '"2965724126806960779"',
+  '"4858739171092033580"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14569,15 +14569,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  '8ef53c272490417b82ab59d42e392bf0',
+  'd8d3e499f5de64b8aca6f35db9ac5965',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=299a305XQoC84HAW4R9AlJbmDl8AAAAAQUIPAAAAAACIdIvTDGu3fFK5KuVe8TH9; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=MPo6b8mcTWOKS2YwBGb6Jof+Dl8AAAAAQUIPAAAAAABmmWUtnYRtQU217bOMeVLz; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=gtXZGyVgsA6Ywi2OKsJtVwAAAAAMiP1xdGqknXWXRaeqv8PY; path=/; Domain=.contentful.com',
+  'nlbi_673446=q7hPAeucwiGm5KasKsJtVwAAAADayZEvxUs6GhckEO1TGPJ9; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=g9ApQqSgv1FrtA9OOoVtA5bmDl8AAAAAn0nU2a9o0uN5yV6JxUiXKw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=c+C+WnpjUzUyDixOOoVtA4f+Dl8AAAAA4gJGFsSt+9r6WccKfu4+FA==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14585,7 +14585,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '7-12577938-12577942 NNYN CT(87 87 0) RT(1594812054048 30) q(0 0 2 -1) r(3 3) U5'
+  '14-49435010-49435023 NNYN CT(93 97 0) RT(1594818183373 35) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14629,8 +14629,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-15T11:20:51.359Z",
-        "updatedAt": "2020-07-15T11:20:54.241Z",
+        "createdAt": "2020-07-15T13:03:01.197Z",
+        "updatedAt": "2020-07-15T13:03:03.438Z",
         "version": 2
       },
       "name": "better marketing"
@@ -14667,8 +14667,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id": "1Y7O5FbAkPYgNvD0MpQoAE"
           }
         },
-        "createdAt": "2020-07-15T11:20:11.344Z",
-        "updatedAt": "2020-07-15T11:20:11.344Z",
+        "createdAt": "2020-07-15T13:02:22.024Z",
+        "updatedAt": "2020-07-15T13:02:22.024Z",
         "version": 1
       },
       "name": "long example marketing"
@@ -14699,9 +14699,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:55 GMT',
+  'Wed, 15 Jul 2020 13:03:04 GMT',
   'etag',
-  'W/"12627871901362631166"',
+  'W/"313427910239614299"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14719,21 +14719,21 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  '4ef30785622097855abd556eaedcc416',
+  '216aecc3b6e8dccbdbce1f2f279ab775',
   'transfer-encoding',
   'chunked',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=kAJ0YmTXTxi5udIgM7CVipbmDl8AAAAAQUIPAAAAAABaHRwwhG0YPEunINOHwX9a; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=e4HQpYVBRhSQUEYid39Sc4j+Dl8AAAAAQUIPAAAAAABm1p5wT+U2ucYB6m+OGnKY; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=BWkjNrbByVQVMDZQKsJtVwAAAACC38hwlRS4aPzZ9IJyeGCz; path=/; Domain=.contentful.com',
+  'nlbi_673446=5ZTNWtdKPyJXu18nKsJtVwAAAADeIRWnPuyW4gr8PYpMBaxq; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=eUGMbSQ4v3KftQ9OOoVtA5bmDl8AAAAA3H2UNg5JGaLP8SyH0azH+Q==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=1uaqRH1FYWy5DixOOoVtA4j+Dl8AAAAAoAKAY2mJYFR9VePNQC/Y1A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '12-30386709-30386722 NNNN CT(86 87 0) RT(1594812054598 32) q(0 0 2 -1) r(3 3) U5'
+  '11-25375986-25376012 NNNN CT(88 89 0) RT(1594818183873 34) q(0 0 1 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14774,8 +14774,8 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
             "id":"env-integration"
           }
         },
-        "createdAt":"2020-07-15T11:19:28Z",
-        "updatedAt":"2020-07-15T11:19:28Z"
+        "createdAt":"2020-07-15T13:01:40Z",
+        "updatedAt":"2020-07-15T13:01:40Z"
       }
     }
   ]
@@ -14805,9 +14805,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:55 GMT',
+  'Wed, 15 Jul 2020 13:03:04 GMT',
   'etag',
-  'W/"0c620f18e31bd26710de56f85f1c4e18"',
+  'W/"6e10216e1ac922f60100fcd077f6c626"',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -14827,7 +14827,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '8',
   'X-Contentful-Request-Id',
-  'a863d72256577e358abf53cf33c2805b',
+  'c891a8f0f7f1fef0ef6a442079e3f977',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -14839,11 +14839,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=cHPbg6HPRfSCbb4Kgzf/mZfmDl8AAAAAQUIPAAAAAAAhBir05DKxYvOqfc9QmGes; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=wWOIh0TMQymiNbkqGz6kQIj+Dl8AAAAAQUIPAAAAAADNQ0HvECmISGEAuv7BvwAo; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=uewpSOz5tC4gMPv3KsJtVwAAAACNs4Jip1Ja/MI92p+pLAmM; path=/; Domain=.contentful.com',
+  'nlbi_673446=KbhlQJ3K60JnAoZNKsJtVwAAAAARPhWPU8gtImgpCC8xvFhX; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=bGF6QZgJ/kTRtg9OOoVtA5fmDl8AAAAABKA7qhMV5kE+WA6O7FzdNw==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=gm5pNHELLh40DyxOOoVtA4j+Dl8AAAAAGLQ0gQGoSOdZtwZt9sxLvg==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14851,11 +14851,11 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '6-7443853-7443860 NNYN CT(94 96 0) RT(1594812055206 32) q(0 0 2 -1) r(3 3) U5'
+  '13-37656461-37656468 NNYN CT(86 87 0) RT(1594818184398 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
-  .delete('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag', {"sys":{"id":"sampletag","version":2},"name":"better marketing"})
+  .delete('/spaces/bohepdihyxin/environments/env-integration/tags/sampletag')
   .reply(204, "", [
   'Access-Control-Allow-Headers',
   'Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team,X-Contentful-Parent-Id,x-contentful-validate-only,X-Contentful-Skip-UI-Draft-Validation,X-Contentful-Marketplace,X-Contentful-UI-Content-Auto-Save',
@@ -14878,7 +14878,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:56 GMT',
+  'Wed, 15 Jul 2020 13:03:05 GMT',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14896,19 +14896,19 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Second-Remaining',
   '9',
   'X-Contentful-Request-Id',
-  'bd3a91e9372192e04bd7be633a6605ac',
+  '100ec466d7e1a657fbd50ce48e1f3a33',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=4X+YdLIETSSXwrA0g0MxPJjmDl8AAAAAQUIPAAAAAACwMq1fXqRhVsthMCPfyLqF; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=G4FbljwqQj2Hz/pntuzJEIn+Dl8AAAAAQUIPAAAAAABJtQXMO0X0vAExhY54istQ; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=xfuHMktQYRmCKJABKsJtVwAAAAAxL9jHpDTwpO5fLikh3JrA; path=/; Domain=.contentful.com',
+  'nlbi_673446=d39UTqjPGgdYAes7KsJtVwAAAAAU1rkVk9PPC2UQSgHX9YXt; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=fvSnIW4RMWLGtw9OOoVtA5jmDl8AAAAAlZZU0ihIp1tP1akCwGt1hA==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=WjL/Twn9LDGpDyxOOoVtA4n+Dl8AAAAAShLSSX4qM/yEzejHfd049A==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '4-15469688-15469694 NNNN CT(93 93 0) RT(1594812055614 30) q(0 0 2 -1) r(4 4) U5'
+  '7-13174144-13174146 NNNN CT(88 88 0) RT(1594818184807 29) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -14925,7 +14925,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
     "environment": "env-integration",
     "space": "bohepdihyxin"
   },
-  "requestId": "6ad0b13eaec148e07fd0727fd120c247"
+  "requestId": "fea5a7f4298604f1f1e4e62dcbfba3a8"
 }
 , [
   'Access-Control-Allow-Headers',
@@ -14949,9 +14949,9 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:56 GMT',
+  'Wed, 15 Jul 2020 13:03:06 GMT',
   'etag',
-  '"14807791832860259092"',
+  '"2679286926505558565"',
   'Server',
   'Contentful',
   'Strict-Transport-Security',
@@ -14961,23 +14961,23 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35998',
+  '35999',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '8',
+  '9',
   'X-Contentful-Request-Id',
-  '6ad0b13eaec148e07fd0727fd120c247',
+  'fea5a7f4298604f1f1e4e62dcbfba3a8',
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=OW9oTe/hRHGRoxS++GJBRJjmDl8AAAAAQUIPAAAAAABVE0y912Bkki9qgMAXp+37; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=BWKeSA6yRv6XHmOonyi2ZYn+Dl8AAAAAQUIPAAAAAACXuJtTzT5aikDJmQzgprfi; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=wxbTDDXky2ELTb57KsJtVwAAAADwVnefRrEjmCXtXrXuLYMl; path=/; Domain=.contentful.com',
+  'nlbi_673446=iZOCWKCTnj75Ny/SKsJtVwAAAAA5GPsOg5QBxQA3OxfP1ksG; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=snnPR6Eq51AauQ9OOoVtA5jmDl8AAAAAy5f45lRElQT9APxNRyTezg==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=uptUWf9tOnE5ECxOOoVtA4n+Dl8AAAAAEQyFFQeDxXw2iRkq2Lr44g==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   
@@ -14985,7 +14985,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Transfer-Encoding',
   'chunked',
   'X-Iinfo',
-  '3-10885134-10885140 NNYN CT(93 94 0) RT(1594812056231 28) q(0 0 2 -1) r(3 3) U5'
+  '4-16163701-16163704 NNYN CT(85 87 0) RT(1594818185429 30) q(0 0 2 -1) r(3 3) U5'
 ]);
 
 nock('https://api.contentful.com:443', {"encodedQueryParams":true})
@@ -15010,7 +15010,7 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Contentful-Api',
   'cma',
   'Date',
-  'Wed, 15 Jul 2020 11:20:58 GMT',
+  'Wed, 15 Jul 2020 13:03:07 GMT',
   'referrer-policy',
   'strict-origin-when-cross-origin',
   'Server',
@@ -15022,15 +15022,15 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'X-Contentful-RateLimit-Hour-Limit',
   '36000',
   'X-Contentful-RateLimit-Hour-Remaining',
-  '35999',
+  '35998',
   'X-Contentful-RateLimit-Reset',
   '0',
   'X-Contentful-RateLimit-Second-Limit',
   '10',
   'X-Contentful-RateLimit-Second-Remaining',
-  '9',
+  '8',
   'X-Contentful-Request-Id',
-  '7d7b155b4acd205a38442176c8497103',
+  '0e047fb06f48618be659fd9b0ab3b264',
   'x-download-options',
   'noopen',
   'x-frame-options',
@@ -15042,13 +15042,13 @@ nock('https://api.contentful.com:443', {"encodedQueryParams":true})
   'Connection',
   'Close',
   'Set-Cookie',
-  'visid_incap_673446=MP3ZwU1BRpG8ZphXPkEjt5nmDl8AAAAAQUIPAAAAAACQIYL+bCHa4RmbjuvuwTk5; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
+  'visid_incap_673446=Ur1u/LCNRgqvZtq6jmejnIv+Dl8AAAAAQUIPAAAAAAC8XEEnru1SWjWSLckEvK3E; expires=Wed, 14 Jul 2021 14:42:26 GMT; HttpOnly; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'nlbi_673446=vBgzW1fquinLNOORKsJtVwAAAACowxNbZJuHeQG665m8FRjE; path=/; Domain=.contentful.com',
+  'nlbi_673446=AEN1K3XfUwXubG9aKsJtVwAAAAD3XySpeGH9lwL2ZTk6s5TQ; path=/; Domain=.contentful.com',
   'Set-Cookie',
-  'incap_ses_247_673446=tVkjYI85i13ivA9OOoVtA5nmDl8AAAAAClDnG2tKZ/oawDqav+vh6g==; path=/; Domain=.contentful.com',
+  'incap_ses_247_673446=xOVTOA+sGEEMEixOOoVtA4v+Dl8AAAAA56AVISorSkat16OiPJdB4Q==; path=/; Domain=.contentful.com',
   'X-CDN',
   'Incapsula',
   'X-Iinfo',
-  '6-7444023-7444025 NNNN CT(88 89 0) RT(1594812056848 32) q(0 0 2 -1) r(11 11) U5'
+  '13-37656770-37656774 NNNN CT(88 89 0) RT(1594818186055 32) q(0 0 2 -1) r(10 10) U5'
 ]);

--- a/test/helpers/client.js
+++ b/test/helpers/client.js
@@ -105,5 +105,6 @@ module.exports = {
   deleteDevEnvironment,
   getDevContentType,
   getEntries,
-  getDevEditorInterface
+  getDevEditorInterface,
+  getDevTag
 };

--- a/test/helpers/client.js
+++ b/test/helpers/client.js
@@ -92,6 +92,13 @@ function deleteDevEnvironment (spaceId, environmentId) {
   });
 }
 
+function getDevTag (spaceId, environmentId, id) {
+  return makeRequest(spaceId, environmentId, {
+    method: 'GET',
+    url: `/tags/${id}`
+  });
+}
+
 module.exports = {
   makeRequest,
   createDevEnvironment,

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -613,6 +613,8 @@ describe('the migration', function () {
   });
 
   it('modifies the name of an existing tag', async function () {
+    // TODO: As with the content type tests, the tag tests depend on
+    // each other to pass. Is this okay?
     await migrator(modifyTag);
     const tag = await request({
       method: 'GET',

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -325,6 +325,14 @@ describe('the migration', function () {
       }
     });
 
+    const tag = yield request({
+      method: 'GET',
+      url: '/tags/longexampletag',
+      headers: {
+        'X-Contentful-Beta-Dev-Spaces': 1
+      }
+    });
+
     expect(person.name).to.eql('Person');
     expect(person.description).to.eql('A content type for a person');
     expect(person.fields).to.eql([
@@ -395,6 +403,8 @@ describe('the migration', function () {
         validations: []
       }
     ]);
+
+    expect(tag.name).to.eql('long example marketing');
   }));
 
   it('returns an error when the script is invalid', co(function * () {

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -19,6 +19,7 @@ const addSidebarWidgets = require('../../examples/24-add-sidebar-widgets-to-new-
 const addSidebarWidgetsToExisting = require('../../examples/27-add-sidebar-widgets-to-existing-content-type');
 const createTag = require('../../examples/28-create-tag');
 const modifyTag = require('../../examples/29-modify-tag');
+const deleteTag = require('../../examples/30-delete-tag');
 
 const { createMigrationParser } = require('../../built/lib/migration-parser');
 const co = Bluebird.coroutine;
@@ -623,4 +624,23 @@ describe('the migration', function () {
     expect(tag.name).to.eql('better marketing');
     expect(tag.sys.id).to.eql('sampletag');
   });
+
+  it('deletes a tag', co(function * () {
+    let result;
+    yield migrator(deleteTag);
+
+    try {
+      yield request({
+        method: 'GET',
+        url: `/tags/sampletag`,
+        headers: {
+          'X-Contentful-Beta-Dev-Spaces': 1
+        }
+      });
+    } catch (err) {
+      expect(err.name).to.eql('NotFound');
+    }
+
+    expect(result).to.be.undefined();
+  }));
 });

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -18,6 +18,7 @@ const changeEditorInterfaceWithExistingContentTypeAddingHelpText = require('../.
 const addSidebarWidgets = require('../../examples/24-add-sidebar-widgets-to-new-content-type');
 const addSidebarWidgetsToExisting = require('../../examples/27-add-sidebar-widgets-to-existing-content-type');
 const createTag = require('../../examples/28-create-tag');
+const modifyTag = require('../../examples/29-modify-tag');
 
 const { createMigrationParser } = require('../../built/lib/migration-parser');
 const co = Bluebird.coroutine;
@@ -608,6 +609,16 @@ describe('the migration', function () {
       url: '/tags/sampletag'
     });
     expect(tag.name).to.eql('marketing');
+    expect(tag.sys.id).to.eql('sampletag');
+  });
+
+  it('modifies the name of an existing tag', async function () {
+    await migrator(modifyTag);
+    const tag = await request({
+      method: 'GET',
+      url: '/tags/sampletag'
+    });
+    expect(tag.name).to.eql('better marketing');
     expect(tag.sys.id).to.eql('sampletag');
   });
 });

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -625,22 +625,18 @@ describe('the migration', function () {
     expect(tag.sys.id).to.eql('sampletag');
   });
 
-  it('deletes a tag', co(function * () {
+  it('deletes a tag', async function () {
     let result;
-    yield migrator(deleteTag);
+    await migrator(deleteTag);
 
     try {
-      yield request({
+      result = await request({
         method: 'GET',
-        url: `/tags/sampletag`,
-        headers: {
-          'X-Contentful-Beta-Dev-Spaces': 1
-        }
+        url: `/tags/sampletag`
       });
     } catch (err) {
       expect(err.name).to.eql('NotFound');
     }
-
     expect(result).to.be.undefined();
-  }));
+  });
 });

--- a/test/unit/lib/intent/composed-intent.spec.ts
+++ b/test/unit/lib/intent/composed-intent.spec.ts
@@ -16,7 +16,7 @@ const composedIntent = async function (migration): Promise<ComposedIntent> {
 
 describe('ComposedIntent', function () {
   describe('making a composed intent', function () {
-    it('creates the right plan message', async function () {
+    it('creates the right plan message for composed ct intent', async function () {
       const intent = await composedIntent((migration) => {
         const ct = migration.createContentType('test')
         ct.name('Test CT')
@@ -72,6 +72,23 @@ describe('ComposedIntent', function () {
             details: []
           }
         ]
+      })
+    }),
+
+    it('creates the right plan message for composed tag intent', async function () {
+      const intent = await composedIntent((migration) => {
+        const ct = migration.createTag('test')
+        ct.name('Test Tag')
+      })
+
+      const message: PlanMessage = intent.toPlanMessage()
+
+      expect(message).to.eql({
+        heading: chalk`Create Tag {bold.yellow test}`,
+        details: [
+          chalk`{italic name}: "Test Tag"`,
+        ],
+        sections: []
       })
     })
   })

--- a/test/unit/lib/intent/composed-intent.spec.ts
+++ b/test/unit/lib/intent/composed-intent.spec.ts
@@ -86,7 +86,7 @@ describe('ComposedIntent', function () {
       expect(message).to.eql({
         heading: chalk`Create Tag {bold.yellow test}`,
         details: [
-          chalk`{italic name}: "Test Tag"`,
+          chalk`{italic name}: "Test Tag"`
         ],
         sections: []
       })

--- a/test/unit/lib/migration-chunks/validation/content-type-delete.spec.js
+++ b/test/unit/lib/migration-chunks/validation/content-type-delete.spec.js
@@ -339,37 +339,6 @@ describe('content type delete validation', function () {
     }));
   });
 
-  describe('when deleting a content type twice', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
-      const contentTypes = [{
-        sys: { id: 'foo' }
-      }];
-
-      const errors = yield validateChunks(function up (migration) {
-        migration.deleteContentType('foo');
-        migration.deleteContentType('foo');
-      }, contentTypes);
-
-      expect(errors).to.eql([
-        {
-          type: 'InvalidAction',
-          message: 'Content type with id "foo" cannot be deleted more than once.',
-          details: {
-            step: {
-              type: 'contentType/delete',
-              meta: {
-                contentTypeInstanceId: 'contentType/foo/1'
-              },
-              payload: {
-                contentTypeId: 'foo'
-              }
-            }
-          }
-        }
-      ]);
-    }));
-  });
-
   describe('when deleting a content type that still has entries', function () {
     it('returns an error', Bluebird.coroutine(function * () {
       const contentTypes = [{

--- a/test/unit/lib/migration-chunks/validation/tag-delete.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag-delete.spec.js
@@ -1,0 +1,278 @@
+'use strict';
+
+const { expect } = require('chai');
+const Bluebird = require('bluebird');
+
+const validateChunks = require('./validate-chunks').default;
+
+// TODO Remove Bluebird
+
+describe('tag delete validation', function () {
+  describe('when deleting a tag twice', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const tags = [{
+        sys: { id: 'foo' }
+      }];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.deleteTag('foo');
+        migration.deleteTag('foo');
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "foo" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/foo/1'
+              },
+              payload: {
+                tagId: 'foo'
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when deleting several tags several times', function () {
+    it('returns the right errors', Bluebird.coroutine(function * () {
+      const tags = [
+        { sys: { id: 'foo' } },
+        { sys: { id: 'bar' } },
+        { sys: { id: 'baz' } }
+      ];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.deleteTag('foo');
+        migration.deleteTag('bar');
+        migration.deleteTag('baz');
+        migration.deleteTag('foo');
+        migration.deleteTag('bar');
+        migration.deleteTag('baz');
+        migration.deleteTag('foo');
+        migration.deleteTag('bar');
+        migration.deleteTag('baz');
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "foo" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/foo/1'
+              },
+              payload: {
+                tagId: 'foo'
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "bar" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/bar/1'
+              },
+              payload: {
+                tagId: 'bar'
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "baz" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/baz/1'
+              },
+              payload: {
+                tagId: 'baz'
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "foo" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/foo/2'
+              },
+              payload: {
+                tagId: 'foo'
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "bar" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/bar/2'
+              },
+              payload: {
+                tagId: 'bar'
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "baz" cannot be deleted more than once.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/baz/2'
+              },
+              payload: {
+                tagId: 'baz'
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when deleting a tag that does not exist', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const tags = [{
+        sys: { id: 'foo' }
+      }, {
+        sys: { id: 'bar' }
+      }];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.deleteTag('baz');
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot delete tag "baz" because it does not exist.',
+          details: {
+            step: {
+              type: 'tag/delete',
+              meta: {
+                tagInstanceId: 'tag/baz/0'
+              },
+              payload: {
+                tagId: 'baz'
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+
+  describe('when editing a tag that has been deleted earlier', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const tags = [{
+        sys: { id: 'foo' }
+      }];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.deleteTag('foo');
+        migration.editTag('foo').name('another name');
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "foo" cannot be edited because it was deleted before.',
+          details: {
+            step: {
+              type: 'tag/update',
+              meta: {
+                tagInstanceId: 'tag/foo/1'
+              },
+              payload: {
+                tagId: 'foo',
+                props: {
+                  name: 'another name'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+
+    it('returns an error also when several edits after several deletes', Bluebird.coroutine(function * () {
+      const tags = [{
+        sys: { id: 'foo' },
+        name: 'tag name'
+      }, {
+        sys: { id: 'bar' }
+      }];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.editTag('bar').name('confusedYet?');
+        migration.deleteTag('foo');
+        migration.editTag('foo').name('yet?');
+        migration.deleteTag('bar');
+        migration.editTag('bar').name('last name');
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "foo" cannot be edited because it was deleted before.',
+          details: {
+            step: {
+              type: 'tag/update',
+              meta: {
+                tagInstanceId: 'tag/foo/1'
+              },
+              payload: {
+                tagId: 'foo',
+                props: {
+                  name: 'yet?'
+                }
+              }
+            }
+          }
+        },
+        {
+          type: 'InvalidAction',
+          message: 'Tag with id "bar" cannot be edited because it was deleted before.',
+          details: {
+            step: {
+              type: 'tag/update',
+              meta: {
+                tagInstanceId: 'tag/bar/2'
+              },
+              payload: {
+                tagId: 'bar',
+                props: {
+                  name: 'last name'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
+});

--- a/test/unit/lib/migration-chunks/validation/tag-delete.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag-delete.spec.js
@@ -1,20 +1,16 @@
 'use strict';
 
 const { expect } = require('chai');
-const Bluebird = require('bluebird');
-
 const validateChunks = require('./validate-chunks').default;
-
-// TODO Remove Bluebird
 
 describe('tag delete validation', function () {
   describe('when deleting a tag twice', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'foo' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.deleteTag('foo');
         migration.deleteTag('foo');
       }, [], tags);
@@ -36,18 +32,18 @@ describe('tag delete validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when deleting several tags several times', function () {
-    it('returns the right errors', Bluebird.coroutine(function * () {
+    it('returns the right errors', async function () {
       const tags = [
         { sys: { id: 'foo' } },
         { sys: { id: 'bar' } },
         { sys: { id: 'baz' } }
       ];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.deleteTag('foo');
         migration.deleteTag('bar');
         migration.deleteTag('baz');
@@ -151,18 +147,18 @@ describe('tag delete validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when deleting a tag that does not exist', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'foo' }
       }, {
         sys: { id: 'bar' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.deleteTag('baz');
       }, [], tags);
 
@@ -183,16 +179,16 @@ describe('tag delete validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when editing a tag that has been deleted earlier', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'foo' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.deleteTag('foo');
         migration.editTag('foo').name('another name');
       }, [], tags);
@@ -217,9 +213,9 @@ describe('tag delete validation', function () {
           }
         }
       ]);
-    }));
+    });
 
-    it('returns an error also when several edits after several deletes', Bluebird.coroutine(function * () {
+    it('returns an error also when several edits after several deletes', async function () {
       const tags = [{
         sys: { id: 'foo' },
         name: 'tag name'
@@ -227,7 +223,7 @@ describe('tag delete validation', function () {
         sys: { id: 'bar' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.editTag('bar').name('confusedYet?');
         migration.deleteTag('foo');
         migration.editTag('foo').name('yet?');
@@ -273,6 +269,6 @@ describe('tag delete validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 });

--- a/test/unit/lib/migration-chunks/validation/tag.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag.spec.js
@@ -40,9 +40,9 @@ describe('tag plan validation', function () {
   describe('when creating a tag that already exists', function () {
     it('returns an error', Bluebird.coroutine(function * () {
       const tags = [{
-        sys: { id: 'somethingElse' }
+        sys: { id: 'somethingElse' }, name: 'bar'
       }, {
-        sys: { id: 'person' }
+        sys: { id: 'person' }, name: 'more'
       }];
 
       const errors = yield validateChunks(function up (migration) {

--- a/test/unit/lib/migration-chunks/validation/tag.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag.spec.js
@@ -107,4 +107,43 @@ describe('tag plan validation', function () {
       ]);
     }));
   });
+
+  describe('when editing a tag before creating it', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const tags = [{
+        sys: { id: 'somethingElse' }
+      }];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.editTag('person', {
+          name: 'foo'
+        });
+
+        migration.createTag('person', {
+          name: 'the new name'
+        });
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'You cannot set a property on tag "person" because it has not yet been created.',
+          details: {
+            step: {
+              'type': 'tag/update',
+              'meta': {
+                'tagInstanceId': 'tag/person/0'
+              },
+              'payload': {
+                'tagId': 'person',
+                'props': {
+                  'name': 'foo'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
 });

--- a/test/unit/lib/migration-chunks/validation/tag.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag.spec.js
@@ -70,4 +70,41 @@ describe('tag plan validation', function () {
       ]);
     }));
   });
+
+  describe('when creating a tag with a name that already exists', function () {
+    it('returns an error', Bluebird.coroutine(function * () {
+      const tags = [{
+        sys: { id: 'somethingElse' }, name: 'foo'
+      }, {
+        sys: { id: 'person' }, name: 'more'
+      }];
+
+      const errors = yield validateChunks(function up (migration) {
+        migration.createTag('differentId', {
+          name: 'foo'
+        });
+      }, [], tags);
+
+      expect(errors).to.eql([
+        {
+          type: 'InvalidAction',
+          message: 'Tag with name "foo" already exists.',
+          details: {
+            step: {
+              'type': 'tag/update',
+              'meta': {
+                'tagInstanceId': 'tag/differentId/0'
+              },
+              'payload': {
+                'tagId': 'differentId',
+                'props': {
+                  'name': 'foo'
+                }
+              }
+            }
+          }
+        }
+      ]);
+    }));
+  });
 });

--- a/test/unit/lib/migration-chunks/validation/tag.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag.spec.js
@@ -1,16 +1,12 @@
 'use strict';
 
 const { expect } = require('chai');
-const Bluebird = require('bluebird');
-
 const validateChunks = require('./validate-chunks').default;
-
-// TODO Replace Bluebird
 
 describe('tag plan validation', function () {
   describe('when creating a tag twice', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
-      const errors = yield validateChunks(function up (migration) {
+    it('returns an error', async function () {
+      const errors = await validateChunks(function up (migration) {
         migration.createTag('person', {
           name: 'foo'
         });
@@ -36,16 +32,16 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when editing a tag before creating it', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'somethingElse' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.editTag('person', {
           name: 'foo'
         });
@@ -75,19 +71,18 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
-  // TODO
   describe('when editing a tag that already exists and creating it again later on', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'somethingElse' }
       }, {
         sys: { id: 'person' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.editTag('person', {
           name: 'foo'
         });
@@ -118,18 +113,18 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when creating a tag that already exists', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'somethingElse' }, name: 'bar'
       }, {
         sys: { id: 'person' }, name: 'more'
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.createTag('person', {
           name: 'foo'
         });
@@ -152,18 +147,18 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when creating a tag with a name that already exists', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'somethingElse' }, name: 'foo'
       }, {
         sys: { id: 'person' }, name: 'more'
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.createTag('differentId', {
           name: 'foo'
         });
@@ -189,16 +184,16 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when editing a tag that does not exist', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [{
         sys: { id: 'somethingElse' }
       }];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         migration.editTag('person', {
           name: 'foo'
         });
@@ -250,14 +245,14 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 
   describe('when setting the same prop more than once in one chunk', function () {
-    it('returns an error', Bluebird.coroutine(function * () {
+    it('returns an error', async function () {
       const tags = [];
 
-      const errors = yield validateChunks(function up (migration) {
+      const errors = await validateChunks(function up (migration) {
         const person = migration.createTag('person').name('Person');
         person.name('Person McPersonface');
       }, [], tags);
@@ -282,6 +277,6 @@ describe('tag plan validation', function () {
           }
         }
       ]);
-    }));
+    });
   });
 });


### PR DESCRIPTION
## Done
- Implement `editTag`.
- Implement `deleteTag`.
- Add more validation for more complex `editTag` and `deleteTag` use cases [here](https://github.com/contentful/contentful-migration/blob/master/src/lib/migration-chunks/validation/tag.ts)

## Todos
- tag id (and content type id) validations are currently missing. Should they be added?

## Notes for test setup
- New integration tests are actually only being checked if env var `NOCK_RECORD` is set to 1!