### PR TITLE
feat: support initialValue for array of symbols

### DIFF
--- a/examples/32-create-fields-with-initial-values.js
+++ b/examples/32-create-fields-with-initial-values.js
@@ -25,4 +25,15 @@ module.exports = function (migration) {
     .initialValue({
       'en-US': '2021-06-15T13:46:06Z'
     });
+
+  Event.createField('categories')
+    .name('Categories')
+    .type('Array')
+    .items({
+      type: 'Symbol'
+    })
+    .localized(false)
+    .initialValue({
+      'en-US': ['Culture', 'Local History']
+    });
 };

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -78,6 +78,9 @@ const errors = {
 
       UNSUPPORTED_FIELD_TYPE: (fieldId, key, fieldType) => {
         return `Cannot set "${key}" in field "${fieldId}" because it is not supported by field type "${fieldType}".`
+      },
+      UNSUPPORTED_ARRAY_ITEMS_TYPE: (fieldId, key, itemsType) => {
+        return `Cannot set "${key}" in field "${fieldId}" because it is not supported in array with items of type "${itemsType}".`
       }
     }
   },

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -80,7 +80,7 @@ const errors = {
         return `Cannot set "${key}" in field "${fieldId}" because it is not supported by field type "${fieldType}".`
       },
       UNSUPPORTED_ARRAY_ITEMS_TYPE: (fieldId, key, itemsType) => {
-        return `Cannot set "${key}" in field "${fieldId}" because it is not supported in array with items of type "${itemsType}".`
+        return `Cannot set "${key}" in field "${fieldId}" because it is not supported by field type "Array" with items type "${itemsType}".`
       }
     }
   },

--- a/src/lib/offline-api/validator/schema/fields-schema.ts
+++ b/src/lib/offline-api/validator/schema/fields-schema.ts
@@ -66,6 +66,14 @@ export function createFieldsSchema (locales: string[]) {
           {
             is: 'Date',
             then: Joi.date().iso().strict(false)
+          },
+          {
+            is: 'Array',
+            then: Joi.when(Joi.ref('...items.type'), {
+              is: 'Symbol',
+              then: Joi.array().items(Joi.string()),
+              otherwise: Joi.forbidden()
+            })
           }
         ]
       }

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -188,6 +188,13 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
       }
 
       if (type === 'any.unknown') {
+
+        if (field.type === 'Array') {
+          return {
+            type: 'InvalidPayload',
+            message: errorMessages.field.initialValue.UNSUPPORTED_ARRAY_ITEMS_TYPE(field.id, path[1], field.items.type)
+          }
+        }
         return {
           type: 'InvalidPayload',
           message: errorMessages.field.initialValue.UNSUPPORTED_FIELD_TYPE(field.id, path[1], field.type)

--- a/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
@@ -221,7 +221,7 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set "initialValue" in field "aNumberArray" because it is not supported in array with items of type "Link".'
+            message: 'Cannot set "initialValue" in field "aNumberArray" because it is not supported by field type "Array" with items type "Link".'
           }
         ]
       ])
@@ -251,7 +251,6 @@ describe('payload validation (initial value)', function () {
     })
   })
 
