### PR TITLE
FIX request url with double slashes

### DIFF
--- a/test/helpers/client.js
+++ b/test/helpers/client.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const Bluebird = require('bluebird');
-
-const path = require('path');
 const packageVersion = require('../../package.json').version;
 const { createManagementClient } = require('../../built/bin/lib/contentful-client');
+const createMakeRequest = require('../../built/bin/cli').createMakeRequest;
 
 const config = {
   accessToken: process.env.CONTENTFUL_INTEGRATION_MANAGEMENT_TOKEN,
@@ -15,8 +14,7 @@ const config = {
 const client = createManagementClient(config);
 
 const makeRequest = function (spaceId, environmentId, requestConfig) {
-  requestConfig.url = path.join(spaceId, 'environments', environmentId, requestConfig.url);
-  return client.rawRequest(requestConfig);
+  return createMakeRequest(client, { spaceId, environmentId })(requestConfig);
 };
 
 const waitForJobCompletion = Bluebird.coroutine(function * (makeRequest, spaceId, environmentId) {


### PR DESCRIPTION

## Summary

Fix for: [request with double slashes](https://github.com/contentful/contentful-migration/issues/515)

## Description

Wrong request url example 

`https://api.contentful.com/spaces/SPACE_ID/environments/master//content-types`

Solution:
replace _Array.join()_ for _path.join()_ in makeRequest()

