### PR TITLE
feat: add custom headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ module.exports = function (migration, context) {
 | accessToken       |            | string  | The access token to use                                     | true     |
 | yes               | false      | boolean | Skips any confirmation before applying the migration,script | false    |
 | requestBatchSize  | 100        | number  | Limit for every single request                              | false    |
+| headers           |            | object  | Additional headers to attach to the requests                | false    |
 
 ### Chaining vs Object notation
 

--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -95,7 +95,7 @@ function getConfig (argv) {
   const envConfig = getEnvConfig()
   const argvConfig = getArgvConfig({
     ...argv,
-    headers: argv.headers || getHeadersConfig(argv.header)
+    headers: argv?.headers || getHeadersConfig(argv?.header)
   })
 
   return Object.assign(fileConfig, envConfig, argvConfig)

--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -12,6 +12,7 @@ interface ClientConfig {
   proxy?: string,
   rawProxy?: boolean
   requestBatchSize?: number
+  headers?: Record<string, unknown>
 }
 
 function getFileConfig (): ClientConfig {
@@ -32,14 +33,15 @@ function getEnvConfig (): ClientConfig {
     {}
 }
 
-function getArgvConfig ({ spaceId, environmentId = 'master', accessToken, proxy, rawProxy, requestBatchSize }): ClientConfig {
+function getArgvConfig ({ spaceId, environmentId = 'master', accessToken, proxy, rawProxy, requestBatchSize, headers }): ClientConfig {
   const config = {
     spaceId,
     environmentId,
     accessToken,
     proxy,
     rawProxy,
-    requestBatchSize
+    requestBatchSize,
+    headers
   }
 
   if (!config.accessToken) {

--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -51,10 +51,52 @@ function getArgvConfig ({ spaceId, environmentId = 'master', accessToken, proxy,
   return config
 }
 
+/**
+ * Turn header option into an object. Invalid header values
+ * are ignored.
+ *
+ * @example
+ * getHeadersConfig('Accept: Any')
+ * // -> {Accept: 'Any'}
+ *
+ * @example
+ * getHeadersConfig(['Accept: Any', 'X-Version: 1'])
+ * // -> {Accept: 'Any', 'X-Version': '1'}
+ */
+function getHeadersConfig (value?: string | string[]) {
+  if (!value) {
+    return {}
+  }
+
+  const values = Array.isArray(value) ? value : [value]
+
+  return values.reduce((headers, value) => {
+    value = value.trim()
+
+    const separatorIndex = value.indexOf(':')
+
+		// Invalid header format
+    if (separatorIndex === -1) {
+      return headers
+    }
+
+    const headerKey = value.slice(0, separatorIndex).trim()
+    const headerValue = value.slice(separatorIndex + 1).trim()
+
+    return {
+      ...headers,
+      [headerKey]: headerValue
+    }
+  }, {})
+}
+
 function getConfig (argv) {
   const fileConfig = getFileConfig()
   const envConfig = getEnvConfig()
-  const argvConfig = getArgvConfig(argv || {})
+  const argvConfig = getArgvConfig({
+    ...argv,
+    headers: argv.headers || getHeadersConfig(argv.header)
+  })
 
   return Object.assign(fileConfig, envConfig, argvConfig)
 }

--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -75,7 +75,7 @@ function getHeadersConfig (value?: string | string[]) {
 
     const separatorIndex = value.indexOf(':')
 
-		// Invalid header format
+    // Invalid header format
     if (separatorIndex === -1) {
       return headers
     }

--- a/src/bin/usage-params.ts
+++ b/src/bin/usage-params.ts
@@ -56,6 +56,11 @@ export default yargs
     type: 'number',
     default: 100
   })
+  .option('header', {
+    alias: 'H',
+    type: 'string',
+    describe: 'Pass an additional HTTP Header'
+  })
   .demandOption(['space-id'], 'Please provide a space ID')
   .help('h')
   .alias('h', 'help')

--- a/test/integration/bin/lib/contentful-client.spec.js
+++ b/test/integration/bin/lib/contentful-client.spec.js
@@ -63,21 +63,4 @@ describe('contentful-client', function () {
     const invocation = () => createManagementClient({ accessToken: 'something-random' });
     expect(invocation).to.throw('specify the application name');
   });
-
-  it('passes down headers option to contentful-management', function () {
-    const headers = {
-      myHeader: true
-    };
-
-    const clientConfig = Object.assign({
-      application: `contentful.migration-cli/0.0.0`,
-      headers
-    }, getConfig());
-
-    contentfulClient.__set__('createClient', (params) => {
-      expect(params.headers).to.eql(headers);
-    });
-
-    createManagementClient(clientConfig);
-  });
 });

--- a/test/integration/bin/lib/contentful-client.spec.js
+++ b/test/integration/bin/lib/contentful-client.spec.js
@@ -63,4 +63,21 @@ describe('contentful-client', function () {
     const invocation = () => createManagementClient({ accessToken: 'something-random' });
     expect(invocation).to.throw('specify the application name');
   });
+
+  it('passes down headers option to contentful-management', function () {
+    const headers = {
+      myHeader: true
+    };
+
+    const clientConfig = Object.assign({
+      application: `contentful.migration-cli/0.0.0`,
+      headers
+    }, getConfig());
+
+    contentfulClient.__set__('createClient', (params) => {
+      expect(params.headers).to.eql(headers);
+    });
+
+    createManagementClient(clientConfig);
+  });
 });

--- a/test/unit/bin/lib/config.spec.ts
+++ b/test/unit/bin/lib/config.spec.ts
@@ -46,4 +46,9 @@ describe('Config', function () {
     const config = getConfig({ headers: { test: true } })
     expect(config.headers).to.eql({ test: true })
   })
+
+  it('parses argv.header if provided', function () {
+    const config = getConfig({ header: ['Accept   : application/json ', ' X-Header: 1'] })
+    expect(config.headers).to.eql({ Accept: 'application/json', 'X-Header': '1' })
+  })
 })

--- a/test/unit/bin/lib/config.spec.ts
+++ b/test/unit/bin/lib/config.spec.ts
@@ -41,4 +41,9 @@ describe('Config', function () {
     const config = getConfig({ requestBatchSize: 99 })
     expect(config.requestBatchSize).to.eql(99)
   })
+
+  it('exposes headers from argv', function () {
+    const config = getConfig({ headers: { test: true } })
+    expect(config.headers).to.eql({ test: true })
+  })
 })


### PR DESCRIPTION
## Summary

Added support for passing `headers` option down to `contentful-management`. I also added `-H/--header` option to the CLI.

A similar option/flag will be added to other related libraries as well (e.g. contentful/contentful-export#562).

## Motivation and Context

To enable users to pass custom HTTP headers. This is especially useful when trying out alpha features.
