### PR TITLE
feat(tags): validation

### DIFF
--- a/src/lib/action/action.ts
+++ b/src/lib/action/action.ts
@@ -8,7 +8,6 @@ abstract class APIAction {
 }
 
 abstract class EntityAction {
-  // Really should be using an ENUM here
   abstract getEntityType (): EntityType
   abstract getEntityId (): string
   // For Entries, we could add `getEntityQuery` or something like that

--- a/src/lib/intent-list/index.ts
+++ b/src/lib/intent-list/index.ts
@@ -100,7 +100,6 @@ class IntentList {
       await api.startRecordingRequests(intent)
 
       for (const action of intent.toActions()) {
-
         if (action instanceof APIAction) {
           await action.applyTo(api)
           continue

--- a/src/lib/migration-chunks/validation/tag.ts
+++ b/src/lib/migration-chunks/validation/tag.ts
@@ -202,7 +202,6 @@ export default function (intents: Intent[], tags: Tag[]): InvalidActionError[] {
 
     for (const check of checks) {
       error = check.validate(intent, context)
-
       if (error && error.length) {
         // proceed with next intent
         break

--- a/src/lib/offline-api/validator/entry.ts
+++ b/src/lib/offline-api/validator/entry.ts
@@ -1,0 +1,8 @@
+import { ApiHook } from '../'
+import { Entry } from '../../entities/entry'
+import { PayloadValidationError, InvalidActionError } from '../../interfaces/errors'
+
+export interface EntryValidator {
+  hooks: ApiHook[]
+  validate (entry: Entry): (InvalidActionError | PayloadValidationError)[]
+}

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -66,6 +66,14 @@ const errors = {
       }
     }
   },
+  entry: {
+    REQUIRED_PROPERTY: (path) => {
+      return `The property "${path}" is required on an entry.`
+    },
+    TAGS_DO_NOT_EXIST: (entryId) => {
+      return `You cannot update tags on entry "${entryId}" because some of the tags do not exist.`
+    }
+  },
   tag: {
     REQUIRED_PROPERTY: (path) => {
       return `The property "${path}" is required on a tag.`

--- a/src/lib/offline-api/validator/tags-on-entry.ts
+++ b/src/lib/offline-api/validator/tags-on-entry.ts
@@ -1,0 +1,41 @@
+import { ApiHook } from '../'
+import { EntryValidator } from './entry'
+import { InvalidActionError, PayloadValidationError } from '../../interfaces/errors'
+import { Entry } from '../../entities/entry'
+import { Tag } from '../../entities/tag'
+import errorMessages from './errors'
+
+export default class TagsOnEntryValidator implements EntryValidator {
+  public hooks = [ApiHook.SaveEntry]
+  private tags: Map<String, Tag>
+
+  constructor (tags: Map<String, Tag>) {
+    this.tags = tags
+  }
+
+  public validate (entry: Entry): (PayloadValidationError[] | InvalidActionError[]) {
+    const errors: InvalidActionError[] = []
+    const tagsOnEntry = entry.tags
+    const allTags = this.tags
+
+    if (!tagsOnEntry) {
+      return errors
+    }
+
+    // TODO: Make this more verbose and collect one error for every
+    // missing tag
+    const allTagsOnEntryExist = tagsOnEntry.every((tag) => {
+      const tagId = tag.sys.id
+      return allTags.has(tagId)
+    })
+
+    if (!allTagsOnEntryExist) {
+      errors.push({
+        type: 'InvalidAction',
+        message: errorMessages.entry.TAGS_DO_NOT_EXIST(entry.id)
+      })
+    }
+
+    return errors
+  }
+}

--- a/test/unit/lib/offline-api/validation/payload-validation-non-existing-tags.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-non-existing-tags.spec.ts
@@ -1,0 +1,56 @@
+'use strict'
+
+import { expect } from 'chai'
+import validateBatches from './validate-batches'
+import makeApiEntry from '../../../../helpers/make-api-entry'
+import { Entry } from '../../../../../src/lib/entities/entry'
+
+describe('payload validation attach tags to entry', function () {
+  describe('when trying add a tag that does not exist', function () {
+    it('returns an error', async function () {
+      const step = {
+        contentType: 'entry',
+        from: ['name'],
+        setTagsForEntry: async (fields, entryTags, apiTags) => {
+          return [{ sys: { id: 'nonexisting', type: 'Link', linkType: 'Tag' } }]
+        }
+      }
+      const contentTypes = [
+        { sys: { id: 'entry' }, fields: [{ id: 'name', name: 'field name', type: 'Symbol' }], name: 'Lunch' }
+      ]
+
+      const tags = [{ sys: { id: 'marketing' }, name: 'Buenos Aires' }]
+      const entries = [
+        new Entry(
+          makeApiEntry({
+            id: 'entryId',
+            contentTypeId: 'entry',
+            version: 1,
+            fields: {
+              name: {
+                'en-US': 'bob',
+                hawaii: 'haukea'
+              }
+            }
+          })
+        )
+      ]
+      const errors = await validateBatches(
+        function (migration) {
+          migration.setTagsForEntries(step)
+        },
+        contentTypes,
+        tags,
+        entries
+      )
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidAction',
+            message: 'You cannot update tags on entry "entryId" because some of the tags do not exist.'
+          }
+        ]
+      ])
+    })
+  })
+})

--- a/test/unit/lib/offline-api/validation/validate-batches.ts
+++ b/test/unit/lib/offline-api/validation/validate-batches.ts
@@ -1,11 +1,12 @@
 import IntentList from '../../../../../src/lib/intent-list'
 import { ContentType } from '../../../../../src/lib/entities/content-type'
+import { Tag } from '../../../../../src/lib/entities/tag'
 import { OfflineAPI } from '../../../../../src/lib/offline-api/index'
 import { migration } from '../../../../../src/lib/migration-steps'
 
 const noOp = () => undefined
 
-const validateBatches = async function (runMigration, contentTypes) {
+const validateBatches = async function (runMigration, contentTypes, tags = [], entries = []) {
   const intents = await migration(runMigration, noOp, {})
   const list = new IntentList(intents)
 
@@ -13,11 +14,17 @@ const validateBatches = async function (runMigration, contentTypes) {
 
   for (const ct of contentTypes) {
     const contentType = new ContentType(ct)
-
     existingCTs.set(contentType.id, contentType)
   }
 
-  const api = new OfflineAPI({ contentTypes: existingCTs, entries: [], locales: [] })
+  const existingTags: Map<String, Tag> = new Map()
+
+  for (const tagPayload of tags) {
+    const tag = new Tag(tagPayload)
+    existingTags.set(tag.id, tag)
+  }
+
+  const api = new OfflineAPI({ contentTypes: existingCTs, tags: existingTags, entries, locales: [] })
 
   await list.compressed().applyTo(api)
 


### PR DESCRIPTION
Add validation to not allow attaching non-existing tags to entries.

We don't yet check for duplicate tags (which would be done via a joi schema check), because of scope and a bug in the joi version we are using.