### PR TITLE
feat: support initial values

### DIFF
--- a/examples/32-create-fields-with-initial-values.js
+++ b/examples/32-create-fields-with-initial-values.js
@@ -1,0 +1,28 @@
+// Initial value example: create a new content with some initial values
+module.exports = function (migration) {
+  const Event = migration.createContentType('event').name('Event');
+  Event.createField('title')
+    .name('Title')
+    .localized(true)
+    .type('Symbol')
+    .initialValue({
+      'en-US': 'Initial title',
+      'fr-FR': 'Titre initial'
+    });
+
+  Event.createField('advertised')
+    .name('Advertised')
+    .type('Boolean')
+    .localized(false)
+    .initialValue({
+      'en-US': true
+    });
+
+  Event.createField('startDate')
+    .name('Start Date')
+    .type('Date')
+    .localized(false)
+    .initialValue({
+      'en-US': '2021-06-15T13:46:06Z'
+    });
+};

--- a/examples/32-initial-values.js
+++ b/examples/32-initial-values.js
@@ -1,0 +1,9 @@
+// Basic example: update existing content type
+module.exports = function (migration) {
+  const initialValueCT = migration.createContentType('initialValueCt').name("Initial value CT");
+  const shortTextField = initialValueCT.createField('shortText').name("Short Text Field")
+  shortTextField.type("Symbol")
+  shortTextField.initialValue({
+    'en-US': 5
+  })
+};

--- a/examples/32-initial-values.js
+++ b/examples/32-initial-values.js
@@ -1,9 +1,0 @@
-// Basic example: update existing content type
-module.exports = function (migration) {
-  const initialValueCT = migration.createContentType('initialValueCt').name("Initial value CT");
-  const shortTextField = initialValueCT.createField('shortText').name("Short Text Field")
-  shortTextField.type("Symbol")
-  shortTextField.initialValue({
-    'en-US': 5
-  })
-};

--- a/src/lib/intent-validator/field-update.ts
+++ b/src/lib/intent-validator/field-update.ts
@@ -18,6 +18,7 @@ class FieldUpdateStepValidator extends SchemaValidator {
       localized: Joi.boolean().required().strict(),
       required: Joi.boolean().required().strict(),
       validations: Joi.array().required(),
+      initialValue: Joi.object().required().strict(),
       disabled: Joi.boolean().required().strict(),
       omitted: Joi.boolean().required().strict(),
       deleted: Joi.boolean().required().strict(),

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -274,7 +274,12 @@ class OfflineAPI {
 
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.SaveContentType)) {
-        const errors = validator.validate(ct, this.savedContentTypes.get(id), this.publishedContentTypes.get(id))
+        const errors = validator.validate({
+          contentType: ct, 
+          savedContentType: this.savedContentTypes.get(id),
+          publishedContentType: this.publishedContentTypes.get(id),
+          locales: this.locales
+        })
         this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
       }
     }
@@ -301,7 +306,12 @@ class OfflineAPI {
 
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.PublishContentType)) {
-        const errors = validator.validate(ct, this.savedContentTypes.get(id), this.publishedContentTypes.get(id))
+        const errors = validator.validate({
+          contentType: ct, 
+          savedContentType: this.savedContentTypes.get(id),
+          publishedContentType: this.publishedContentTypes.get(id),
+          locales: this.locales
+        })
         this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
       }
     }
