### PR TITLE
Only need to include ESNext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,7 @@
     "target": "es2017",
     "esModuleInterop":true,
     "module": "commonjs",
-    "lib": [
-      "es2015",
-      "es2016",
-      "es2017",
-      "esnext"
-    ],
+    "lib": ["esnext"],
     "sourceMap": true,
     "typeRoots": [
       "./typings",


### PR DESCRIPTION
It's only necessary to mention the newest version in `lib` - ESNext include all the prior versions of ECMAScript. See <https://github.com/microsoft/TypeScript/blob/2428ade1a91248e847f3e1561e31a9426650efee/src/lib/esnext.d.ts>.

Yeah, this is minor, and this mistaken is being made in many repositories. But it's one of these small things you can't help noticing, once you know. 🙂 