### PR TITLE
docs: Add "app" to changeFieldControl's widget namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,7 @@ Changes control interface of given field's ID.
 **`widgetNamespace : string`** – The namespace of the widget, one of the following values:
 - `builtin` (Standard widget)
 - `extension` (Custom UI extension)
+- `app` (Custom app widget)
 
 **`widgetId : string`** – The new widget ID for the field. See the [editor interface documentation](https://www.contentful.com/developers/docs/concepts/editor-interfaces/) for a list of available widgets.
 


### PR DESCRIPTION
## Summary

Add the `'app'` option to the possible widget namespaces of `changeFieldControl`.

## Description

As you can see [here](https://github.com/contentful/contentful-migration/blob/e7a2f95c0cb225e92ecfb19a50e7dcf8de8f172e/index.d.ts#L186), `changeFieldControl` supports `'app'` as a possible value of the `widgetNamespace` param.
So this PR documents that.
