### PR TITLE
fix(publish): respect entry state CHANGED for preserve value

### DIFF
--- a/src/lib/action/entry-transform-to-type.ts
+++ b/src/lib/action/entry-transform-to-type.ts
@@ -1,4 +1,5 @@
 import EntryTransformToType from '../interfaces/entry-transform-to-type'
+import shouldPublishLocalChanges from '../utils/should-publish-local-changes'
 import { APIAction } from './action'
 import { OfflineAPI } from '../offline-api'
 import Entry from '../entities/entry'
@@ -91,7 +92,7 @@ class EntryTransformToTypeAction extends APIAction {
 
       }
       await api.saveEntry(targetEntry.id)
-      if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && entry.isPublished)) {
+      if (shouldPublishLocalChanges(this.shouldPublish, entry)) {
         await api.publishEntry(targetEntry.id)
       }
 
@@ -106,7 +107,7 @@ class EntryTransformToTypeAction extends APIAction {
           }
 
           await api.saveEntry(link.element.id)
-          if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && link.element.isPublished)) {
+          if (shouldPublishLocalChanges(this.shouldPublish, link.element)) {
             await api.publishEntry(link.element.id)
           }
         }

--- a/src/lib/action/entry-transform.ts
+++ b/src/lib/action/entry-transform.ts
@@ -1,3 +1,4 @@
+import shouldPublishLocalChanges from '../utils/should-publish-local-changes'
 import { APIAction } from './action'
 import { OfflineAPI } from '../offline-api'
 import Entry from '../entities/entry'
