### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ Changes control interface of given field's ID.
 - **`ampm : string`** _(only for fields of type datePicker)_ – Specifies which type of clock to use. Must be one of the strings “12” or “24” (default).
 - **`bulkEditing : boolean`** _(only for fields of type Array)_ – Specifies whether bulk editing of linked entries is possible.
 - **`trackingFieldId : string`** _(only for fields of type slugEditor)_ – Specifies the ID of the field that will be used to generate the slug value.
+- **`showCreateEntityAction : boolean`** _(only for fields of type Link)_ - specifies whether creation of new entries from the field is enabled.
+- **`showLinkEntityAction : boolean`** _(only for fields of type Link)_ - specifies whether linking to existing entries from the field is enabled.
 
 #### `resetFieldControl (fieldId)` : void
 


### PR DESCRIPTION
This PR updates the readme regarding the `changeFieldControl` function, to include missing details about two optional settings: `showCreateEntityAction ` and `showLinkEntityAction `

<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Adds details of additional options to `changeFieldControl` function in the readme.

## Description

The following options are now documented:
showCreateEntityAction
showLinkEntityAction

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

It took me quite a while to find what these options were called so I could use them as they are currently missing from the docs, even though they work when used in migration scripts.