-
   it('allows initial value to be set for supported field types', async function () {
     const errors = await validateBatches(function (migration) {
       const lunch = migration.createContentType('lunch').name('lunch')
@@ -259,31 +258,31 @@ describe('payload validation (initial value)', function () {
         .name('aSymbol')
         .type('Symbol')
         .initialValue({
-          'en-US': 'Valid symbol',
+          'en-US': 'Valid symbol'
         })
       lunch.createField('aNumber')
         .name('aNumber')
         .type('Number')
         .initialValue({
-          'en-US': 1234.213,
+          'en-US': 1234.213
         })
       lunch.createField('aBoolean')
         .name('aBoolean')
         .type('Boolean')
         .initialValue({
-          'en-US': true,
+          'en-US': true
         })
       lunch.createField('anInteger')
         .name('anInteger')
         .type('Integer')
         .initialValue({
-          'en-US': -20,
+          'en-US': -20
         })
       lunch.createField('aText')
         .name('aText')
         .type('Text')
         .initialValue({
-          'en-US': 'A valid Text',
+          'en-US': 'A valid Text'
         })
       lunch.createField('aDate')
         .name('aDate')
@@ -298,7 +297,7 @@ describe('payload validation (initial value)', function () {
           type: 'Symbol'
         })
         .initialValue({
-          'en-US': ['a', 'b', 'c'],
+          'en-US': ['a', 'b', 'c']
         })
     }, [], [], [], ['en-US'])
 

--- a/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-initialvalue.spec.ts
@@ -10,14 +10,14 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('mainCourse')
-        .name('mainCourse')
-        .type('Symbol')
-        .initialValue({
-          'en-US': 'A Symbol',
-          'de-DE': 'A Symbol',
-          'fr-FR': 'A Symbol'
-        })
-      }, [], [], [], [ 'en-US'])
+          .name('mainCourse')
+          .type('Symbol')
+          .initialValue({
+            'en-US': 'A Symbol',
+            'de-DE': 'A Symbol',
+            'fr-FR': 'A Symbol'
+          })
+      }, [], [], [], ['en-US'])
 
       expect(errors).to.eql([
         [
@@ -38,14 +38,14 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aSymbol')
-        .name('aSymbol')
-        .type('Symbol')
-        .initialValue({
-          'en-US': 1234,
-          'de-DE': false,
-          'fr-FR': 'A string'
-        })
-      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
+          .name('aSymbol')
+          .type('Symbol')
+          .initialValue({
+            'en-US': 1234,
+            'de-DE': false,
+            'fr-FR': 'A string'
+          })
+      }, [], [], [], ['en-US', 'de-DE', 'fr-FR'])
 
       expect(errors).to.eql([
         [
@@ -64,14 +64,14 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aNumber')
-        .name('aNumber')
-        .type('Number')
-        .initialValue({
-          'en-US': '1.234',
-          'de-DE': 'A string',
-          'fr-FR': 555
-        })
-      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
+          .name('aNumber')
+          .type('Number')
+          .initialValue({
+            'en-US': '1.234',
+            'de-DE': 'A string',
+            'fr-FR': 555
+          })
+      }, [], [], [], ['en-US', 'de-DE', 'fr-FR'])
 
       expect(errors).to.eql([
         [
@@ -90,15 +90,15 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('anInteger')
-        .name('anInteger')
-        .type('Integer')
-        .initialValue({
-          'en-US': 1.234,
-          'de-DE': 'A string',
-          'it-IT': '9999',
-          'fr-FR': 555
-        })
-      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT'])
+          .name('anInteger')
+          .type('Integer')
+          .initialValue({
+            'en-US': 1.234,
+            'de-DE': 'A string',
+            'it-IT': '9999',
+            'fr-FR': 555
+          })
+      }, [], [], [], ['en-US', 'de-DE', 'fr-FR', 'it-IT'])
 
       expect(errors).to.eql([
         [
@@ -122,15 +122,15 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aBool')
-        .name('aBool')
-        .type('Boolean')
-        .initialValue({
-          'en-US': 1,
-          'de-DE': 'A string',
-          'it-IT': true,
-          'fr-FR': false
-        })
-      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT'])
+          .name('aBool')
+          .type('Boolean')
+          .initialValue({
+            'en-US': 1,
+            'de-DE': 'A string',
+            'it-IT': true,
+            'fr-FR': false
+          })
+      }, [], [], [], ['en-US', 'de-DE', 'fr-FR', 'it-IT'])
 
       expect(errors).to.eql([
         [
@@ -150,14 +150,14 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aText')
-        .name('aText')
-        .type('Text')
-        .initialValue({
-          'en-US': 1234,
-          'de-DE': false,
-          'fr-FR': 'A string'
-        })
-      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR'])
+          .name('aText')
+          .type('Text')
+          .initialValue({
+            'en-US': 1234,
+            'de-DE': false,
+            'fr-FR': 'A string'
+          })
+      }, [], [], [], ['en-US', 'de-DE', 'fr-FR'])
 
       expect(errors).to.eql([
         [
@@ -177,16 +177,16 @@ describe('payload validation (initial value)', function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aDate')
-        .name('aDate')
-        .type('Date')
-        .initialValue({
-          'en-US': 'A string',
-          'de-DE': false,
-          'fr-FR': 1234,
-          'es-ES': '1234',
-          'it-IT': '2013-05-02T13:00:00Z'
-        })
-      }, [], [], [], [ 'en-US', 'de-DE', 'fr-FR', 'it-IT', 'es-ES'])
+          .name('aDate')
+          .type('Date')
+          .initialValue({
+            'en-US': 'A string',
+            'de-DE': false,
+            'fr-FR': 1234,
+            'es-ES': '1234',
+            'it-IT': '2013-05-02T13:00:00Z'
+          })
+      }, [], [], [], ['en-US', 'de-DE', 'fr-FR', 'it-IT', 'es-ES'])
 
       expect(errors).to.eql([
         [
@@ -201,28 +201,110 @@ describe('payload validation (initial value)', function () {
         ]
       ])
     })
-  })
 
-  describe('when setting initial value a field where is not supported', function () {
-    it('returns an error', async function () {
+    it('returns an error for Array when items are not Symbols', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
-        lunch.createField('mainCourse')
-        .name('mainCourse')
-        .type('RichText')
-        .initialValue({
-          'en-US': 'A Text'
-        })
-      }, [], [], [], [ 'en-US'])
+        lunch.createField('aNumberArray')
+          .name('aNumberArray')
+          .type('Array')
+          .items({
+            type: 'Link',
+            linkType: 'Entry'
+          })
+          .initialValue({
+            'en-US': [{}, {}]
+          })
+      }, [], [], [], ['en-US'])
 
       expect(errors).to.eql([
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set "initialValue" in field "mainCourse" because it is not supported by field type "RichText".'
+            message: 'Cannot set "initialValue" in field "aNumberArray" because it is not supported in array with items of type "Link".'
           }
         ]
       ])
     })
