### PR TITLE
feat(types): adds prohibitRegex to IValidation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,6 +97,8 @@ export interface IValidation {
   range?: { max?: number, min?: number},
   /** Takes a string that reflects a JS regex and flags, validates against a string. See JS reference for the parameters. */
   regexp?: { pattern: string, flags?: string },
+  /** Inverse of `regexp`: Takes a string that reflects a JS regex and flags, validates against a string and expects to not match. */
+  prohibitRegexp?: { pattern: string, flags?: string },
   /** Validates that there are no other entries that have the same field value at the time of publication. */
   unique?: true,
   /** Validates that a value falls within a certain range of dates. */


### PR DESCRIPTION
## Summary

Adds the `prohibitRegexp` validation to `IValidation`.

## Description

`prohibitRegexp` is defined [here](https://www.contentful.com/developers/docs/references/content-management-api/#validations). There are already tests covering it, like the [validator schema](https://github.com/contentful/contentful-migration/blob/212a7ebfa2ada649bf7add896c2739e1c59e54d3/src/lib/offline-api/validator/schema/field-validations-schema.ts#L31-L34), but its type definition was missing.

## Motivation and Context

Type definitions help a lot when creating migrations. It helps to avoid silly mistakes, as misspelling or similar when editing/creating a migration. Going back and forth to the docs can also be avoided in some cases (as all other validations).

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1734873/135823333-c0455126-3e2d-4e1e-aceb-75ccda95b510.png)