### PR TITLE
feat(tags): support for public tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ migration.transformEntriesToType({
 
 For the complete version of this migration, please refer to [this example](./examples/22-transform-entries-to-type.js).
 
-#### `createTag(id[, opts])`
+#### `createTag(id[, opts, visibility])`
 
 Creates a tag with provided `id` and returns a reference to the newly created tag.
 

--- a/README.md
+++ b/README.md
@@ -402,11 +402,13 @@ For the complete version of this migration, please refer to [this example](./exa
 
 Creates a tag with provided `id` and returns a reference to the newly created tag.
 
-**`id : string`** – The ID of the tag.
+- **`id : string`** – The ID of the tag.
 
-**`opts : Object`** – Tag definition, with the following options:
+- **`opts : Object`** – Tag definition, with the following options:
 
-- **`name : string`** – Name of the tag.
+  - **`name : string`** – Name of the tag.
+
+- **`visibility : 'private' | 'public'`** Tag visibility - defaults to `private`.
 
 #### `editTag(id[, opts])`
 

--- a/examples/32-create-public-tag.js
+++ b/examples/32-create-public-tag.js
@@ -1,0 +1,5 @@
+module.exports = function (migration) {
+  migration.createTag('publicsampletag', {
+    name: 'public-marketing'
+  }, 'public');
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -355,6 +355,7 @@ export interface IDeriveLinkedEntriesConfig {
   deriveEntryForLocale: (inputFields: ContentFields, locale: string) => { [field: string]: any }
 }
 
+type TagVisibility = 'private' | 'public'
 export interface ITag {
   id: string
   instanceId: string
@@ -457,8 +458,9 @@ export default interface Migration {
    *
    * @param id string – The ID of the tag.
    * @param init Object – Tag definition
+   * @param tagVisibility string - Whether the tag should be public or private
    */
-  createTag (id: string, init?: ITagOptions): ITag
+  createTag (id: string, init?: ITagOptions, tagVisibility?: TagVisibility): ITag
 
   /**
    * Edits an existing tag of provided id and returns a reference to the tag. Uses the same options as createTag.

--- a/src/lib/action/tag-create.ts
+++ b/src/lib/action/tag-create.ts
@@ -1,12 +1,15 @@
+import { TagVisibility } from '../interfaces/api-tag'
 import { APIAction, EntityType } from './action'
 import OfflineAPI from '../offline-api/index'
 
 class TagCreateAction extends APIAction {
   private tagId: string
+  private tagVisibility: TagVisibility
 
-  constructor (tagId: string) {
+  constructor (tagId: string, tagVisibility: TagVisibility = 'private') {
     super()
     this.tagId = tagId
+    this.tagVisibility = tagVisibility
   }
 
   getEntityId (): string {
@@ -18,7 +21,7 @@ class TagCreateAction extends APIAction {
   }
 
   async applyTo (api: OfflineAPI) {
-    await api.createTag(this.tagId)
+    await api.createTag(this.tagId, this.tagVisibility)
   }
 }
 

--- a/src/lib/entities/tag.ts
+++ b/src/lib/entities/tag.ts
@@ -1,14 +1,16 @@
-import APITag from '../interfaces/api-tag'
+import APITag, { TagVisibility } from '../interfaces/api-tag'
 
 class Tag {
   private _id: string
   private _name: string
   private _version: number
+  private _visibility: TagVisibility
 
   constructor (tag: APITag) {
     this._id = tag.sys.id
     this._version = tag.sys.version
     this._name = tag.name
+    this._visibility = tag.sys.visibility || 'private'
   }
 
   get id () {
@@ -31,10 +33,19 @@ class Tag {
     this._name = name
   }
 
+  get visibility () {
+    return this._visibility || 'private'
+  }
+
+  set visibility (visibility: TagVisibility) {
+    this._visibility = visibility
+  }
+
   toApiTag (): APITag {
     const sys = {
       id: this.id,
-      version: this.version
+      version: this.version,
+      visibility: this.visibility
     }
     return {
       sys,
@@ -48,6 +59,6 @@ class Tag {
 }
 
 export {
-  Tag as default,
-  Tag
+    Tag as default,
+    Tag
 }

--- a/src/lib/intent/tag-create.ts
+++ b/src/lib/intent/tag-create.ts
@@ -1,3 +1,4 @@
+import { TagVisibility } from '../interfaces/api-tag'
 import Intent from './base-intent'
 import { TagCreateAction } from '../action/tag-create'
 import chalk from 'chalk'
@@ -10,6 +11,10 @@ export default class TagCreateIntent extends Intent {
 
   getTagId (): string {
     return this.payload.tagId
+  }
+
+  getTagVisibility (): TagVisibility {
+    return this.payload.tagVisibility
   }
 
   isTagCreate (): boolean {
@@ -34,13 +39,13 @@ export default class TagCreateIntent extends Intent {
 
   toActions () {
     return [
-      new TagCreateAction(this.getTagId())
+      new TagCreateAction(this.getTagId(), this.getTagVisibility())
     ]
   }
 
   toPlanMessage (): PlanMessage {
     return {
-      heading: chalk`Create Tag {bold.yellow ${this.getTagId()}}`,
+      heading: chalk`Create Tag {bold.yellow ${this.getTagId()}} with visibility: "${this.getTagVisibility()}"`,
       details: [],
       sections: []
     }

--- a/src/lib/interfaces/api-tag.ts
+++ b/src/lib/interfaces/api-tag.ts
@@ -1,7 +1,10 @@
+export type TagVisibility = 'private' | 'public'
+
 export default interface APITag {
   sys: {
     id: string,
-    version: number
+    version: number,
+    visibility: TagVisibility
   }
   name: string
 }

--- a/src/lib/interfaces/raw-step.ts
+++ b/src/lib/interfaces/raw-step.ts
@@ -1,3 +1,4 @@
+import { TagVisibility } from './api-tag'
 import ContentTransform from './content-transform'
 import EntryDerive from './entry-derive'
 import EntrySetTags from './entry-set-tags'
@@ -44,6 +45,7 @@ interface RawStepPayload {
   entryEditor?: EntryEditorInfo
   entryEditors?: EntryEditor[]
   tagId?: string
+  tagVisibility?: TagVisibility
   entryTransformationForTags?: EntrySetTags
 }
 

--- a/src/lib/migration-steps/action-creators.ts
+++ b/src/lib/migration-steps/action-creators.ts
@@ -1,4 +1,5 @@
 import * as Intents from '../intent/index'
+import { TagVisibility } from '../interfaces/api-tag'
 import ContentTransform from '../interfaces/content-transform'
 import EntryDerive from '../interfaces/entry-derive'
 import EntrySetTags from '../interfaces/entry-set-tags'
@@ -356,7 +357,7 @@ const actionCreators = {
     })
   },
   tag: {
-    create: (id, instanceId, callsite): Intents.TagCreate => {
+    create: (id, instanceId, callsite, visibility: TagVisibility = 'private'): Intents.TagCreate => {
       return new Intents.TagCreate({
         type: 'tag/create',
         meta: {
@@ -366,7 +367,7 @@ const actionCreators = {
             line: callsite.getLineNumber()
           }
         },
-        payload: { tagId: id }
+        payload: { tagId: id, tagVisibility: visibility }
       })
     },
     update: (id, instanceId, callsite, property, value): Intents.TagUpdate => {

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import Bluebird from 'bluebird'
+import { TagVisibility } from '../interfaces/api-tag'
 import actionCreators from './action-creators'
 import getFirstExternalCaller from './first-external-caller'
 import Intent from '../intent'
@@ -364,11 +365,11 @@ export async function migration (migrationCreator: Function, makeRequest: Functi
       dispatch(actionCreators.contentType.transformEntriesToType(instanceId, stripped, callsite))
     },
 
-    createTag: function (id, init) {
+    createTag: function (id, init, visibility: TagVisibility = 'private') {
       const callsite = getFirstExternalCaller()
       const instanceId = instanceIdManager.getNew(id)
 
-      dispatch(actionCreators.tag.create(id, instanceId, callsite))
+      dispatch(actionCreators.tag.create(id, instanceId, callsite, visibility))
 
       return new Tag(id, instanceId, init, dispatch)
     },

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -14,7 +14,7 @@ import TypeChangeValidator from './validator/type-change'
 import TagsOnEntryValidator from './validator/tags-on-entry'
 import { Intent } from '../interfaces/intent'
 import APIEntry from '../interfaces/api-entry'
-import APITag from '../interfaces/api-tag'
+import APITag, { TagVisibility } from '../interfaces/api-tag'
 import Link from '../entities/link'
 
 interface RequestBatch {
@@ -544,13 +544,14 @@ class OfflineAPI {
     return this.requestBatches
   }
 
-  async createTag (id: string): Promise<Tag> {
+  async createTag (id: string, visibility: TagVisibility = 'private'): Promise<Tag> {
     this.assertRecording()
 
     const tagData: APITag = {
       sys: {
         id,
-        version: 0
+        version: 0,
+        visibility
       },
       name: undefined
     }

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -605,7 +605,7 @@ describe('the migration', function () {
     ]);
   }));
 
-  it('creates a tag private tag by default', async function () {
+  it('creates a private tag by default', async function () {
     await migrator(createTag);
 
     const tag = await request({

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -18,6 +18,7 @@ const changeEditorInterfaceWithExistingContentTypeAddingHelpText = require('../.
 const addSidebarWidgets = require('../../examples/24-add-sidebar-widgets-to-new-content-type');
 const addSidebarWidgetsToExisting = require('../../examples/27-add-sidebar-widgets-to-existing-content-type');
 const createTag = require('../../examples/28-create-tag');
+const createPublicTag = require('../../examples/32-create-public-tag');
 const modifyTag = require('../../examples/29-modify-tag');
 const deleteTag = require('../../examples/30-delete-tag');
 const setTagsForEntries = require('../../examples/31-set-tags-for-entries');
@@ -604,7 +605,7 @@ describe('the migration', function () {
     ]);
   }));
 
-  it('creates a tag', async function () {
+  it('creates a tag private tag by default', async function () {
     await migrator(createTag);
 
     const tag = await request({
@@ -613,6 +614,20 @@ describe('the migration', function () {
     });
     expect(tag.name).to.eql('marketing');
     expect(tag.sys.id).to.eql('sampletag');
+    expect(tag.sys.visibility).to.eql('private');
+  });
+
+  it('creates a public tag', async function () {
+    await migrator(createPublicTag);
+
+    const tag = await request({
+      method: 'GET',
+      url: '/tags/publicsampletag'
+    });
+
+    expect(tag.name).to.eql('public-marketing');
+    expect(tag.sys.id).to.eql('publicsampletag');
+    expect(tag.sys.visibility).to.eql('public');
   });
 
   it('modifies the name of an existing tag', async function () {

--- a/test/unit/lib/intent/composed-intent.spec.ts
+++ b/test/unit/lib/intent/composed-intent.spec.ts
@@ -84,7 +84,7 @@ describe('ComposedIntent', function () {
       const message: PlanMessage = intent.toPlanMessage()
 
       expect(message).to.eql({
-        heading: chalk`Create Tag {bold.yellow test}`,
+        heading: chalk`Create Tag {bold.yellow test} with visibility: "private"`,
         details: [
           chalk`{italic name}: "Test Tag"`
         ],

--- a/test/unit/lib/migration-chunks/validation/tag.spec.js
+++ b/test/unit/lib/migration-chunks/validation/tag.spec.js
@@ -25,7 +25,8 @@ describe('tag plan validation', function () {
                 'tagInstanceId': 'tag/person/1'
               },
               'payload': {
-                'tagId': 'person'
+                'tagId': 'person',
+                'tagVisibility': 'private'
               }
             }
           }
@@ -106,7 +107,8 @@ describe('tag plan validation', function () {
                 'tagInstanceId': 'tag/person/1'
               },
               'payload': {
-                'tagId': 'person'
+                'tagId': 'person',
+                'tagVisibility': 'private'
               }
             }
           }
@@ -140,7 +142,8 @@ describe('tag plan validation', function () {
                 'tagInstanceId': 'tag/person/0'
               },
               'payload': {
-                'tagId': 'person'
+                'tagId': 'person',
+                'tagVisibility': 'private'
               }
             }
           }

--- a/test/unit/lib/migration-steps/migration-steps.spec.js
+++ b/test/unit/lib/migration-steps/migration-steps.spec.js
@@ -165,7 +165,8 @@ describe('migration-steps', function () {
             'tagInstanceId': 'tag/newTag/0'
           },
           'payload': {
-            'tagId': 'newTag'
+            'tagId': 'newTag',
+            'tagVisibility': 'private'
           }
         },
         {


### PR DESCRIPTION
## Summary

Introduce Tag `visibility` for `createTag`

In your migration script, you will be able to get a tag's visibility by calling the getter `visibility`. 
If not explicitly set a tag's visibility will be `private`.

 


