### PR TITLE
referencedsource implementation for derivedentries

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ The derive function is expected to return an object with the desired target fiel
 
 - **`toReferenceField : string`** _(required)_ – ID of the field on the source content type in which to insert the reference
 
+- **`shouldReferenceSource : bool`** _(optional)_ – Flag that changes the `toReferenceField` behavior to use the target content type instead of the source.  Derived reference field will reference the source. (default `false`)
+
 - **`derivedFields : array`** _(required)_ – Array of the field IDs on the target content type
 
 - **`identityKey: function (fields): string`** _(required)_ - Called once per source entry. Returns the ID used for the derived entry, which is also used for de-duplication so that multiple source entries can link to the same derived entry.
@@ -310,6 +312,7 @@ migration.deriveLinkedEntries({
     derivedContentType: 'owner',
     from: ['owner'],
     toReferenceField: 'ownerRef',
+    shouldReferenceSource: true,
     derivedFields: ['firstName', 'lastName'],
     identityKey: async (fromFields) => {
       return fromFields.owner['en-US'].toLowerCase().replace(' ', '-');

--- a/index.d.ts
+++ b/index.d.ts
@@ -344,6 +344,8 @@ export interface IDeriveLinkedEntriesConfig {
   identityKey: (fromFields: ContentFields) => string,
   /** (optional) – If true, both the source and the derived entries will be published. If false, both will remain in draft state (default true) */
   shouldPublish?: boolean,
+  /** (optional) - If true, changes reference field from source->target to target->source (default: false) */
+  shouldReferenceSource?: boolean,
   /**
    * (required) – Function that generates the field values for the derived entry.
    *  fields is an object containing each of the from fields. Each field will contain their current localized values (i.e. fields == {myField: {'en-US': 'my field value'}})

--- a/src/lib/interfaces/entry-derive.ts
+++ b/src/lib/interfaces/entry-derive.ts
@@ -2,6 +2,7 @@ export default interface EntryDerive {
   derivedContentType: string,
   from: string[],
   toReferenceField: string,
+  shouldReferenceSource?: boolean,
   derivedFields: string[],
   identityKey: (fromFields: any) => Promise<string>
   shouldPublish?: boolean,


### PR DESCRIPTION
## Summary

Adds new `shouldReferenceSource` flag to `derivedLinkedEntries`

## Description

This is an attempt to introduce a new flag for derive entries: `shouldReferenceSource`

The idea is to have a way for derived entries to have a reference field that points back to the source, instead of the source pointing to the derived.  (target -> source instead of source -> target)

If the flag is not present, derived entries functions like normal.

## Motivation and Context

https://github.com/contentful/contentful-migration/issues/184

## Todos

-   [ ] Integration Tests Written - **Unable to get working locally, must rely on PR automation**

