### PR TITLE
Adds `table` to Rich Text node types

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -65,6 +65,7 @@ const enabledNodeTypes = validation('enabledNodeTypes', Joi.array().items(Joi.st
   'unordered-list',
   'hr',
   'blockquote',
+  'table',
   'embedded-entry-block',
   'embedded-asset-block',
   'hyperlink',

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -203,6 +203,7 @@ describe('payload validation', function () {
           .name('Chapter')
           .type('RichText')
           .validations([
+            { enabledNodeTypes: ['table'] },
             { nodes: {
               'embedded-entry-block': [{ size: { max: 4 } }],
               'embedded-entry-inline': [{ size: { max: 4 } }],


### PR DESCRIPTION
## Summary

Adds `table` validation for Rich Text node types.

## Context

When generating a migration using `contentful space generate migration` or by copying the validations form the JSON export/preview of a Rich Text field, these now include `table` as a node type.

By adding these node type, those imports are no longer failing.