### PR TITLE
Allow the migration function to be supplied directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ module.exports = function (migration, context) {
 };
 ```
 
+You can also pass the function directly. For example:
+
+```javascript
+const { runMigration } = require('contentful-migration')
+
+function migrationFunction (migration, context) {
+  const dog = migration.createContentType('dog');
+  const name = dog.createField('name');
+  name.type('Symbol').required(true);
+}
+
+const options = {
+  filePath: '', // this is required but won't be used if `migrationFunction` is supplied
+  spaceId: '<space-id>',
+  accessToken: '<access-token>',
+  migrationFunction
+}
+
+runMigration(options)
+        .then(() => console.log('Migration Done!'))
+        .catch((e) => console.error(e))
+```
+
 ## Documentation & References
 
 ### Configuration
@@ -187,6 +210,7 @@ module.exports = function (migration, context) {
 | yes               | false      | boolean | Skips any confirmation before applying the migration,script | false    |
 | requestBatchSize  | 100        | number  | Limit for every single request                              | false    |
 | headers           |            | object  | Additional headers to attach to the requests                | false    |
+| migrationFunction |            | function| Specify the migration function directly. See the [expected signature](https://github.com/contentful/contentful-migration/blob/4b9dcae0e7616da9153d0fa481871978595049e7/index.d.ts#L506). If provided, `filePath` is ignored.                | false    |
 
 ### Chaining vs Object notation
 

--- a/README.md
+++ b/README.md
@@ -186,10 +186,9 @@ function migrationFunction (migration, context) {
 }
 
 const options = {
-  filePath: '', // this is required but won't be used if `migrationFunction` is supplied
+  migrationFunction,
   spaceId: '<space-id>',
-  accessToken: '<access-token>',
-  migrationFunction
+  accessToken: '<access-token>'
 }
 
 runMigration(options)
@@ -203,14 +202,14 @@ runMigration(options)
 
 | Name              | Default    | Type    | Description                                                 | Required |
 |-------------------|------------|---------|-------------------------------------------------------------|----------|
-| filePath          |            | string  | The path to the migration file                              | true     |
+| filePath          |            | string  | The path to the migration file                              | if `migrationFunction` is not supplied     |
+| migrationFunction |            | function| Specify the migration function directly. See the [expected signature](https://github.com/contentful/contentful-migration/blob/4b9dcae0e7616da9153d0fa481871978595049e7/index.d.ts#L506).               | if `filePath` is not supplied    |
 | spaceId           |            | string  | ID of the space to run the migration script on              | true     |
 | environmentId     | `'master'` | string  | ID of the environment within the space to run the           | false    |
 | accessToken       |            | string  | The access token to use                                     | true     |
 | yes               | false      | boolean | Skips any confirmation before applying the migration,script | false    |
 | requestBatchSize  | 100        | number  | Limit for every single request                              | false    |
 | headers           |            | object  | Additional headers to attach to the requests                | false    |
-| migrationFunction |            | function| Specify the migration function directly. See the [expected signature](https://github.com/contentful/contentful-migration/blob/4b9dcae0e7616da9153d0fa481871978595049e7/index.d.ts#L506). If provided, `filePath` is ignored.                | false    |
 
 ### Chaining vs Object notation
 

--- a/examples/specify-migration-function.js
+++ b/examples/specify-migration-function.js
@@ -1,0 +1,37 @@
+const { runMigration } = require('../built/bin/cli');
+
+function migrationFunction (migration) {
+  const dog = migration.createContentType('dog', {
+    name: 'angry dog',
+    description: 'super angry'
+  });
+
+  dog.createField('woofs', {
+    name: 'woof woof',
+    type: 'Number',
+    required: true
+  });
+}
+
+async function main () {
+  let statusCode = 0;
+
+  try {
+    await runMigration({
+      migrationFunction,
+      spaceId: process.env.CONTENTFUL_SPACE_ID,
+      accessToken: process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
+      environmentId: 'master',
+      yes: true
+    });
+  } catch (e) {
+    statusCode = 1;
+    console.log('Catching Error');
+  } finally {
+    console.log('Cleaning Up');
+  }
+
+  process.exit(statusCode);
+}
+
+main();

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface RunMigrationConfig {
   proxy?: string
   rawProxy?: boolean
   yes?: boolean
+  migrationFunction?: MigrationFunction
 }
 
 export function runMigration (config: RunMigrationConfig): Promise<any>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,13 @@
 import * as axios from 'axios'
 
-export interface RunMigrationConfig {
-  filePath: string
+export type RunMigrationConfig = {
   accessToken?: string
   spaceId?: string
   environmentId?: string
   proxy?: string
   rawProxy?: boolean
   yes?: boolean
-  migrationFunction?: MigrationFunction
-}
+} & ({ filePath: string } | { migrationFunction: MigrationFunction })
 
 export function runMigration (config: RunMigrationConfig): Promise<any>
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -68,7 +68,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
   let migrationFunction
   const terminate = makeTerminatingFunction({ shouldThrow })
   try {
-    migrationFunction = require(argv.filePath)
+    migrationFunction = argv.migrationFunction || require(argv.filePath)
   } catch (e) {
     const message = chalk`{red.bold The ${argv.filePath} script could not be parsed, as it seems to contain syntax errors.}\n`
     console.error(message)
@@ -119,7 +119,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
     terminate(new ManyError('Payload Validation Errors', parseResult.payloadValidationErrors))
   }
 
-  const migrationName = path.basename(argv.filePath, '.js')
+  const migrationName = migrationFunction ? migrationFunction.name : path.basename(argv.filePath, '.js')
   const errorsFile = path.join(
     process.cwd(),
     `errors-${migrationName}-${Date.now()}.log`

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -121,7 +121,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
     terminate(new ManyError('Payload Validation Errors', parseResult.payloadValidationErrors))
   }
 
-  const migrationName = migrationFunction ? migrationFunction.name : path.basename(argv.filePath, '.js')
+  const migrationName = argv.migrationFunction ? argv.migrationFunction.name : path.basename(argv.filePath, '.js')
   const errorsFile = path.join(
     process.cwd(),
     `errors-${migrationName}-${Date.now()}.log`

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -64,18 +64,20 @@ export const createMakeRequest = (client: PlainClientAPI, { spaceId, environment
   }
 }
 
-const createRun = ({ shouldThrow }) => async function run (argv) {
-  let migrationFunction
-  const terminate = makeTerminatingFunction({ shouldThrow })
+const getMigrationFunctionFromFile = (filePath, terminate) => {
   try {
-    migrationFunction = argv.migrationFunction || require(argv.filePath)
+    return require(filePath)
   } catch (e) {
-    const message = chalk`{red.bold The ${argv.filePath} script could not be parsed, as it seems to contain syntax errors.}\n`
+    const message = chalk`{red.bold The ${filePath} script could not be parsed, as it seems to contain syntax errors.}\n`
     console.error(message)
     console.error(e)
     terminate(new Error(message))
   }
+}
 
+const createRun = ({ shouldThrow }) => async function run (argv) {
+  const terminate = makeTerminatingFunction({ shouldThrow })
+  const migrationFunction = argv.migrationFunction || getMigrationFunctionFromFile(argv.filePath, terminate)
   const application = argv.managementApplication || `contentful.migration-cli/${version}`
   const feature = argv.managementFeature || `migration-library`
 


### PR DESCRIPTION
## Summary

This Pull Request enhances the experience of using `contentful-migration` as a library, by allowing the migration function to be specified as a configuration option, rather than in a separate file.

## Description

This Pull Request:
- Adds a new configuration option `migrationFunction`, which accepts a function of type `MigrationFunction`
- Updates the expected type of the `RunMigrationConfig` to expect *either* the `filePath` *or* the `migrationFunction`
- If specified, the supplied migration function is used instead of importing the function from a file
- Documents the new configuration option
- Adds an example script to the `/examples` folder

Please note that I've changed the exported `RunMigrationConfig` from an `interface` to a `type`.

## Motivation and Context

As it stands, `contentful-migration` is available for use as a library,  but a file on disk is still required to run a migration. I've added the ability to specify a migration function directly, so that `contentful-migration` can be used with existing programmatic migration toolchains. For example, I'm busy writing a Contentful storage provider for [umzug](https://www.npmjs.com/package/umzug) (the migration tool that powers [sequelize](https://www.npmjs.com/package/sequelize)).

## Todos

-   [ ] I'd love any suggestions on how to add appropriate automated tests for this functionality. The end-to-end test suite seems to mainly test the code as a CLI and there are not currently any unit tests for the `runMigration` function.

