### PR TITLE
feat(EntryEditors): Add support for migrating entry editors [EXT-2359]

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
       - [`removeSidebarWidget (widgetNamespace, widgetId)` : void](#removesidebarwidget-widgetnamespace-widgetid--void)
       - [`resetSidebarToDefault ()` : void](#resetsidebartodefault---void)
       - [`configureEntryEditor (widgetNamespace, widgetId[, settings])` : void](#configureentryeditor-widgetnamespace-widgetid-settings--void)
+      - [`configureEntryEditors (EntryEditor[])` : void](#configureentryeditors-entryeditor--void)
       - [`resetEntryEditorToDefault ()` : void](#resetentryeditortodefault---void)
     - [Field](#field)
   - [Validation errors](#validation-errors)
@@ -678,6 +679,16 @@ Sets the entry editor to specified widget.
 **`widgetNamespace: string`** – The namespace of the widget.
 **`widgetId : string`** – The ID of the builtin or extension widget to add.
 **`settings : Object`** – Instance settings for the widget. Key-value pairs of type (string, number | boolean | string). Optional.
+
+#### `configureEntryEditors (EntryEditor[])` : void
+
+As opposed to `configureEntryEditor` which only sets one editor, this sets a list of editors to the current editor interface of a content-type.
+
+Each `EntryEditor` has the following properties:
+
+- `widgetNamespace: string` – The namespace of the widget (i.e: `app`, `extension` or `builtin-editor`).
+- `widgetId : string` – The ID of the builtin, extension or app widget to add.
+- `settings : Object` – Instance settings for the widget. Key-value pairs of type (string, number | boolean | string). Optional.
 
 #### `resetEntryEditorToDefault ()` : void
 

--- a/src/lib/action/entryeditor-configure.ts
+++ b/src/lib/action/entryeditor-configure.ts
@@ -1,7 +1,7 @@
 import { EditorInterfaces } from '../entities/content-type'
 import { EntityAction, EntityType } from './action'
 
-export type EntryEditorNamespace = 'extension'
+export type EntryEditorNamespace = 'extension' | 'app'
 export interface EntryEditorSettings {
   [key: string]: any
 }
@@ -12,7 +12,7 @@ class EntryEditorConfigureAction extends EntityAction {
   protected widgetNamespace?: EntryEditorNamespace
   protected settings?: EntryEditorSettings
 
-  constructor (contentTypeId: string, widgetNamespace, widgetId, settings) {
+  constructor (contentTypeId: string, widgetNamespace: EntryEditorNamespace, widgetId: string, settings: EntryEditorSettings) {
     super()
     this.contentTypeId = contentTypeId
     this.widgetId = widgetId

--- a/src/lib/action/entryeditor.ts
+++ b/src/lib/action/entryeditor.ts
@@ -7,4 +7,4 @@ export interface EntryEditorSettings {
   [key: string]: any
 }
 
-export type EntryEditorNamespace = 'extension'
+export type EntryEditorNamespace = 'extension' | 'app'

--- a/src/lib/action/entryeditors-configure.ts
+++ b/src/lib/action/entryeditors-configure.ts
@@ -1,0 +1,38 @@
+import { EditorInterfaces } from '../entities/content-type'
+import { EntityAction, EntityType } from './action'
+
+export type EntryEditorNamespace = 'extension' | 'app'
+export interface EntryEditorSettings {
+  [key: string]: any
+}
+export interface EntryEditor {
+  widgetNamespace: EntryEditorNamespace
+  widgetId: string
+  settings?: EntryEditorSettings
+  disabled?: boolean
+}
+
+class EntryEditorsConfigureAction extends EntityAction {
+  protected contentTypeId: string
+  protected editors: EntryEditor[]
+
+  constructor (contentTypeId: string, editors: EntryEditor[]) {
+    super()
+    this.contentTypeId = contentTypeId
+    this.editors = editors
+  }
+
+  getEntityType (): EntityType {
+    return EntityType.EditorInterface
+  }
+
+  getEntityId (): string {
+    return this.contentTypeId
+  }
+
+  async applyTo (editorInterfaces: EditorInterfaces) {
+    editorInterfaces.setEditors(this.editors)
+  }
+}
+
+export { EntryEditorsConfigureAction }

--- a/src/lib/entities/content-type.ts
+++ b/src/lib/entities/content-type.ts
@@ -94,12 +94,14 @@ class EditorInterfaces {
   private _controls: APIEditorInterfaceControl[]
   private _sidebar?: APIEditorInterfaceSidebar[]
   private _editor?: APIEditorIntefaceEditor
+  private _editors?: APIEditorIntefaceEditor[]
 
   constructor (apiEditorInterfaces: APIEditorInterfaces) {
     this._version = apiEditorInterfaces.sys.version
     this._controls = apiEditorInterfaces.controls
     this._sidebar = apiEditorInterfaces.sidebar || undefined
     this._editor = apiEditorInterfaces.editor || undefined
+    this._editors = apiEditorInterfaces.editors || undefined
   }
 
   get version () {
@@ -116,6 +118,10 @@ class EditorInterfaces {
 
   getEditor () {
     return this._editor
+  }
+
+  getEditors () {
+    return this._editors
   }
 
   getControls () {
@@ -233,10 +239,15 @@ class EditorInterfaces {
 
   resetEditorToDefault () {
     this._editor = undefined
+    this._editors = undefined
   }
 
   setEditor (editor: APIEditorIntefaceEditor) {
     this._editor = editor
+  }
+
+  setEditors (editors: APIEditorIntefaceEditor[]) {
+    this._editors = editors
   }
 
   toAPI (): object {
@@ -253,7 +264,8 @@ class EditorInterfaces {
     const result: {
       controls: APIEditorInterfaceControl[],
       sidebar?: APIEditorInterfaceSidebar[],
-      editor?: APIEditorIntefaceEditor
+      editor?: APIEditorIntefaceEditor,
+      editors?: APIEditorIntefaceEditor[]
     } = {
       controls
     }
@@ -263,6 +275,9 @@ class EditorInterfaces {
     }
     if (this._editor) {
       result.editor = this._editor
+    }
+    if (this._editors) {
+      result.editors = this._editors
     }
 
     return result

--- a/src/lib/entities/content-type.ts
+++ b/src/lib/entities/content-type.ts
@@ -273,11 +273,12 @@ class EditorInterfaces {
     if (this._sidebar) {
       result.sidebar = this._sidebar
     }
-    if (this._editor) {
-      result.editor = this._editor
-    }
+
+    // prefer editors over editor
     if (this._editors) {
       result.editors = this._editors
+    } else if (this._editor) {
+      result.editor = this._editor
     }
 
     return result

--- a/src/lib/intent/entryeditors-configure.ts
+++ b/src/lib/intent/entryeditors-configure.ts
@@ -1,0 +1,42 @@
+import Intent from './base-intent'
+import { PlanMessage } from '../interfaces/plan-message'
+import chalk from 'chalk'
+import { SaveEditorInterfaceAction } from '../action/editorinterface-save'
+import { EntryEditorsConfigureAction } from '../action/entryeditors-configure'
+
+export default class EntryEditorsConfigureIntent extends Intent {
+  isEditorInterfaceIntent () {
+    return true
+  }
+  isGroupable () {
+    return false
+  }
+  groupsWith (): boolean {
+    return false
+  }
+  endsGroup (): boolean {
+    return false
+  }
+  shouldSave (): boolean {
+    return false
+  }
+  shouldPublish (): boolean {
+    return false
+  }
+  toActions () {
+    return [
+      new EntryEditorsConfigureAction(
+        this.payload.contentTypeId,
+        this.payload.entryEditors
+      ),
+      new SaveEditorInterfaceAction(this.payload.contentTypeId)
+    ]
+  }
+  toPlanMessage (): PlanMessage {
+    return {
+      heading: chalk`Configure entry editors interface for content type {bold.yellow ${this.getContentTypeId()}}`,
+      details: [],
+      sections: []
+    }
+  }
+}

--- a/src/lib/intent/index.ts
+++ b/src/lib/intent/index.ts
@@ -19,6 +19,7 @@ import SidebarWidgetUpdateIntent from './sidebarwidget-update'
 import SidebarResetToDefaultIntent from './sidebar-reset-to-default'
 import EntryEditorResetToDefaultIntent from './entryeditor-reset-to-default'
 import EntryEditorConfigureIntent from './entryeditor-configure'
+import EntryEditorsConfigureIntent from './entryeditors-configure'
 import TagCreateIntent from './tag-create'
 import TagUpdateIntent from './tag-update'
 import TagDeleteIntent from './tag-delete'
@@ -47,6 +48,7 @@ export {
   SidebarResetToDefaultIntent as SidebarResetToDefault,
   EntryEditorResetToDefaultIntent as EntryEditorResetToDefault,
   EntryEditorConfigureIntent as EntryEditorConfigure,
+  EntryEditorsConfigureIntent as EntryEditorsConfigure,
   TagCreateIntent as TagCreate,
   TagUpdateIntent as TagUpdate,
   TagDeleteIntent as TagDelete,

--- a/src/lib/interfaces/content-type.ts
+++ b/src/lib/interfaces/content-type.ts
@@ -34,8 +34,8 @@ interface APIEditorInterfaceSettings {
   [setting: string]: APIParameterValue
 }
 
-type APISidebarWidgetNamespace = 'builtin' | 'extension'
-type APIControlWidgetNamespace = 'builtin' | 'extension'
+type APISidebarWidgetNamespace = 'builtin' | 'extension' | 'app'
+type APIControlWidgetNamespace = 'builtin' | 'extension' | 'app'
 
 interface APIEditorInterfaceControl {
   fieldId: string,
@@ -68,6 +68,7 @@ interface APIEditorInterfaces {
   controls: APIEditorInterfaceControl[],
   sidebar?: APIEditorInterfaceSidebar[],
   editor?: APIEditorIntefaceEditor
+  editors?: APIEditorIntefaceEditor[]
 }
 
 export {

--- a/src/lib/interfaces/raw-step.ts
+++ b/src/lib/interfaces/raw-step.ts
@@ -7,6 +7,9 @@ import {
   EntryEditorNamespace,
   EntryEditorSettings
 } from '../action/entryeditor-configure'
+import {
+  EntryEditor
+} from '../action/entryeditors-configure'
 
 interface RawStep {
   type: string
@@ -39,6 +42,7 @@ interface RawStepPayload {
   editorInterface?: EditorInterfaceInfo
   sidebarWidget?: SidebarWidgetInfo
   entryEditor?: EntryEditorInfo
+  entryEditors?: EntryEditor[]
   tagId?: string
   entryTransformationForTags?: EntrySetTags
 }

--- a/src/lib/migration-steps/action-creators.ts
+++ b/src/lib/migration-steps/action-creators.ts
@@ -175,6 +175,20 @@ const actionCreators = {
         }
       }
     }),
+    configureEntryEditors: (id, instanceId, callsite, editors): Intents.EntryEditorsConfigure => new Intents.EntryEditorsConfigure({
+      type: 'contentType/configureEntryEditors',
+      meta: {
+        contentTypeInstanceId: `contentType/${id}/${instanceId}`,
+        callsite: {
+          file: callsite.getFileName(),
+          line: callsite.getLineNumber()
+        }
+      },
+      payload: {
+        contentTypeId: id,
+        entryEditors: editors
+      }
+    }),
     addSidebarWidget: (id, instanceId, callsite, widgetId, widgetNamespace, insertBeforeWidgetId, settings = {}): Intents.SidebarWidgetAdd => new Intents.SidebarWidgetAdd({
       type: 'contentType/addSidebarWidget',
       meta: {

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -224,6 +224,17 @@ class ContentType extends DispatchProxy {
     return this
   }
 
+  configureEntryEditors (editors) {
+    const callsite = getFirstExternalCaller()
+    this.dispatch(actionCreators.contentType.configureEntryEditors(
+      this.id,
+      this.instanceId,
+      callsite,
+      editors
+    ))
+    return this
+  }
+
   addSidebarWidget (widgetNamespace, widgetId, settings = {}, insertBeforeWidgetId = null) {
     const callsite = getFirstExternalCaller()
     this.dispatch(actionCreators.contentType.addSidebarWidget(

--- a/test/unit/lib/entities/editor-interface.spec.ts
+++ b/test/unit/lib/entities/editor-interface.spec.ts
@@ -158,4 +158,31 @@ describe('EditorInterfaces', () => {
     expect(editorInterface.getEditor().settings.key).to.eql('value')
   })
 
+  it('configures editors', () => {
+    const editorInterface = makeEditorInterface([existingWidget, testWidget])
+
+    editorInterface.setEditors([
+      {
+        widgetId: 'test-widget-id',
+        widgetNamespace: 'extension',
+        settings: { key: 'value' }
+      },
+      {
+        widgetId: 'builtin-editor',
+        widgetNamespace: 'builtin'
+      }
+    ])
+
+    expect(editorInterface.getEditors().length).to.eql(2)
+    expect(editorInterface.getEditors()[0]).to.eql({
+      widgetId: 'test-widget-id',
+      widgetNamespace: 'extension',
+      settings: { key: 'value' }
+    })
+    expect(editorInterface.getEditors()[1]).to.eql({
+      widgetId: 'builtin-editor',
+      widgetNamespace: 'builtin'
+    })
+  })
+
 })


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Adding support for migrating [multiple editors in editor_interface](https://www.contentful.com/developers/docs/concepts/editor-interfaces/#custom-editor)

## Description

Adds a new method `configureEntryEditors`

## Motivation and Context

Could have rewritten the previous method `configureEntryEditor` but this would break any previous scripts relying on its intended behaviour.