@@ -325,7 +335,12 @@ class OfflineAPI {
 
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.UnpublishContentType)) {
-        const errors = validator.validate(ct, this.savedContentTypes.get(id), this.publishedContentTypes.get(id))
+        const errors = validator.validate({
+          contentType: ct, 
+          savedContentType: this.savedContentTypes.get(id),
+          publishedContentType: this.publishedContentTypes.get(id),
+          locales: this.locales
+        })
         this.currentValidationErrorsRecorded = this.currentValidationErrorsRecorded.concat(errors)
       }
     }

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -275,7 +275,7 @@ class OfflineAPI {
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.SaveContentType)) {
         const errors = validator.validate({
-          contentType: ct, 
+          contentType: ct,
           savedContentType: this.savedContentTypes.get(id),
           publishedContentType: this.publishedContentTypes.get(id),
           locales: this.locales
@@ -307,7 +307,7 @@ class OfflineAPI {
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.PublishContentType)) {
         const errors = validator.validate({
-          contentType: ct, 
+          contentType: ct,
           savedContentType: this.savedContentTypes.get(id),
           publishedContentType: this.publishedContentTypes.get(id),
           locales: this.locales
@@ -336,7 +336,7 @@ class OfflineAPI {
     for (const validator of this.contentTypeValidators) {
       if (validator.hooks.includes(ApiHook.UnpublishContentType)) {
         const errors = validator.validate({
-          contentType: ct, 
+          contentType: ct,
           savedContentType: this.savedContentTypes.get(id),
           publishedContentType: this.publishedContentTypes.get(id),
           locales: this.locales

--- a/src/lib/offline-api/validator/content-type.ts
+++ b/src/lib/offline-api/validator/content-type.ts
@@ -2,7 +2,15 @@ import { ApiHook } from '../'
 import { ContentType } from '../../entities/content-type'
 import { PayloadValidationError, InvalidActionError } from '../../interfaces/errors'
 
+
+export type ContentTypePayloadValidatorOptions = {
+  contentType: ContentType
+  locales: string[]
+  savedContentType?: ContentType
+  publishedContentType?: ContentType,
+}
+
 export interface ContentTypePayloadValidator {
   hooks: ApiHook[]
-  validate (contentType: ContentType, savedContentType?: ContentType, publishedContentType?: ContentType): (InvalidActionError | PayloadValidationError)[]
+  validate (options: ContentTypePayloadValidatorOptions): (InvalidActionError | PayloadValidationError)[]
 }

--- a/src/lib/offline-api/validator/content-type.ts
+++ b/src/lib/offline-api/validator/content-type.ts
@@ -2,12 +2,11 @@ import { ApiHook } from '../'
 import { ContentType } from '../../entities/content-type'
 import { PayloadValidationError, InvalidActionError } from '../../interfaces/errors'
 
-
 export type ContentTypePayloadValidatorOptions = {
   contentType: ContentType
   locales: string[]
   savedContentType?: ContentType
-  publishedContentType?: ContentType,
+  publishedContentType?: ContentType
 }
 
 export interface ContentTypePayloadValidator {

--- a/src/lib/offline-api/validator/display-field.ts
+++ b/src/lib/offline-api/validator/display-field.ts
@@ -1,7 +1,6 @@
 import { ApiHook } from '../'
 import { ContentTypePayloadValidator } from './content-type'
 import { InvalidActionError } from '../../interfaces/errors'
-import { ContentType } from '../../entities/content-type'
 import errorMessages from './errors'
 
 const isDisplayFieldAndHasBeenDeleted = function (field, displayField) {
@@ -15,7 +14,7 @@ const fieldIsDisplayField = function (field, displayField) {
 export default class DisplayFieldValidator implements ContentTypePayloadValidator {
   public hooks = [ApiHook.SaveContentType]
 
-  public validate (contentType: ContentType): InvalidActionError[] {
+  public validate ({ contentType }): InvalidActionError[] {
     const errors: InvalidActionError[] = []
 
     const displayField = contentType.displayField

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -64,6 +64,14 @@ const errors = {
       INVALID_VALIDATION_PARAMETER: (propName, expectedType, actualType) => {
         return `"${propName}" validation expected to be "${expectedType}", but got "${actualType}"`
       }
+    },
+    initialValue: {
+      TYPE_MISMATCH: (fieldId, valueType, locale, fieldType) => {
+        return `Cannot set initial value of type "${valueType}" for locale "${locale}" on field "${fieldId}". The initial value must match the field type "${fieldType}".`
+      },
+      DATE_TYPE_MISMATCH: (fieldId, valueType, value, locale, fieldType) => {
+        return `Cannot set initial value of type "${valueType}" to "${value}" for locale "${locale}" on field "${fieldId}". The initial value must match the field type "${fieldType}" using a valid ISO date.`
+      }
     }
   },
   entry: {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -71,6 +71,13 @@ const errors = {
       },
       DATE_TYPE_MISMATCH: (fieldId, valueType, value, locale, fieldType) => {
         return `Cannot set initial value of type "${valueType}" to "${value}" for locale "${locale}" on field "${fieldId}". The initial value must match the field type "${fieldType}" using a valid ISO date.`
+      },
+      INVALID_LOCALE: (fieldId, locale) => {
+        return `Cannot set initial value for locale "${locale}" on field "${fieldId}". The locale does not exist.`
+      },
+
+      UNSUPPORTED_FIELD_TYPE: (fieldId, key, fieldType) => {
+        return `Cannot set "${key}" in field "${fieldId}" because it is not supported by field type "${fieldType}".`
       }
     }
   },

--- a/src/lib/offline-api/validator/field-deletion.ts
+++ b/src/lib/offline-api/validator/field-deletion.ts
@@ -1,5 +1,5 @@
 import { ApiHook } from '../'
-import { ContentTypePayloadValidator, ContentTypePayloadValidatorOptions } from './content-type';
+import { ContentTypePayloadValidator, ContentTypePayloadValidatorOptions } from './content-type'
 import { PayloadValidationError, InvalidActionError } from '../../interfaces/errors'
 import errorMessages from './errors'
 import { difference } from 'lodash'
@@ -14,7 +14,7 @@ const deletedFieldError = function (contentTypeId: string, fieldId: string): Inv
 export default class FieldDeletionValidator implements ContentTypePayloadValidator {
   public hooks = [ApiHook.SaveContentType]
 
-  public validate({ contentType, publishedContentType }: ContentTypePayloadValidatorOptions): (PayloadValidationError | InvalidActionError)[] {
+  public validate ({ contentType, publishedContentType }: ContentTypePayloadValidatorOptions): (PayloadValidationError | InvalidActionError)[] {
 
     const deletedFields = contentType.fields.filter((field) => field.deleted)
     const omittedFieldsInParent = publishedContentType ? publishedContentType.fields.filter((field) => field.omitted) : []

--- a/src/lib/offline-api/validator/field-deletion.ts
+++ b/src/lib/offline-api/validator/field-deletion.ts
@@ -1,7 +1,6 @@
 import { ApiHook } from '../'
-import { ContentTypePayloadValidator } from './content-type'
+import { ContentTypePayloadValidator, ContentTypePayloadValidatorOptions } from './content-type';
 import { PayloadValidationError, InvalidActionError } from '../../interfaces/errors'
-import { ContentType } from '../../entities/content-type'
 import errorMessages from './errors'
 import { difference } from 'lodash'
 
@@ -15,7 +14,8 @@ const deletedFieldError = function (contentTypeId: string, fieldId: string): Inv
 export default class FieldDeletionValidator implements ContentTypePayloadValidator {
   public hooks = [ApiHook.SaveContentType]
 
-  public validate (contentType: ContentType, _savedContentType: ContentType, publishedContentType: ContentType): (PayloadValidationError | InvalidActionError)[] {
+  public validate({ contentType, publishedContentType }: ContentTypePayloadValidatorOptions): (PayloadValidationError | InvalidActionError)[] {
+
     const deletedFields = contentType.fields.filter((field) => field.deleted)
     const omittedFieldsInParent = publishedContentType ? publishedContentType.fields.filter((field) => field.omitted) : []
 

--- a/src/lib/offline-api/validator/schema/fields-schema.ts
+++ b/src/lib/offline-api/validator/schema/fields-schema.ts
@@ -1,8 +1,7 @@
 import * as Joi from 'joi'
 import getFieldValidations from './field-validations-schema'
 
-
-export function createFieldsSchema(locales: string[]) {
+export function createFieldsSchema (locales: string[]) {
   const fieldSchema = Joi.object().keys({
     id: Joi.string().required(),
     newId: Joi.string()
@@ -46,28 +45,28 @@ export function createFieldsSchema(locales: string[]) {
         switch: [
           {
             is: 'Symbol',
-            then: Joi.string(),
+            then: Joi.string()
           },
           {
             is: 'Text',
-            then: Joi.string(),
+            then: Joi.string()
           },
           {
             is: 'Number',
-            then: Joi.number(),
+            then: Joi.number()
           },
           {
             is: 'Integer',
-            then: Joi.number().integer(),
+            then: Joi.number().integer()
           },
           {
             is: 'Boolean',
-            then: Joi.boolean(),
+            then: Joi.boolean()
           },
           {
             is: 'Date',
-            then: Joi.date().iso().strict(false),
-          },
+            then: Joi.date().iso().strict(false)
+          }
         ]
       }
     )),

--- a/src/lib/offline-api/validator/schema/fields-schema.ts
+++ b/src/lib/offline-api/validator/schema/fields-schema.ts
@@ -95,16 +95,16 @@ const getFieldSchema = () => Joi.object().keys({
   localized: Joi.boolean(),
   required: Joi.boolean(),
   validations: Joi.array().unique().items(getFieldValidations()),
-  initialValue: Joi.object().keys({
-    "en-US": Joi.string(),
-  }),
-  
+  // initialValue: Joi.object().keys({
+  //   "en-US": Joi.string(),
+  // }),
+
   // Joi.object().when('type', {
   //   is: 'Symbol',
   //   then: Joi.object().pattern(/.*/, Joi.string()),
   //   otherwise: Joi.any().forbidden()
   // }),
-  
+
   // enforceDependency({
   //   valid: Joi.object().keys({
   //     "en-US": Joi.string(),
@@ -112,13 +112,50 @@ const getFieldSchema = () => Joi.object().keys({
   //   when: 'type',
   //   is: 'Symbol'
   // }),
-  
-  // Joi.object().pattern(/.*/, enforceDependency({
+  initialValue: Joi.object().strict().pattern(/.*/, Joi.when(
+    Joi.ref('...type'),
+    {
+      otherwise: Joi.forbidden(),
+      switch: [
+        {
+          is: 'Symbol',
+          then: Joi.string(),
+        },
+        {
+          is: 'Text',
+          then: Joi.string(),
+        },
+        {
+          is: 'Number',
+          then: Joi.number(),
+        },
+        {
+          is: 'Integer',
+          then: Joi.number().integer(),
+        },
+        {
+          is: 'Boolean',
+          then: Joi.boolean(),
+        },
+        {
+          is: 'Date',
+          then: Joi.date().iso().strict(false),
+        },
+      ]
+    }
+  )),
+
+  // initialValue: Joi.object().pattern(/.*/, enforceDependency({
   //     valid: Joi.string(),
   //     when: Joi.ref('...type'),
   //     is: 'Symbol'
-  //   })),
-  
+  //   }))
+  //   .concat( Joi.object().pattern(/.*/, enforceDependency({
+  //     valid: Joi.number(),
+  //     when: Joi.ref('...type'),
+  //     is: 'Number'
+  //   }))),
+
   // }).concat(),
   disabled: Joi.boolean()
 })

--- a/src/lib/offline-api/validator/schema/fields-schema.ts
+++ b/src/lib/offline-api/validator/schema/fields-schema.ts
@@ -95,6 +95,31 @@ const getFieldSchema = () => Joi.object().keys({
   localized: Joi.boolean(),
   required: Joi.boolean(),
   validations: Joi.array().unique().items(getFieldValidations()),
+  initialValue: Joi.object().keys({
+    "en-US": Joi.string(),
+  }),
+  
+  // Joi.object().when('type', {
+  //   is: 'Symbol',
+  //   then: Joi.object().pattern(/.*/, Joi.string()),
+  //   otherwise: Joi.any().forbidden()
+  // }),
+  
+  // enforceDependency({
+  //   valid: Joi.object().keys({
+  //     "en-US": Joi.string(),
+  //   }),//Joi.object().pattern(/.*/, Joi.string()),
+  //   when: 'type',
+  //   is: 'Symbol'
+  // }),
+  
+  // Joi.object().pattern(/.*/, enforceDependency({
+  //     valid: Joi.string(),
+  //     when: Joi.ref('...type'),
+  //     is: 'Symbol'
+  //   })),
+  
+  // }).concat(),
   disabled: Joi.boolean()
 })
 

--- a/src/lib/offline-api/validator/schema/index.ts
+++ b/src/lib/offline-api/validator/schema/index.ts
@@ -1,15 +1,14 @@
 import { ApiHook } from '../../index'
 import { ContentTypePayloadValidator } from '../content-type'
 import { PayloadValidationError } from '../../../interfaces/errors'
-import { ContentType } from '../../../entities/content-type'
 import { validateContentType, validateFields } from './schema-validation'
 
 export default class SchemaValidator implements ContentTypePayloadValidator {
   public hooks = [ApiHook.SaveContentType]
 
-  public validate (contentType: ContentType): PayloadValidationError[] {
+  public validate ({ contentType, locales }): PayloadValidationError[] {
     const ctErrors = validateContentType(contentType)
-    const fieldErrors = validateFields(contentType)
+    const fieldErrors = validateFields(contentType, locales)
 
     return ctErrors.concat(fieldErrors)
   }

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -18,13 +18,14 @@ interface SimplifiedValidationError {
     isRequiredDependency?: boolean
     isForbiddenDependency?: boolean
     dependsOn?: {
-      key: string,
+      key: string
       value: any
     }
     dupeValue?: any
     key?: any
-    keys?: any[],
+    keys?: any[]
     valids?: any[]
+    value: any
   }
 }
 
@@ -161,8 +162,6 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
     abortEarly: false
   })
 
-  console.log(validateResult)
-
   const { error } = validateResult
 
   if (!error) {
@@ -170,7 +169,6 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
   }
 
   const cleanErrors = cleanNoiseFromJoiErrors(error)
-  console.log(cleanErrors)
 
   return cleanErrors.map((details: Joi.ValidationErrorItem): PayloadValidationError => {
     const { path, type, context } = details
@@ -180,6 +178,19 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
     const [index, ...fieldNames] = path
     const prop = fieldNames.join('.')
     const field = fields[index]
+
+    if(prop.startsWith('initialValue')){
+      if(field.type === 'Date'){
+        return {
+          type: 'InvalidPayload',
+          message: errorMessages.field.initialValue.DATE_TYPE_MISMATCH(field.id, kindOf(context.value), context.value, context.key, field.type)
+        }
+      }
+      return {
+        type: 'InvalidPayload',
+        message: errorMessages.field.initialValue.TYPE_MISMATCH(field.id, kindOf(context.value), context.key, field.type)
+      }
+    }
 
     // 'string.base'
     if (type === 'any.required') {

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -161,13 +161,18 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
     abortEarly: false
   })
 
+  console.log(validateResult)
+
   const { error } = validateResult
 
   if (!error) {
     return []
   }
 
-  return cleanNoiseFromJoiErrors(error).map((details: Joi.ValidationErrorItem): PayloadValidationError => {
+  const cleanErrors = cleanNoiseFromJoiErrors(error)
+  console.log(cleanErrors)
+
+  return cleanErrors.map((details: Joi.ValidationErrorItem): PayloadValidationError => {
     const { path, type, context } = details
 
     // `path` looks like [0, 'field']
@@ -176,6 +181,7 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
     const prop = fieldNames.join('.')
     const field = fields[index]
 
+    // 'string.base'
     if (type === 'any.required') {
       if (context.isRequiredDependency) {
         const dependentProp = context.dependsOn.key

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -8,7 +8,7 @@ import { ContentType } from '../../../entities/content-type'
 import { Tag } from '../../../entities/tag'
 import { contentTypeSchema, MAX_FIELDS } from './content-type-schema'
 import { tagSchema } from './tag-schema'
-import getFieldsSchema from './fields-schema'
+import { createFieldsSchema } from './fields-schema'
 
 interface SimplifiedValidationError {
   message: string
@@ -25,7 +25,7 @@ interface SimplifiedValidationError {
     key?: any
     keys?: any[]
     valids?: any[]
-    value: any
+    value?: any
   }
 }
 
@@ -156,9 +156,9 @@ const cleanNoiseFromJoiErrors = function (error: Joi.ValidationError): Joi.Valid
   return allErrors
 }
 
-const validateFields = function (contentType: ContentType): PayloadValidationError[] {
+const validateFields = function (contentType: ContentType, locales: string[]): PayloadValidationError[] {
   const fields = contentType.fields.toRaw()
-  const validateResult = getFieldsSchema().validate(fields, {
+  const validateResult = createFieldsSchema(locales).validate(fields, {
     abortEarly: false
   })
 
@@ -178,8 +178,22 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
     const [index, ...fieldNames] = path
     const prop = fieldNames.join('.')
     const field = fields[index]
-
     if(prop.startsWith('initialValue')){
+
+      if (type === 'object.unknown') {
+        return {
+          type: 'InvalidPayload',
+          message: errorMessages.field.initialValue.INVALID_LOCALE(field.id, context.key)
+        }
+      }
+
+      if (type === 'any.unknown') {
+        return {
+          type: 'InvalidPayload',
+          message: errorMessages.field.initialValue.UNSUPPORTED_FIELD_TYPE(field.id, path[1], field.type)
+        }
+      }
+
       if(field.type === 'Date'){
         return {
           type: 'InvalidPayload',
@@ -285,6 +299,7 @@ const validateFields = function (contentType: ContentType): PayloadValidationErr
         }
       }
     }
+   
   })
 }
 

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -178,7 +178,7 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
     const [index, ...fieldNames] = path
     const prop = fieldNames.join('.')
     const field = fields[index]
-    if(prop.startsWith('initialValue')){
+    if (prop.startsWith('initialValue')) {
 
       if (type === 'object.unknown') {
         return {
@@ -194,7 +194,7 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
         }
       }
 
-      if(field.type === 'Date'){
+      if (field.type === 'Date') {
         return {
           type: 'InvalidPayload',
           message: errorMessages.field.initialValue.DATE_TYPE_MISMATCH(field.id, kindOf(context.value), context.value, context.key, field.type)
@@ -206,7 +206,6 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
       }
     }
 
-    // 'string.base'
     if (type === 'any.required') {
       if (context.isRequiredDependency) {
         const dependentProp = context.dependsOn.key
@@ -299,7 +298,6 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
         }
       }
     }
-   
   })
 }
 

--- a/src/lib/offline-api/validator/type-change.ts
+++ b/src/lib/offline-api/validator/type-change.ts
@@ -1,15 +1,14 @@
 import { Field } from '../../interfaces/content-type'
 import { ApiHook } from '../'
-import { ContentTypePayloadValidator } from './content-type'
+import { ContentTypePayloadValidator, ContentTypePayloadValidatorOptions } from './content-type';
 import { InvalidActionError } from '../../interfaces/errors'
-import { ContentType } from '../../entities/content-type'
 import errorMessages from './errors'
 import { keyBy } from 'lodash'
 
 export default class TypeChangeValidator implements ContentTypePayloadValidator {
   public hooks = [ApiHook.SaveContentType]
 
-  public validate (contentType: ContentType, _savedContentType: ContentType, publishedContentType: ContentType): InvalidActionError[] {
+  public validate ({ contentType, publishedContentType }: ContentTypePayloadValidatorOptions): InvalidActionError[] {
     const errors: InvalidActionError[] = []
 
     if (!publishedContentType) {

--- a/src/lib/offline-api/validator/type-change.ts
+++ b/src/lib/offline-api/validator/type-change.ts
@@ -1,6 +1,6 @@
 import { Field } from '../../interfaces/content-type'
 import { ApiHook } from '../'
-import { ContentTypePayloadValidator, ContentTypePayloadValidatorOptions } from './content-type';
+import { ContentTypePayloadValidator, ContentTypePayloadValidatorOptions } from './content-type'
 import { InvalidActionError } from '../../interfaces/errors'
 import errorMessages from './errors'
 import { keyBy } from 'lodash'

--- a/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
@@ -8,72 +8,173 @@ import validateBatches from './validate-batches'
   // field type allowes initial values > [ShortText, "Text ..."]
 
 describe('payload validation (initial value)', function () {
-  // describe('when setting a display field that does not (yet) exist', function () {
-  //   it('returns an error', async function () {
-  //     const errors = await validateBatches(function (migration) {
-  //       const lunch = migration.createContentType('lunch').name('lunch')
-  //       lunch.createField('mainCourse').name('mainCourse').type('Symbol')
+  describe.only('when initial value does not match the field type', function () {
+    it('returns an error for Symbol', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('mainCourse')
+        .name('mainCourse')
+        .type('Symbol')
+        .initialValue({
+          'en-US': 1234,
+          'de-DE': false,
+          'fr-FR': 'A string',
+        })
+      }, [])
 
-  //       lunch.deleteField('mainCourse')
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "number" for locale "en-US" on field "mainCourse". The initial value must match the field type "Symbol".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "mainCourse". The initial value must match the field type "Symbol".'
+          }
+        ],
+      ])
+    })
+    it('returns an error for Number', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('aNumber')
+        .name('aNumber')
+        .type('Number')
+        .initialValue({
+          'en-US': '1.234',
+          'de-DE': 'A string',
+          'fr-FR': 555,
+        })
+      }, [])
 
-  //       lunch.displayField('dessert')
-  //       migration.createContentType('dinner').name('dinner')
-  //       lunch.createField('dessert').name('dessert').type('Symbol')
-  //     }, [])
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "string" for locale "en-US" on field "aNumber". The initial value must match the field type "Number".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "string" for locale "de-DE" on field "aNumber". The initial value must match the field type "Number".'
+          }
+        ],
+      ])
+    })
+    it('returns an error for Integer', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('anInteger')
+        .name('anInteger')
+        .type('Integer')
+        .initialValue({
+          'en-US': 1.234,
+          'de-DE': 'A string',
+          'it-IT': '9999',
+          'fr-FR': 555,
+        })
+      }, [])
 
-  //     expect(errors).to.eql([
-  //       [],
-  //       [],
-  //       [
-  //         {
-  //           type: 'InvalidAction',
-  //           message: 'Cannot set "dessert" as displayField on content type "lunch" because it does not exist'
-  //         }
-  //       ],
-  //       [],
-  //       []
-  //     ])
-  //   })
-  // })
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "number" for locale "en-US" on field "anInteger". The initial value must match the field type "Integer".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "string" for locale "de-DE" on field "anInteger". The initial value must match the field type "Integer".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "string" for locale "it-IT" on field "anInteger". The initial value must match the field type "Integer".'
+          }
+        ],
+      ])
+    })
 
-  // describe('when setting a display field that does exist', function () {
-  //   it('does not return any errors', async function () {
-  //     const errors = await validateBatches(function (migration) {
-  //       const lunch = migration.createContentType('lunch').name('lunch')
-  //       lunch.createField('dessert').name('dessert').type('Symbol')
-  //       lunch.createField('mainCourse').name('mainCourse').type('Symbol')
-  //       lunch.displayField('dessert')
-  //     }, [])
+    it('returns an error for Boolean', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('aBool')
+        .name('aBool')
+        .type('Boolean')
+        .initialValue({
+          'en-US': 1,
+          'de-DE': 'A string',
+          'it-IT': true,
+          'fr-FR': false,
+        })
+      }, [])
 
-  //     expect(errors).to.eql([
-  //       []
-  //     ])
-  //   })
-  // })
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "number" for locale "en-US" on field "aBool". The initial value must match the field type "Boolean".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "string" for locale "de-DE" on field "aBool". The initial value must match the field type "Boolean".'
+          },
+        ],
+      ])
+    })
 
-  // describe('when deleting a field that is set as the display field', function () {
-  //   it('returns an error', async function () {
-  //     const errors = await validateBatches(function (migration) {
-  //       const lunch = migration.createContentType('lunch').name('lunch')
-  //       lunch.createField('mainCourse').name('mainCourse').type('Symbol')
-  //       lunch.createField('dessert').name('dessert').type('Symbol')
-  //       lunch.displayField('dessert')
+    it('returns an error for Text', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('aText')
+        .name('aText')
+        .type('Text')
+        .initialValue({
+          'en-US': 1234,
+          'de-DE': false,
+          'fr-FR': 'A string',
+        })
+      }, [])
 
-  //       migration.createContentType('dinner').name('dinner')
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "number" for locale "en-US" on field "aText". The initial value must match the field type "Text".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "aText". The initial value must match the field type "Text".'
+          }
+        ],
+      ])
+    })
 
-  //       lunch.deleteField('dessert')
-  //     }, [])
+    it.only('returns an error for Date', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('aDate')
+        .name('aDate')
+        .type('Date')
+        .initialValue({
+          'en-US': 'A string',
+          'de-DE': false,
+          'fr-FR': 1234,
+          'es-ES': '1234',
+          'it-IT': '2013-05-02T13:00:00Z',
+        })
+      }, [])
 
