### PR TITLE
fix(transformEntries): shouldPublish will 'preserve' by default

### DIFF
--- a/src/lib/action/entry-transform.ts
+++ b/src/lib/action/entry-transform.ts
@@ -10,7 +10,7 @@ class EntryTransformAction extends APIAction {
   private transformEntryForLocale: Function
   private shouldPublish: boolean | 'preserve'
 
-  constructor (contentTypeId: string, fromFields: string[], transformation: Function, shouldPublish: boolean | 'preserve' = true) {
+  constructor (contentTypeId: string, fromFields: string[], transformation: Function, shouldPublish: boolean | 'preserve' = 'preserve') {
     super()
     this.contentTypeId = contentTypeId
     this.fromFields = fromFields

--- a/test/unit/lib/actions/entry-transform.spec.ts
+++ b/test/unit/lib/actions/entry-transform.spec.ts
@@ -99,7 +99,7 @@ describe('Entry Action', function () {
         'hawaii': 'haukea'
       }
     })
-    expect(batches[0].requests[2].data.fields).to.eql({
+    expect(batches[0].requests[1].data.fields).to.eql({
       name: {
         'en-US': 'jim!',
         'hawaii': 'aloha'

--- a/test/unit/lib/migration-parser.spec.ts
+++ b/test/unit/lib/migration-parser.spec.ts
@@ -102,9 +102,8 @@ describe('Migration parser', function () {
 
       expect(result.length).to.eql(2)
 
-      expect(result[0].requests.length).to.eql(2)
+      expect(result[0].requests.length).to.eql(1)
       expect(result[0].requests[0].url).to.eql('/entries/456')
-      expect(result[0].requests[1].url).to.eql('/entries/456/published')
       expect(result[0].runtimeErrors.length).to.eql(1)
       expect(result[0].runtimeErrors).to.eql([fooError])
 


### PR DESCRIPTION

## Summary

Fixes: https://github.com/contentful/contentful-migration/issues/329

## Description

transformEntries DSL was publishing all entries by default, now it will be 'preserve' by default


