### PR TITLE
chore(types): add type guard

### DIFF
--- a/src/bin/usage-params.ts
+++ b/src/bin/usage-params.ts
@@ -8,7 +8,7 @@ export default yargs
   .usage('Parses and runs a migration script on a Contentful space.\n\nUsage: contentful-migration [args] <path-to-script-file>\n\nScript: path to a migration script.')
   .demandCommand(1, 'Please provide the file containing the migration script.')
   .check((args) => {
-    const filePath = path.resolve(process.cwd(), args._[0])
+    const filePath = path.resolve(process.cwd(), args._[0].toString())
     if (fs.existsSync(filePath)) {
       args.filePath = filePath
       return true


### PR DESCRIPTION
Add typeguard to fix typescript error which is triggered on test runs:

```

src/bin/usage-params.ts:11:50 - error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.

11     const filePath = path.resolve(process.cwd(), args._[0])
                                                    ~~~~~~~~~
```