-  //     expect(errors).to.eql([
-  //       [],
-  //       [],
-  //       [
-  //         {
-  //           type: 'InvalidAction',
-  //           message: 'Cannot delete field "dessert" on content type "lunch" because it is set as the display field'
-  //         }
-  //       ]
-  //     ])
-  //   })
-  // })
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "string" to "A string" for locale "en-US" on field "aDate". The initial value must match the field type "Date" using a valid ISO date.'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "boolean" to "false" for locale "de-DE" on field "aDate". The initial value must match the field type "Date" using a valid ISO date.'
+          }
+        ],
+      ])
+    })
+  })
 })

--- a/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
@@ -1,0 +1,79 @@
+'use strict'
+
+import { expect } from 'chai'
+import validateBatches from './validate-batches'
+
+  // locales are invalid
+  // type of values is correct > string, number, integer, boolean
+  // field type allowes initial values > [ShortText, "Text ..."]
+
+describe('payload validation (initial value)', function () {
+  // describe('when setting a display field that does not (yet) exist', function () {
+  //   it('returns an error', async function () {
+  //     const errors = await validateBatches(function (migration) {
+  //       const lunch = migration.createContentType('lunch').name('lunch')
+  //       lunch.createField('mainCourse').name('mainCourse').type('Symbol')
+
+  //       lunch.deleteField('mainCourse')
+
+  //       lunch.displayField('dessert')
+  //       migration.createContentType('dinner').name('dinner')
+  //       lunch.createField('dessert').name('dessert').type('Symbol')
+  //     }, [])
+
+  //     expect(errors).to.eql([
+  //       [],
+  //       [],
+  //       [
+  //         {
+  //           type: 'InvalidAction',
+  //           message: 'Cannot set "dessert" as displayField on content type "lunch" because it does not exist'
+  //         }
+  //       ],
+  //       [],
+  //       []
+  //     ])
+  //   })
+  // })
+
+  // describe('when setting a display field that does exist', function () {
+  //   it('does not return any errors', async function () {
+  //     const errors = await validateBatches(function (migration) {
+  //       const lunch = migration.createContentType('lunch').name('lunch')
+  //       lunch.createField('dessert').name('dessert').type('Symbol')
+  //       lunch.createField('mainCourse').name('mainCourse').type('Symbol')
+  //       lunch.displayField('dessert')
+  //     }, [])
+
+  //     expect(errors).to.eql([
+  //       []
+  //     ])
+  //   })
+  // })
+
+  // describe('when deleting a field that is set as the display field', function () {
+  //   it('returns an error', async function () {
+  //     const errors = await validateBatches(function (migration) {
+  //       const lunch = migration.createContentType('lunch').name('lunch')
+  //       lunch.createField('mainCourse').name('mainCourse').type('Symbol')
+  //       lunch.createField('dessert').name('dessert').type('Symbol')
+  //       lunch.displayField('dessert')
+
+  //       migration.createContentType('dinner').name('dinner')
+
+  //       lunch.deleteField('dessert')
+  //     }, [])
+
+  //     expect(errors).to.eql([
+  //       [],
+  //       [],
+  //       [
+  //         {
+  //           type: 'InvalidAction',
+  //           message: 'Cannot delete field "dessert" on content type "lunch" because it is set as the display field'
+  //         }
+  //       ]
+  //     ])
+  //   })
+  // })
+})