+
+    describe('when setting initial value a field where is not supported', function () {
+      it('returns an error', async function () {
+        const errors = await validateBatches(function (migration) {
+          const lunch = migration.createContentType('lunch').name('lunch')
+          lunch.createField('mainCourse')
+            .name('mainCourse')
+            .type('RichText')
+            .initialValue({
+              'en-US': 'A Text'
+            })
+        }, [], [], [], ['en-US'])
+
+        expect(errors).to.eql([
+          [
+            {
+              type: 'InvalidPayload',
+              message: 'Cannot set "initialValue" in field "mainCourse" because it is not supported by field type "RichText".'
+            }
+          ]
+        ])
+      })
+    })
   })
+
+
+  it('allows initial value to be set for supported field types', async function () {
+    const errors = await validateBatches(function (migration) {
+      const lunch = migration.createContentType('lunch').name('lunch')
+      lunch.createField('aSymbol')
+        .name('aSymbol')
+        .type('Symbol')
+        .initialValue({
+          'en-US': 'Valid symbol',
+        })
+      lunch.createField('aNumber')
+        .name('aNumber')
+        .type('Number')
+        .initialValue({
+          'en-US': 1234.213,
+        })
+      lunch.createField('aBoolean')
+        .name('aBoolean')
+        .type('Boolean')
+        .initialValue({
+          'en-US': true,
+        })
+      lunch.createField('anInteger')
+        .name('anInteger')
+        .type('Integer')
+        .initialValue({
+          'en-US': -20,
+        })
+      lunch.createField('aText')
+        .name('aText')
+        .type('Text')
+        .initialValue({
+          'en-US': 'A valid Text',
+        })
+      lunch.createField('aDate')
+        .name('aDate')
+        .type('Date')
+        .initialValue({
+          'en-US': '2013-05-02T13:00:00Z'
+        })
+      lunch.createField('anArray')
+        .name('anArray')
+        .type('Array')
+        .items({
+          type: 'Symbol'
+        })
+        .initialValue({
+          'en-US': ['a', 'b', 'c'],
+        })
+    }, [], [], [], ['en-US'])
+
+    expect(errors).to.eql([
+      []
+    ])
+  })
+
 })


### PR DESCRIPTION
## Summary

Update validations to allow defining `initialValue` for short text list fields. Extend tests and examples.