### PR TITLE
fix(config): Fix missing uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "kind-of": "^6.0.3",
         "listr": "^0.14.3",
         "lodash": "^4.17.15",
+        "uuid": "^8.3.2",
         "yargs": "^15.3.1"
       },
       "bin": {
@@ -66,7 +67,6 @@
         "tslint": "^6.1.1",
         "tslint-config-standard": "^9.0.0",
         "typescript": "^3.8.3",
-        "uuid": "^8.3.2",
         "zlib": "^1.0.5"
       },
       "engines": {
@@ -15272,7 +15272,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -27438,8 +27437,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "kind-of": "^6.0.3",
     "listr": "^0.14.3",
     "lodash": "^4.17.15",
+    "uuid": "^8.3.2",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
@@ -103,7 +104,6 @@
     "tslint": "^6.1.1",
     "tslint-config-standard": "^9.0.0",
     "typescript": "^3.8.3",
-    "uuid": "^8.3.2",
     "zlib": "^1.0.5"
   },
   "bin": {


### PR DESCRIPTION
## Summary

This PR is fixing the issue `Cannot find module 'uuid'` that occurs when you try to install and use the latest version `v4.6.0`

closes #984