--- a/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
@@ -3,11 +3,9 @@
 import { expect } from 'chai'
 import validateBatches from './validate-batches'
 
-
-
 describe.only('payload validation (initial value)', function () {
 
-  describe('when setting initial value for non existing locales', function(){
+  describe('when setting initial value for non existing locales', function () {
     it('returns an error', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
@@ -17,7 +15,7 @@ describe.only('payload validation (initial value)', function () {
         .initialValue({
           'en-US': 'A Symbol',
           'de-DE': 'A Symbol',
-          'fr-FR': 'A Symbol',
+          'fr-FR': 'A Symbol'
         })
       }, [], [], [], [ 'en-US'])
 
@@ -31,7 +29,7 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set initial value for locale "fr-FR" on field "mainCourse". The locale does not exist.'
           }
-        ],
+        ]
       ])
     })
   })
@@ -45,7 +43,7 @@ describe.only('payload validation (initial value)', function () {
         .initialValue({
           'en-US': 1234,
           'de-DE': false,
-          'fr-FR': 'A string',
+          'fr-FR': 'A string'
         })
       }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
 
@@ -59,7 +57,7 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "aSymbol". The initial value must match the field type "Symbol".'
           }
-        ],
+        ]
       ])
     })
     it('returns an error for Number', async function () {
@@ -71,7 +69,7 @@ describe.only('payload validation (initial value)', function () {
         .initialValue({
           'en-US': '1.234',
           'de-DE': 'A string',
-          'fr-FR': 555,
+          'fr-FR': 555
         })
       }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
 
@@ -85,7 +83,7 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "string" for locale "de-DE" on field "aNumber". The initial value must match the field type "Number".'
           }
-        ],
+        ]
       ])
     })
     it('returns an error for Integer', async function () {
@@ -98,7 +96,7 @@ describe.only('payload validation (initial value)', function () {
           'en-US': 1.234,
           'de-DE': 'A string',
           'it-IT': '9999',
-          'fr-FR': 555,
+          'fr-FR': 555
         })
       }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT'])
 
@@ -116,7 +114,7 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "string" for locale "it-IT" on field "anInteger". The initial value must match the field type "Integer".'
           }
