### PR TITLE
fix: rename initial value default value

### DIFF
--- a/examples/32-create-fields-with-default-values.js
+++ b/examples/32-create-fields-with-default-values.js
@@ -1,20 +1,20 @@
-// Initial value example: create a new content with some initial values
+// Default value example: create a new content with some default values
 module.exports = function (migration) {
   const Event = migration.createContentType('event').name('Event');
   Event.createField('title')
     .name('Title')
     .localized(true)
     .type('Symbol')
-    .initialValue({
-      'en-US': 'Initial title',
-      'fr-FR': 'Titre initial'
+    .defaultValue({
+      'en-US': 'Default title',
+      'fr-FR': 'Titre par défaut'
     });
 
   Event.createField('advertised')
     .name('Advertised')
     .type('Boolean')
     .localized(false)
-    .initialValue({
+    .defaultValue({
       'en-US': true
     });
 
@@ -22,7 +22,7 @@ module.exports = function (migration) {
     .name('Start Date')
     .type('Date')
     .localized(false)
-    .initialValue({
+    .defaultValue({
       'en-US': '2021-06-15T13:46:06Z'
     });
 
@@ -33,7 +33,7 @@ module.exports = function (migration) {
       type: 'Symbol'
     })
     .localized(false)
-    .initialValue({
+    .defaultValue({
       'en-US': ['Culture', 'Local History']
     });
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,9 @@ export interface IFieldOptions {
   omitted?: boolean
   /** Sets the field as deleted. Requires to have been omitted first. You may prefer using the deleteField method. */
   deleted?: boolean
+
+  /** Sets the default value for the field. */
+  defaultValue?: { [locale: string]: any }
 }
 
 export interface Field {
@@ -75,6 +78,8 @@ export interface Field {
   /** Sets the field as deleted. Requires to have been omitted first. You may prefer using the deleteField method. */
   deleted(deleted: boolean): Field
 
+  /** Sets the default value for the field. */
+  defaultValue(defaultValue: { [locale: string]: any }): Field
 }
 
 type LinkMimetype = 'attachment' | 'plaintext' | 'image' | 'audio' | 'video' | 'richtext' |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "contentful-management": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.24.0.tgz",
-      "integrity": "sha512-Uo6SZ2q5PqrOSwFWX609/Dy1xfpwTJ0uOw4GuohIeo+MgJJqEwJcZ+K4H7/ie3QievZ1V7dm/f5AyyCalTCtgA==",
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.32.1.tgz",
+      "integrity": "sha512-h45bwyI1Zv6ZCJCtkeo/xtNJNK9LU4s6DqudqQC/FWUH6+op59xxZ4V+KWaCJ14nR8Rh+hcwXIHzF4VNhGSEmg==",
       "requires": {
         "@types/json-patch": "0.0.30",
         "axios": "^0.21.0",
@@ -10514,9 +10514,9 @@
       },
       "dependencies": {
         "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",
     "chalk": "^4.0.0",
-    "contentful-management": "^7.3.1",
+    "contentful-management": "^7.32.1",
     "didyoumean2": "^5.0.0",
     "hoek": "^6.1.3",
     "https-proxy-agent": "^5.0.0",

--- a/src/lib/intent-validator/field-update.ts
+++ b/src/lib/intent-validator/field-update.ts
@@ -18,7 +18,7 @@ class FieldUpdateStepValidator extends SchemaValidator {
       localized: Joi.boolean().required().strict(),
       required: Joi.boolean().required().strict(),
       validations: Joi.array().required(),
-      initialValue: Joi.object().required().strict(),
+      defaultValue: Joi.object().required().strict(),
       disabled: Joi.boolean().required().strict(),
       omitted: Joi.boolean().required().strict(),
       deleted: Joi.boolean().required().strict(),

--- a/src/lib/interfaces/content-type.ts
+++ b/src/lib/interfaces/content-type.ts
@@ -15,6 +15,7 @@ interface Field {
   required?: boolean
   validations?: any[]
   disabled?: boolean
+  defaultValue?: { [locale: string]: any }
 }
 
 interface APIContentType {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -65,15 +65,15 @@ const errors = {
         return `"${propName}" validation expected to be "${expectedType}", but got "${actualType}"`
       }
     },
-    initialValue: {
+    defaultValue: {
       TYPE_MISMATCH: (fieldId, valueType, locale, fieldType) => {
-        return `Cannot set initial value of type "${valueType}" for locale "${locale}" on field "${fieldId}". The initial value must match the field type "${fieldType}".`
+        return `Cannot set default value of type "${valueType}" for locale "${locale}" on field "${fieldId}". The default value must match the field type "${fieldType}".`
       },
       DATE_TYPE_MISMATCH: (fieldId, valueType, value, locale, fieldType) => {
-        return `Cannot set initial value of type "${valueType}" to "${value}" for locale "${locale}" on field "${fieldId}". The initial value must match the field type "${fieldType}" using a valid ISO date.`
+        return `Cannot set default value of type "${valueType}" to "${value}" for locale "${locale}" on field "${fieldId}". The default value must match the field type "${fieldType}" using a valid ISO date.`
       },
       INVALID_LOCALE: (fieldId, locale) => {
-        return `Cannot set initial value for locale "${locale}" on field "${fieldId}". The locale does not exist.`
+        return `Cannot set default value for locale "${locale}" on field "${fieldId}". The locale does not exist.`
       },
 
       UNSUPPORTED_FIELD_TYPE: (fieldId, key, fieldType) => {

--- a/src/lib/offline-api/validator/schema/fields-schema.ts
+++ b/src/lib/offline-api/validator/schema/fields-schema.ts
@@ -38,7 +38,7 @@ export function createFieldsSchema (locales: string[]) {
     localized: Joi.boolean(),
     required: Joi.boolean(),
     validations: Joi.array().unique().items(getFieldValidations()),
-    initialValue: Joi.object().strict().pattern(Joi.valid(...locales), Joi.when(
+    defaultValue: Joi.object().strict().pattern(Joi.valid(...locales), Joi.when(
       Joi.ref('...type'),
       {
         otherwise: Joi.forbidden(),

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -178,12 +178,12 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
     const [index, ...fieldNames] = path
     const prop = fieldNames.join('.')
     const field = fields[index]
-    if (prop.startsWith('initialValue')) {
+    if (prop.startsWith('defaultValue')) {
 
       if (type === 'object.unknown') {
         return {
           type: 'InvalidPayload',
-          message: errorMessages.field.initialValue.INVALID_LOCALE(field.id, context.key)
+          message: errorMessages.field.defaultValue.INVALID_LOCALE(field.id, context.key)
         }
       }
 
@@ -192,24 +192,24 @@ const validateFields = function (contentType: ContentType, locales: string[]): P
         if (field.type === 'Array') {
           return {
             type: 'InvalidPayload',
-            message: errorMessages.field.initialValue.UNSUPPORTED_ARRAY_ITEMS_TYPE(field.id, path[1], field.items.type)
+            message: errorMessages.field.defaultValue.UNSUPPORTED_ARRAY_ITEMS_TYPE(field.id, path[1], field.items.type)
           }
         }
         return {
           type: 'InvalidPayload',
-          message: errorMessages.field.initialValue.UNSUPPORTED_FIELD_TYPE(field.id, path[1], field.type)
+          message: errorMessages.field.defaultValue.UNSUPPORTED_FIELD_TYPE(field.id, path[1], field.type)
         }
       }
 
       if (field.type === 'Date') {
         return {
           type: 'InvalidPayload',
-          message: errorMessages.field.initialValue.DATE_TYPE_MISMATCH(field.id, kindOf(context.value), context.value, context.key, field.type)
+          message: errorMessages.field.defaultValue.DATE_TYPE_MISMATCH(field.id, kindOf(context.value), context.value, context.key, field.type)
         }
       }
       return {
         type: 'InvalidPayload',
-        message: errorMessages.field.initialValue.TYPE_MISMATCH(field.id, kindOf(context.value), context.key, field.type)
+        message: errorMessages.field.defaultValue.TYPE_MISMATCH(field.id, kindOf(context.value), context.key, field.type)
       }
     }
 

--- a/test/unit/lib/offline-api/validation/payload-validation-field-defaultvalue.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-defaultvalue.spec.ts
@@ -3,16 +3,16 @@
 import { expect } from 'chai'
 import validateBatches from './validate-batches'
 
-describe('payload validation (initial value)', function () {
+describe('payload validation (default value)', function () {
 
-  describe('when setting initial value for non existing locales', function () {
+  describe('when setting default value for non existing locales', function () {
     it('returns an error', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('mainCourse')
           .name('mainCourse')
           .type('Symbol')
-          .initialValue({
+          .defaultValue({
             'en-US': 'A Symbol',
             'de-DE': 'A Symbol',
             'fr-FR': 'A Symbol'
@@ -23,24 +23,24 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value for locale "de-DE" on field "mainCourse". The locale does not exist.'
+            message: 'Cannot set default value for locale "de-DE" on field "mainCourse". The locale does not exist.'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value for locale "fr-FR" on field "mainCourse". The locale does not exist.'
+            message: 'Cannot set default value for locale "fr-FR" on field "mainCourse". The locale does not exist.'
           }
         ]
       ])
     })
   })
-  describe('when initial value does not match the field type', function () {
+  describe('when default value does not match the field type', function () {
     it('returns an error for Symbol', async function () {
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('lunch')
         lunch.createField('aSymbol')
           .name('aSymbol')
           .type('Symbol')
-          .initialValue({
+          .defaultValue({
             'en-US': 1234,
             'de-DE': false,
             'fr-FR': 'A string'
@@ -51,11 +51,11 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "number" for locale "en-US" on field "aSymbol". The initial value must match the field type "Symbol".'
+            message: 'Cannot set default value of type "number" for locale "en-US" on field "aSymbol". The default value must match the field type "Symbol".'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "aSymbol". The initial value must match the field type "Symbol".'
+            message: 'Cannot set default value of type "boolean" for locale "de-DE" on field "aSymbol". The default value must match the field type "Symbol".'
           }
         ]
       ])
@@ -66,7 +66,7 @@ describe('payload validation (initial value)', function () {
         lunch.createField('aNumber')
           .name('aNumber')
           .type('Number')
-          .initialValue({
+          .defaultValue({
             'en-US': '1.234',
             'de-DE': 'A string',
             'fr-FR': 555
@@ -77,11 +77,11 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "string" for locale "en-US" on field "aNumber". The initial value must match the field type "Number".'
+            message: 'Cannot set default value of type "string" for locale "en-US" on field "aNumber". The default value must match the field type "Number".'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "string" for locale "de-DE" on field "aNumber". The initial value must match the field type "Number".'
+            message: 'Cannot set default value of type "string" for locale "de-DE" on field "aNumber". The default value must match the field type "Number".'
           }
         ]
       ])
@@ -92,7 +92,7 @@ describe('payload validation (initial value)', function () {
         lunch.createField('anInteger')
           .name('anInteger')
           .type('Integer')
-          .initialValue({
+          .defaultValue({
             'en-US': 1.234,
             'de-DE': 'A string',
             'it-IT': '9999',
@@ -104,15 +104,15 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "number" for locale "en-US" on field "anInteger". The initial value must match the field type "Integer".'
+            message: 'Cannot set default value of type "number" for locale "en-US" on field "anInteger". The default value must match the field type "Integer".'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "string" for locale "de-DE" on field "anInteger". The initial value must match the field type "Integer".'
+            message: 'Cannot set default value of type "string" for locale "de-DE" on field "anInteger". The default value must match the field type "Integer".'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "string" for locale "it-IT" on field "anInteger". The initial value must match the field type "Integer".'
+            message: 'Cannot set default value of type "string" for locale "it-IT" on field "anInteger". The default value must match the field type "Integer".'
           }
         ]
       ])
@@ -124,7 +124,7 @@ describe('payload validation (initial value)', function () {
         lunch.createField('aBool')
           .name('aBool')
           .type('Boolean')
-          .initialValue({
+          .defaultValue({
             'en-US': 1,
             'de-DE': 'A string',
             'it-IT': true,
@@ -136,11 +136,11 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "number" for locale "en-US" on field "aBool". The initial value must match the field type "Boolean".'
+            message: 'Cannot set default value of type "number" for locale "en-US" on field "aBool". The default value must match the field type "Boolean".'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "string" for locale "de-DE" on field "aBool". The initial value must match the field type "Boolean".'
+            message: 'Cannot set default value of type "string" for locale "de-DE" on field "aBool". The default value must match the field type "Boolean".'
           }
         ]
       ])
@@ -152,7 +152,7 @@ describe('payload validation (initial value)', function () {
         lunch.createField('aText')
           .name('aText')
           .type('Text')
-          .initialValue({
+          .defaultValue({
             'en-US': 1234,
             'de-DE': false,
             'fr-FR': 'A string'
@@ -163,11 +163,11 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "number" for locale "en-US" on field "aText". The initial value must match the field type "Text".'
+            message: 'Cannot set default value of type "number" for locale "en-US" on field "aText". The default value must match the field type "Text".'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "boolean" for locale "de-DE" on field "aText". The initial value must match the field type "Text".'
+            message: 'Cannot set default value of type "boolean" for locale "de-DE" on field "aText". The default value must match the field type "Text".'
           }
         ]
       ])
@@ -179,7 +179,7 @@ describe('payload validation (initial value)', function () {
         lunch.createField('aDate')
           .name('aDate')
           .type('Date')
-          .initialValue({
+          .defaultValue({
             'en-US': 'A string',
             'de-DE': false,
             'fr-FR': 1234,
@@ -192,11 +192,11 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "string" to "A string" for locale "en-US" on field "aDate". The initial value must match the field type "Date" using a valid ISO date.'
+            message: 'Cannot set default value of type "string" to "A string" for locale "en-US" on field "aDate". The default value must match the field type "Date" using a valid ISO date.'
           },
           {
             type: 'InvalidPayload',
-            message: 'Cannot set initial value of type "boolean" to "false" for locale "de-DE" on field "aDate". The initial value must match the field type "Date" using a valid ISO date.'
+            message: 'Cannot set default value of type "boolean" to "false" for locale "de-DE" on field "aDate". The default value must match the field type "Date" using a valid ISO date.'
           }
         ]
       ])
@@ -212,7 +212,7 @@ describe('payload validation (initial value)', function () {
             type: 'Link',
             linkType: 'Entry'
           })
-          .initialValue({
+          .defaultValue({
             'en-US': [{}, {}]
           })
       }, [], [], [], ['en-US'])
@@ -221,20 +221,20 @@ describe('payload validation (initial value)', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Cannot set "initialValue" in field "aNumberArray" because it is not supported by field type "Array" with items type "Link".'
+            message: 'Cannot set "defaultValue" in field "aNumberArray" because it is not supported by field type "Array" with items type "Link".'
           }
         ]
       ])
     })
 
-    describe('when setting initial value a field where is not supported', function () {
+    describe('when setting default value a field where is not supported', function () {
       it('returns an error', async function () {
         const errors = await validateBatches(function (migration) {
           const lunch = migration.createContentType('lunch').name('lunch')
           lunch.createField('mainCourse')
             .name('mainCourse')
             .type('RichText')
-            .initialValue({
+            .defaultValue({
               'en-US': 'A Text'
             })
         }, [], [], [], ['en-US'])
@@ -243,7 +243,7 @@ describe('payload validation (initial value)', function () {
           [
             {
               type: 'InvalidPayload',
-              message: 'Cannot set "initialValue" in field "mainCourse" because it is not supported by field type "RichText".'
+              message: 'Cannot set "defaultValue" in field "mainCourse" because it is not supported by field type "RichText".'
             }
           ]
         ])
@@ -251,43 +251,43 @@ describe('payload validation (initial value)', function () {
     })
   })
 
-  it('allows initial value to be set for supported field types', async function () {
+  it('allows default value to be set for supported field types', async function () {
     const errors = await validateBatches(function (migration) {
       const lunch = migration.createContentType('lunch').name('lunch')
       lunch.createField('aSymbol')
         .name('aSymbol')
         .type('Symbol')
-        .initialValue({
+        .defaultValue({
           'en-US': 'Valid symbol'
         })
       lunch.createField('aNumber')
         .name('aNumber')
         .type('Number')
-        .initialValue({
+        .defaultValue({
           'en-US': 1234.213
         })
       lunch.createField('aBoolean')
         .name('aBoolean')
         .type('Boolean')
-        .initialValue({
+        .defaultValue({
           'en-US': true
         })
       lunch.createField('anInteger')
         .name('anInteger')
         .type('Integer')
-        .initialValue({
+        .defaultValue({
           'en-US': -20
         })
       lunch.createField('aText')
         .name('aText')
         .type('Text')
-        .initialValue({
+        .defaultValue({
           'en-US': 'A valid Text'
         })
       lunch.createField('aDate')
         .name('aDate')
         .type('Date')
-        .initialValue({
+        .defaultValue({
           'en-US': '2013-05-02T13:00:00Z'
         })
       lunch.createField('anArray')
@@ -296,7 +296,7 @@ describe('payload validation (initial value)', function () {
         .items({
           type: 'Symbol'
         })
-        .initialValue({
+        .defaultValue({
           'en-US': ['a', 'b', 'c']
         })
     }, [], [], [], ['en-US'])


### PR DESCRIPTION
## Summary

Rename `initialValue` for content type fields `defaultValue`.

## Motivation and Context

The feature was renamed so we’re renaming the property as well.