@@ -50,7 +51,7 @@ class EntryTransformAction extends APIAction {
       }
       if (changesForThisEntry) {
         await api.saveEntry(entry.id)
-        if (this.shouldPublish === true || (this.shouldPublish === 'preserve' && entry.isPublished)) {
+        if (shouldPublishLocalChanges(this.shouldPublish ,entry)) {
           await api.publishEntry(entry.id)
         }
       }

--- a/src/lib/utils/should-publish-local-changes.ts
+++ b/src/lib/utils/should-publish-local-changes.ts
@@ -1,0 +1,28 @@
+import Entry from '../entities/entry'
+
+/**
+ * Calculate if an entry should be published.
+ * @constructor
+ * @param {boolean | 'preserve'} shouldPublish - expected result.
+ * @param {Entry} entry - entry to be published.
+ * @description we expect a diff of > 2 between version and publishedVersion because version has been already bumped in this specific use case.
+ */
+
+export default function shouldPublishLocalChanges (shouldPublish: boolean | 'preserve', entry: Entry) {
+  if (shouldPublish === true) {
+    return true
+  } else if (shouldPublish === false) {
+    return false
+  } else if (shouldPublish === 'preserve') {
+    if (!entry.isPublished) {
+      return false
+    }
+    if (!entry.version || isNaN(entry.version)) {
+      return false
+    }
+    const hasUnpublishedChanges = entry.version > entry.publishedVersion + 2
+    return !hasUnpublishedChanges
+  } else {
+    return false
+  }
+}

--- a/test/unit/lib/actions/entry-transform-to-type.spec.ts
+++ b/test/unit/lib/actions/entry-transform-to-type.spec.ts
@@ -265,6 +265,7 @@ describe('Transform Entry to Type Action', function () {
 
     const action = new EntryTransformToTypeAction(transformation)
     const entries = [
+      // has never been published
       new Entry(makeApiEntry({
         id: '246',
         contentTypeId: 'dog',
@@ -276,6 +277,7 @@ describe('Transform Entry to Type Action', function () {
           }
         }
       })),
+      // published, but with pending changes
       new Entry(makeApiEntry({
         id: '123',
         contentTypeId: 'person',

--- a/test/unit/lib/actions/entry-transform.spec.ts
+++ b/test/unit/lib/actions/entry-transform.spec.ts
@@ -3,6 +3,8 @@
 import { expect } from 'chai'
 
 import { EntryTransformAction } from '../../../../src/lib/action/entry-transform'
+import { EntryTransformToTypeAction } from '../../../../src/lib/action/entry-transform-to-type'
+import TransformEntryToType from '../../../../src/lib/interfaces/entry-transform-to-type'
 import OfflineApi from '../../../../src/lib/offline-api/index'
 import { Entry } from '../../../../src/lib/entities/entry'
 
@@ -56,7 +58,7 @@ describe('Entry Action', function () {
         return
       }
       return {
-        name:  fields.name[locale] + '!'
+        name: fields.name[locale] + '!'
       }
     }
 
@@ -143,4 +145,58 @@ describe('Entry Action', function () {
     const batches = await api.getRequestBatches()
     expect(batches[0].requests).to.eql([])
   })
+
+  async function shouldPublishTest (shouldPublish, version, publishedVersion, expectPublish) {
+    const transformation: TransformEntryToType = {
+      sourceContentType: 'dog',
+      targetContentType: 'copycat',
+      from: ['name'],
+      shouldPublish,
+      identityKey: async () => '345',
+      transformEntryForLocale: async (fields, locale) => {
+        return { name: fields['name'][locale] }
+      }
+    }
+    const action = new EntryTransformToTypeAction(transformation)
+    const entries = [
+      new Entry(makeApiEntry({
+        contentTypeId: 'dog',
+        version,
+        publishedVersion,
+        fields: {
+          name: {
+            'en-US': 'bob',
+            'hawaii': 'haukea'
+          }
+        }
+      }))
+    ]
+    const api = new OfflineApi({ contentTypes: new Map(), entries, locales: ['en-US'] })
+    await api.startRecordingRequests(null)
+
+    await action.applyTo(api)
+    await api.stopRecordingRequests()
+    const batches = await api.getRequestBatches()
+
+    const requestUrls = batches[0].requests.map(r => r.url)
+
+    expect(requestUrls).include('/entries/345')
+
+    if (expectPublish) {
+      expect(requestUrls).include('/entries/345/published')
+    } else {
+      expect(requestUrls).not.include('/entries/345/published')
+    }
+  }
+
+  it('preservers CHANGED state with unpublished remote changes', async () => {
+    await shouldPublishTest('preserve', 4, 1, false)
+    await shouldPublishTest('preserve', 5, 1, false)
+  })
+
+  it('preservers PUBLISH state with no unpublished remote changes', async () => {
+    return shouldPublishTest('preserve', 2, 1, true)
+    return shouldPublishTest('preserve', 3, 1, true)
+  })
+
 })

--- a/test/unit/lib/utils/should-publish-local-changes.spec.ts
+++ b/test/unit/lib/utils/should-publish-local-changes.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai'
+import { Entry } from '../../../../src/lib/entities/entry'
+import shouldPublishLocalChanges from '../../../../src/lib/utils/should-publish-local-changes'
+import makeApiEntry from '../../../helpers/make-api-entry'
+
+function entry (version, publishedVersion) {
+  return new Entry(makeApiEntry({
+    id: '246',
+    contentTypeId: 'dog',
+    version,
+    publishedVersion,
+    fields: {
+      name: {
+        'en-US': 'bob',
+        'hawaii': 'haukea'
+      }
+    }
+  }))
+}
+
+describe('A shouldPublish util function', function () {
+  it('returns true if explicitly set', () => {
+    expect(shouldPublishLocalChanges(true, entry(1, 1))).to.eql(true)
+  })
+
+  it('returns false if explicitly set', () => {
+    expect(shouldPublishLocalChanges(false, entry(1, 1))).to.eql(false)
+  })
+
+  it('returns false for "preserve" and pending remote changes', () => {
+    expect(shouldPublishLocalChanges('preserve', entry(4, 1))).to.eql(false)
+    expect(shouldPublishLocalChanges('preserve', entry(5, 1))).to.eql(false)
+  })
+
+  it('returns true for "preserve" and no pending remote changes', () => {
+    expect(shouldPublishLocalChanges('preserve', entry(2, 1))).to.eql(true)
+  })
+
+  it('returns false if shouldPublish is not defined', () => {
+    expect(shouldPublishLocalChanges(undefined, entry(2, 1))).to.eql(false)
+    expect(shouldPublishLocalChanges(undefined, entry(5, 1))).to.eql(false)
+  })
+})


### PR DESCRIPTION
## Summary

In case of a published entry but with unpublished changes, `shouldPublish: 'preserve'` would always resolve in a published entry. With these changes we check for pending changes and only publish if there are none.

Resolves #229, #223