-        ],
+        ]
       ])
     })
 
@@ -130,7 +128,7 @@ describe.only('payload validation (initial value)', function () {
           'en-US': 1,
           'de-DE': 'A string',
           'it-IT': true,
-          'fr-FR': false,
+          'fr-FR': false
         })
       }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT'])
 
@@ -143,8 +141,8 @@ describe.only('payload validation (initial value)', function () {
           {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "string" for locale "de-DE" on field "aBool". The initial value must match the field type "Boolean".'
-          },
-        ],
+          }
+        ]
       ])
     })
 
@@ -157,7 +155,7 @@ describe.only('payload validation (initial value)', function () {
         .initialValue({
           'en-US': 1234,
           'de-DE': false,
-          'fr-FR': 'A string',
+          'fr-FR': 'A string'
         })
       }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
 
@@ -171,7 +169,7 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "aText". The initial value must match the field type "Text".'
           }
-        ],
+        ]
       ])
     })
 
@@ -186,7 +184,7 @@ describe.only('payload validation (initial value)', function () {
           'de-DE': false,
           'fr-FR': 1234,
           'es-ES': '1234',
-          'it-IT': '2013-05-02T13:00:00Z',
+          'it-IT': '2013-05-02T13:00:00Z'
         })
       }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT', 'es-ES'])
 
