### PR TITLE
feat: Add 'preserve' to 'shouldPublish' option of 'deriveLinkedEntries'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ npm-debug.log
 contentful-migration-cli-*.tgz
 errors-*
 .idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The derive function is expected to return an object with the desired target fiel
 
   The return value must be an object with the same keys as specified in `derivedFields`. Their values will be written to the respective new entry fields for the current locale (i.e. `{nameField: 'myNewValue'}`)
 
-- **`shouldPublish : bool`** _(optional)_ – Flag that specifies publishing of target entries. (default `true`)
+- **`shouldPublish : bool|'preserve'`** _(optional)_ – If true, both the source and the derived entries will be published. If false, both will remain in draft state. If preserve, will keep current states of the source entries (default `true`)
 
 
 ##### `deriveLinkedEntries(config)` Example

--- a/index.d.ts
+++ b/index.d.ts
@@ -342,8 +342,8 @@ export interface IDeriveLinkedEntriesConfig {
    *   fields is an object containing each of the from fields. Each field will contain their current localized values (i.e. fields == {myField: {'en-US': 'my field value'}})
    */
   identityKey: (fromFields: ContentFields) => string,
-  /** (optional) – If true, both the source and the derived entries will be published. If false, both will remain in draft state (default true) */
-  shouldPublish?: boolean,
+  /** (optional) – If true, both the source and the derived entries will be published. If false, both will remain in draft state. If preserve, will keep current states of the source entries (default true) */
+  shouldPublish?: boolean | 'preserve',
   /**
    * (required) – Function that generates the field values for the derived entry.
    *  fields is an object containing each of the from fields. Each field will contain their current localized values (i.e. fields == {myField: {'en-US': 'my field value'}})

--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -6,6 +6,7 @@ import isDefined from '../utils/is-defined'
 
 import Entry from '../entities/entry'
 import * as _ from 'lodash'
+import shouldPublishLocalChanges from '../utils/should-publish-local-changes'
 
 class EntryDeriveAction extends APIAction {
   private contentTypeId: string
@@ -14,7 +15,7 @@ class EntryDeriveAction extends APIAction {
   private derivedContentType: string
   private deriveEntryForLocale: (inputFields: any, locale: string) => Promise<any>
   private identityKey: (fromFields: any) => Promise<string>
-  private shouldPublish: boolean
+  private shouldPublish: boolean | 'preserve'
 
   constructor (contentTypeId: string, entryDerivation: EntryDerive) {
     super()
@@ -93,8 +94,8 @@ class EntryDeriveAction extends APIAction {
 
         }
         await api.saveEntry(targetEntry.id)
-        if (this.shouldPublish) {
-          await api.publishEntry(targetEntry.id)
+        if (shouldPublishLocalChanges(this.shouldPublish, entry)) {
+          await api.publishEntry(targetEntry.id);
         }
       }
       const field = sourceContentType.fields.getField(this.referenceField)
@@ -110,8 +111,8 @@ class EntryDeriveAction extends APIAction {
       }
 
       await api.saveEntry(entry.id)
-      if (this.shouldPublish) {
-        await api.publishEntry(entry.id)
+      if (shouldPublishLocalChanges(this.shouldPublish, entry)) {
+          await api.publishEntry(entry.id);
       }
     }
   }

--- a/src/lib/intent-validator/entry-derive.ts
+++ b/src/lib/intent-validator/entry-derive.ts
@@ -25,7 +25,7 @@ class EntryDeriveIntentValidator extends SchemaValidator {
       toReferenceField: Joi.string().required(),
       derivedFields: Joi.array().items(Joi.string()).required(),
       identityKey: Joi.func().required(),
-      shouldPublish: Joi.boolean(),
+      shouldPublish: Joi.alternatives().try([Joi.boolean(), Joi.string().valid(['preserve'])]),
       deriveEntryForLocale: Joi.func().required()
     }
   }

--- a/src/lib/interfaces/entry-derive.ts
+++ b/src/lib/interfaces/entry-derive.ts
@@ -4,6 +4,6 @@ export default interface EntryDerive {
   toReferenceField: string,
   derivedFields: string[],
   identityKey: (fromFields: any) => Promise<string>
-  shouldPublish?: boolean,
+  shouldPublish?: boolean | 'preserve',
   deriveEntryForLocale (inputFields: any, locale: string): Promise<any>
 }

--- a/test/unit/lib/intent-validator/entry-derive.spec.ts
+++ b/test/unit/lib/intent-validator/entry-derive.spec.ts
@@ -187,7 +187,7 @@ describe('Entry derivation', function () {
         },
         {
           type: 'InvalidType',
-          message: '\"number\" is not a valid type for the entry derivation property \"shouldPublish\". Expected \"boolean\".',
+          message: '"48" is not a valid value for the entry derivation property "shouldPublish". Expected type boolean or string value "preserve".',
           details: {
             step: {
               type: 'contentType/deriveEntries',


### PR DESCRIPTION


<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Add `preserve` to `shouldPublish` option of `deriveLinkedEntries`

## Description

`shouldPublish` now accepts the string `preserve`. When you set `preserve` will keep current states of the source entries.

## Motivation and Context

When you want to derive linked entries usually is needed to preserve the original state of the source, otherwise the tool will publish draft entries (so items not yet approved) or un-publish already published entries.
This solves the feature request #691 

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
