### PR TITLE
Terminate with an error when a migration is aborted

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -225,6 +225,7 @@ const createRun = ({ shouldThrow }) => async function run (argv) {
     }
   } else {
     console.warn(chalk`⚠️  {bold.yellow Migration aborted}`)
+    terminate(new Error('Migration aborted'))
   }
 }
 


### PR DESCRIPTION
## Summary



## Description

This Pull Request changes the behaviour when you select `N` (No) when the script prompts you whether you want to apply a migration.

Previous behaviour:
- Log warning
- Exit with 0 exit code

New behaviour:
- Log warning
- Exit with a non-zero exit code / throw error, depending on how `terminate` has been configured.

I'll leave it to your discretion, but this is likely a breaking change and would require releasing a new major semver version.

## Motivation and Context

I'm plugging `contentful-migration` into our CLI-based migration tooling (using [umzug](https://github.com/sequelize/umzug)), so it's nice if aborting the migration prevents subsequent commands from running.  The current behaviour is particularly problematic when using an external migration tool, because it will interpret the run as a success and will therefore consider the migration as applied, even though it hasn't been.

A workaround would be to force the script not to prompt, using the `yes` option. I quite like the nice feedback the `contentful-migration` library gives you before applying a change, though, so it would be a shame to lose that. (Especially when testing migrations locally against a test environment.)

## Screenshots:

### Before:

<img width="938" alt="131104157-4554efea-0fb0-4536-b77e-d861ebe51d4a" src="https://user-images.githubusercontent.com/2362668/131105569-b6ef0fe3-cc3c-459c-8ec2-7eb2fbb9854e.png">

### After:

<img width="948" alt="131104809-2769fffb-79a8-4184-acbd-9ca1dbb21ba3" src="https://user-images.githubusercontent.com/2362668/131105582-f9013d66-2eba-45da-b82c-8f4fd7706850.png">