@@ -200,12 +198,12 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "boolean" to "false" for locale "de-DE" on field "aDate". The initial value must match the field type "Date" using a valid ISO date.'
           }
-        ],
+        ]
       ])
     })
   })
 
-  describe('when setting initial value a field where is not supported', function(){
+  describe('when setting initial value a field where is not supported', function () {
     it('returns an error', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
@@ -213,7 +211,7 @@ describe.only('payload validation (initial value)', function () {
         .name('mainCourse')
         .type('RichText')
         .initialValue({
-          'en-US': 'A Text',
+          'en-US': 'A Text'
         })
       }, [], [], [], [ 'en-US'])
 
@@ -223,7 +221,7 @@ describe.only('payload validation (initial value)', function () {
             type: 'InvalidPayload',
             message: 'Cannot set "initialValue" in field "mainCourse" because it is not supported by field type "RichText".'
           }
-        ],
+        ]
       ])
     })
   })

--- a/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
@@ -3,34 +3,61 @@
 import { expect } from 'chai'
 import validateBatches from './validate-batches'
 
-  // locales are invalid
-  // type of values is correct > string, number, integer, boolean
-  // field type allowes initial values > [ShortText, "Text ..."]
 
-describe('payload validation (initial value)', function () {
-  describe.only('when initial value does not match the field type', function () {
-    it('returns an error for Symbol', async function () {
+
+describe.only('payload validation (initial value)', function () {
+
+  describe('when setting initial value for non existing locales', function(){
+    it('returns an error', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('mainCourse')
         .name('mainCourse')
         .type('Symbol')
         .initialValue({
-          'en-US': 1234,
-          'de-DE': false,
-          'fr-FR': 'A string',
+          'en-US': 'A Symbol',
+          'de-DE': 'A Symbol',
+          'fr-FR': 'A Symbol',
         })
-      }, [])
+      }, [], [], [], [ 'en-US'])
 
       expect(errors).to.eql([
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "number" for locale "en-US" on field "mainCourse". The initial value must match the field type "Symbol".'
+            message: 'Cannot set initial value for locale "de-DE" on field "mainCourse". The locale does not exist.'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "mainCourse". The initial value must match the field type "Symbol".'
+            message: 'Cannot set initial value for locale "fr-FR" on field "mainCourse". The locale does not exist.'
+          }
+        ],
+      ])
+    })
+  })
+  describe('when initial value does not match the field type', function () {
+    it('returns an error for Symbol', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('aSymbol')
+        .name('aSymbol')
+        .type('Symbol')
+        .initialValue({
+          'en-US': 1234,
+          'de-DE': false,
+          'fr-FR': 'A string',
+        })
+      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
+
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "number" for locale "en-US" on field "aSymbol". The initial value must match the field type "Symbol".'
+          },
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "aSymbol". The initial value must match the field type "Symbol".'
           }
         ],
       ])
@@ -46,7 +73,7 @@ describe('payload validation (initial value)', function () {
           'de-DE': 'A string',
           'fr-FR': 555,
         })
-      }, [])
+      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
 
       expect(errors).to.eql([
         [
@@ -73,7 +100,7 @@ describe('payload validation (initial value)', function () {
           'it-IT': '9999',
           'fr-FR': 555,
         })
-      }, [])
+      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT'])
 
       expect(errors).to.eql([
         [
@@ -105,7 +132,7 @@ describe('payload validation (initial value)', function () {
           'it-IT': true,
           'fr-FR': false,
         })
-      }, [])
+      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT'])
 
       expect(errors).to.eql([
         [
@@ -132,7 +159,7 @@ describe('payload validation (initial value)', function () {
           'de-DE': false,
           'fr-FR': 'A string',
         })
-      }, [])
+      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
 
       expect(errors).to.eql([
         [
@@ -148,7 +175,7 @@ describe('payload validation (initial value)', function () {
       ])
     })
 
-    it.only('returns an error for Date', async function () {
+    it('returns an error for Date', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aDate')
@@ -161,7 +188,7 @@ describe('payload validation (initial value)', function () {
           'es-ES': '1234',
           'it-IT': '2013-05-02T13:00:00Z',
         })
-      }, [])
+      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT', 'es-ES'])
 
       expect(errors).to.eql([
         [
@@ -172,6 +199,29 @@ describe('payload validation (initial value)', function () {
           {
             type: 'InvalidPayload',
             message: 'Cannot set initial value of type "boolean" to "false" for locale "de-DE" on field "aDate". The initial value must match the field type "Date" using a valid ISO date.'
+          }
+        ],
+      ])
+    })
+  })
+
+  describe('when setting initial value a field where is not supported', function(){
+    it('returns an error', async function () {
+      const errors = await validateBatches(function (migration) {
+        const lunch = migration.createContentType('lunch').name('lunch')
+        lunch.createField('mainCourse')
+        .name('mainCourse')
+        .type('RichText')
+        .initialValue({
+          'en-US': 'A Text',
+        })
+      }, [], [], [], [ 'en-US'])
+
+      expect(errors).to.eql([
+        [
+          {
+            type: 'InvalidPayload',
+            message: 'Cannot set "initialValue" in field "mainCourse" because it is not supported by field type "RichText".'
           }
         ],
       ])

--- a/test/unit/lib/offline-api/validation/validate-batches.ts
+++ b/test/unit/lib/offline-api/validation/validate-batches.ts
@@ -6,7 +6,7 @@ import { migration } from '../../../../../src/lib/migration-steps'
 
 const noOp = () => undefined
 
-const validateBatches = async function (runMigration, contentTypes, tags = [], entries = []) {
+const validateBatches = async function (runMigration, contentTypes, tags = [], entries = [], locales = []) {
   const intents = await migration(runMigration, noOp, {})
   const list = new IntentList(intents)
 
@@ -24,7 +24,7 @@ const validateBatches = async function (runMigration, contentTypes, tags = [], e
     existingTags.set(tag.id, tag)
   }
 
-  const api = new OfflineAPI({ contentTypes: existingCTs, tags: existingTags, entries, locales: [] })
+  const api = new OfflineAPI({ contentTypes: existingCTs, tags: existingTags, entries, locales })
 
   await list.compressed().applyTo(api)
 


### PR DESCRIPTION
## Summary

Allow defining `initialValue` property on content type fields. Validate for supported field types, existing locales and correct type of initial values.
