### PR TITLE
feat: validate editor layout [DANTE-407]

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,16 +785,10 @@ Moves the field with the provided `id`.
 Creates a tab with the provided `id`.
 
 **`id : string`** – The ID of the group.
-**`widgetNamespace : string`** – The widget namespace of the group.
-**`widgetId : string`** – The widget ID of the group.
 
 **`opts : Object`** – Group settings, with the following options:
 
-- **`name : string`** _(required)_ – Field set name.
-
-**`settings : Object`** – Group settings, with the following properties:
-
-- **`helpText : string`** – Help text for the tab. Displayed when editing.
+- **`name : string`** _(required)_ – Group name.
 
 #### `deleteFieldGroup (id)` : void
 
@@ -815,13 +809,13 @@ Changes the group’s ID.
 
 #### `createFieldGroup (id[, opts])` : [EditorLayoutFieldGroup](#editor-layout-field-group)
 
-Creates a field set with the provided `id`. Returns the created
+Creates a field set with the provided `id`.
 
 **`id : string`** – The ID of the group.
 
 **`opts : Object`** – Group settings, with the following options:
 
-- **`name : string`** _(required)_ – Field set name.
+- **`name : string`** _(required)_ – Group name.
 
 #### `changeFieldGroupControl (id, widgetNamespace, widgetId[, settings])` : void
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -459,32 +459,14 @@ author.editField('fullName')
   .name('Name')
 ```
 
-## editorLayout.FIELD_GROUP_LEVEL_TOO_DEEP
-When saving an editor layout with more than 2 levels deep
-
-**Example:**
-```javascript
-editorLayout.createFieldGroup('settings', {
-    name: 'Settings'
-  });
-
-editorLayout.editFieldGroup('settings')
-  .createFieldGroup('seo')
-  .name('SEO');
-
-editorLayout.editFieldGroup('seo')
-  .createFieldGroup('keywords')
-  .name('Keywords');
-```
-
 ## editorLayout.TOO_MANY_TABS
 When saving an editor layout with more than 5 tabs
 
 **Example:**
 ```javascript
 editorLayout.createFieldGroup('content', {
-    name: 'Content'
-  });
+  name: 'Content'
+});
 
 editorLayout.createFieldGroup('references', {
   name: 'References'
@@ -506,4 +488,51 @@ editorLayout.createFieldGroup('extras', {
   name: 'Extras'
 });
 
+```
+
+## editorLayout.TAB_CONTROL_INVALID
+When saving an editor layout with a tab that has `fieldset` control
+
+**Example:**
+```javascript
+editorLayout.createFieldGroup('settings', {
+  name: 'Settings'
+});
+
+editorLayout.changeFieldGroupControl('settings', 'builtin', 'fieldset');
+```
+
+## editorLayout.FIELDSET_CONTROL_INVALID
+When saving an editor layout with a field set that has `topLevelTab` control
+
+**Example:**
+```javascript
+editorLayout.createFieldGroup('settings', {
+  name: 'Settings'
+});
+
+editorLayout.editFieldGroup('settings')
+  .createFieldGroup('seo')
+  .name('SEO');
+
+editorLayout.changeFieldGroupControl('seo', 'builtin', 'topLevelTab');
+
+```
+
+## editorLayout.FIELD_GROUP_LEVEL_TOO_DEEP
+When saving an editor layout with more than 2 levels deep
+
+**Example:**
+```javascript
+editorLayout.createFieldGroup('settings', {
+  name: 'Settings'
+});
+
+editorLayout.editFieldGroup('settings')
+  .createFieldGroup('seo')
+  .name('SEO');
+
+editorLayout.editFieldGroup('seo')
+  .createFieldGroup('keywords')
+  .name('Keywords');
 ```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -536,3 +536,29 @@ editorLayout.editFieldGroup('seo')
   .createFieldGroup('keywords')
   .name('Keywords');
 ```
+
+## editorLayout.TOO_FEW_FIELD_GROUPS
+When saving an editor layout with less than 2 field groups.
+
+**Example:**
+```javascript
+editorLayout.createFieldGroup('content', {
+  name: 'Content'
+});
+```
+
+## editorLayout.TOO_MANY_FIELD_SETS
+When saving an editor layout with more than 15 field sets.
+
+**Example:**
+```javascript
+editorLayout.createFieldGroup('content', {
+  name: 'Content'
+});
+
+for (let i = 0; i <= 15; i++) {
+  editorLayout.editFieldGroup('content')
+    .createFieldGroup('dummy-' + i)
+    .name('Dummy group ' + i)
+}
+```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -460,12 +460,11 @@ author.editField('fullName')
 ```
 
 ## editorLayout.FIELD_GROUP_LEVEL_TOO_DEEP
-When trying to create a field group more than 2 levels deep 
+When saving an editor layout with more than 2 levels deep
 
 **Example:**
 ```javascript
-editorLayout
-  .createFieldGroup('settings', {
+editorLayout.createFieldGroup('settings', {
     name: 'Settings'
   });
 
@@ -476,4 +475,35 @@ editorLayout.editFieldGroup('settings')
 editorLayout.editFieldGroup('seo')
   .createFieldGroup('keywords')
   .name('Keywords');
+```
+
+## editorLayout.TOO_MANY_TABS
+When saving an editor layout with more than 5 tabs
+
+**Example:**
+```javascript
+editorLayout.createFieldGroup('content', {
+    name: 'Content'
+  });
+
+editorLayout.createFieldGroup('references', {
+  name: 'References'
+});
+
+editorLayout.createFieldGroup('settings', {
+  name: 'Settings'
+});
+
+editorLayout.createFieldGroup('seo', {
+  name: 'SEO'
+});
+
+editorLayout.createFieldGroup('keywords', {
+  name: 'Keywords'
+});
+
+editorLayout.createFieldGroup('extras', {
+  name: 'Extras'
+});
+
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -299,12 +299,6 @@ export interface FieldGroup {
   createFieldGroup: FieldGroupUpdateFunction
 }
 
-export interface FieldGroupControl {
-  widgetNamespace: 'builtin',
-  widgetId: 'fieldset' | 'topLevelTab',
-  settings?: IFieldGroupWidgetSettings
-}
-
 export interface EditorLayout {
   /** 
    * Creates a field group at the top level of editor layout

--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -106,10 +106,6 @@ export default abstract class Intent implements IntentInterface {
     return false
   }
 
-  isEditorLayoutUpdate () {
-    return false
-  }
-
   isFieldGroupCreate () {
     return false
   }

--- a/src/lib/intent/editor-layout/editor-layout-change-field-group-control.ts
+++ b/src/lib/intent/editor-layout/editor-layout-change-field-group-control.ts
@@ -9,10 +9,12 @@ export default class EditorLayoutChangeFieldGroupControlIntent extends Intent {
     return true
   }
   isGroupable () {
-    return false
+    return true
   }
-  groupsWith (): boolean {
-    return false
+  groupsWith (other): boolean {
+    return other.isGroupable()
+      && other.isEditorInterfaceIntent()
+      && this.isSameContentType(other)
   }
   endsGroup (): boolean {
     return false

--- a/src/lib/intent/editor-layout/editor-layout-change-field-group-id.ts
+++ b/src/lib/intent/editor-layout/editor-layout-change-field-group-id.ts
@@ -7,15 +7,12 @@ export default class EditorLayoutChangeFieldGroupIdIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
-  isEditorLayoutUpdate () {
-    return true
-  }
   isGroupable () {
     return true
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorLayoutUpdate()
+      && other.isEditorInterfaceIntent()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/intent/editor-layout/editor-layout-create-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-create-field-group.ts
@@ -7,9 +7,6 @@ export default class EditorLayoutCreateFieldGroupIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
-  isEditorLayoutUpdate () {
-    return true
-  }
   isFieldGroupCreate () {
     return true
   }
@@ -18,7 +15,7 @@ export default class EditorLayoutCreateFieldGroupIntent extends Intent {
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorLayoutUpdate()
+      && other.isEditorInterfaceIntent()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/intent/editor-layout/editor-layout-delete-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-delete-field-group.ts
@@ -7,9 +7,6 @@ export default class EditorLayoutDeleteFieldGroupIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
-  isEditorLayoutUpdate () {
-    return true
-  }
   isFieldGroupDelete () {
     return true
   }
@@ -18,7 +15,7 @@ export default class EditorLayoutDeleteFieldGroupIntent extends Intent {
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorLayoutUpdate()
+      && other.isEditorInterfaceIntent()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/intent/editor-layout/editor-layout-delete.ts
+++ b/src/lib/intent/editor-layout/editor-layout-delete.ts
@@ -7,9 +7,6 @@ export default class EditorLayoutDeleteIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
-  isEditorLayoutUpdate () {
-    return true
-  }
   isGroupable () {
     return false
   }

--- a/src/lib/intent/editor-layout/editor-layout-move-field.ts
+++ b/src/lib/intent/editor-layout/editor-layout-move-field.ts
@@ -8,15 +8,12 @@ export default class EditorLayoutMoveFieldIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
-  isEditorLayoutUpdate () {
-    return true
-  }
   isGroupable () {
     return true
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorLayoutUpdate()
+      && other.isEditorInterfaceIntent()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/intent/editor-layout/editor-layout-update-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-update-field-group.ts
@@ -8,15 +8,12 @@ export default class EditorLayoutUpdateFieldGroupIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
-  isEditorLayoutUpdate () {
-    return true
-  }
   isGroupable () {
     return true
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorLayoutUpdate()
+      && other.isEditorInterfaceIntent()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/interfaces/intent.ts
+++ b/src/lib/interfaces/intent.ts
@@ -35,7 +35,6 @@ interface Intent {
   isGroupable (): boolean
   isEditorInterfaceIntent (): boolean
   isEditorInterfaceUpdate (): boolean
-  isEditorLayoutUpdate (): boolean
   isSidebarUpdate (): boolean
   isTagIntent (): boolean
   isTagCreate (): boolean

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -17,6 +17,7 @@ import APIEntry from '../interfaces/api-entry'
 import APITag, { TagVisibility } from '../interfaces/api-tag'
 import Link from '../entities/link'
 import { EditorInterfaceSchemaValidator } from './validator/editor-interface'
+import FieldGroupsCountValidator from './validator/field-groups-count'
 
 interface RequestBatch {
   intent: Intent
@@ -216,6 +217,7 @@ class OfflineAPI {
     this.contentTypeValidators.push(new TypeChangeValidator())
 
     this.editorInterfaceValidators.push(new EditorInterfaceSchemaValidator())
+    this.editorInterfaceValidators.push(new FieldGroupsCountValidator())
 
     this.tagValidators.push(new TagSchemaValidator())
 

--- a/src/lib/offline-api/validator/editor-interface.ts
+++ b/src/lib/offline-api/validator/editor-interface.ts
@@ -6,13 +6,12 @@ import {
 } from '../../interfaces/errors'
 import { validateEditorInterface } from './schema/schema-validation'
 
-interface EditorInterfacePayloadValidator {
+export interface EditorInterfacePayloadValidator {
   hooks: ApiHook[]
   validate (editorInterface: EditorInterfaces): (InvalidActionError | PayloadValidationError)[]
 }
 
-export class EditorInterfaceSchemaValidator
-  implements EditorInterfacePayloadValidator {
+export class EditorInterfaceSchemaValidator implements EditorInterfacePayloadValidator {
   public hooks = [ApiHook.SaveEditorInterface]
 
   public validate (editorInterface: EditorInterfaces): PayloadValidationError[] {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -87,7 +87,10 @@ const errors = {
   editorLayout: {
     FIELD_GROUP_LEVEL_TOO_DEEP: () => {
       return 'Editor layout cannot have more than 2 levels of depth'
-    }
+    },
+    TOO_MANY_TABS: () => {
+      return 'Editor layout cannot have more than 5 tabs'
+    },
   },
   entry: {
     REQUIRED_PROPERTY: (path) => {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -102,7 +102,7 @@ const errors = {
     },
     TOO_MANY_FIELD_SETS: () => {
       return 'Editor layout cannot have more than 15 field sets'
-    },
+    }
   },
   entry: {
     REQUIRED_PROPERTY: (path) => {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -85,12 +85,18 @@ const errors = {
     }
   },
   editorLayout: {
-    FIELD_GROUP_LEVEL_TOO_DEEP: () => {
-      return 'Editor layout cannot have more than 2 levels of depth'
-    },
     TOO_MANY_TABS: () => {
       return 'Editor layout cannot have more than 5 tabs'
     },
+    TAB_CONTROL_INVALID: (groupId) => {
+      return `Editor layout tab "${groupId}" requires a "topLevelTab" widget group control`
+    },
+    FIELD_SET_CONTROL_INVALID: (groupId) => {
+      return `Editor layout field set "${groupId}" cannot have a "topLevelTab" widget group control`
+    },
+    FIELD_GROUP_LEVEL_TOO_DEEP: () => {
+      return 'Editor layout cannot have more than 2 levels of depth'
+    }
   },
   entry: {
     REQUIRED_PROPERTY: (path) => {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -1,3 +1,5 @@
+import { MAX_FIELD_SETS, MAX_TABS, MIN_GROUPS } from '../../utils/editor-layout'
+
 const errors = {
   contentType: {
     REQUIRED_PROPERTY: (path) => {
@@ -86,7 +88,7 @@ const errors = {
   },
   editorLayout: {
     TOO_MANY_TABS: () => {
-      return 'Editor layout cannot have more than 5 tabs'
+      return `Editor layout cannot have more than ${MAX_TABS} tabs`
     },
     TAB_CONTROL_INVALID: (groupId) => {
       return `Editor layout tab "${groupId}" requires a "topLevelTab" widget group control`
@@ -98,10 +100,10 @@ const errors = {
       return 'Editor layout cannot have more than 2 levels of depth'
     },
     TOO_FEW_FIELD_GROUPS: () => {
-      return 'Editor layout cannot have less than 2 groups'
+      return `Editor layout cannot have less than ${MIN_GROUPS} groups`
     },
     TOO_MANY_FIELD_SETS: () => {
-      return 'Editor layout cannot have more than 15 field sets'
+      return `Editor layout cannot have more than ${MAX_FIELD_SETS} field sets`
     }
   },
   entry: {

--- a/src/lib/offline-api/validator/errors.ts
+++ b/src/lib/offline-api/validator/errors.ts
@@ -96,7 +96,13 @@ const errors = {
     },
     FIELD_GROUP_LEVEL_TOO_DEEP: () => {
       return 'Editor layout cannot have more than 2 levels of depth'
-    }
+    },
+    TOO_FEW_FIELD_GROUPS: () => {
+      return 'Editor layout cannot have less than 2 groups'
+    },
+    TOO_MANY_FIELD_SETS: () => {
+      return 'Editor layout cannot have more than 15 field sets'
+    },
   },
   entry: {
     REQUIRED_PROPERTY: (path) => {

--- a/src/lib/offline-api/validator/field-groups-count.ts
+++ b/src/lib/offline-api/validator/field-groups-count.ts
@@ -1,0 +1,34 @@
+import { ApiHook } from '..'
+import errorMessages from './errors'
+import { EditorInterfacePayloadValidator } from './editor-interface';
+import { EditorInterfaces } from '../../entities/content-type';
+import { collectFieldGroupIds } from '../../utils/editor-layout';
+import { PayloadValidationError } from '../../interfaces/errors';
+
+export default class FieldGroupsCountValidator implements EditorInterfacePayloadValidator {
+   public hooks = [ApiHook.SaveEditorInterface]
+
+  public validate (editorInterface: EditorInterfaces): PayloadValidationError[] {
+    const errors: PayloadValidationError[] = []
+    const editorLayout = editorInterface.getEditorLayout()
+
+    const groupsCount = collectFieldGroupIds(editorLayout).length
+    const tabsCount = editorLayout.length
+
+    if (groupsCount < 2) {
+      errors.push({
+        type: 'InvalidPayload',
+        message: errorMessages.editorLayout.TOO_FEW_FIELD_GROUPS()
+      })
+    }
+
+    if (groupsCount - tabsCount > 15) {
+      errors.push({
+        type: 'InvalidPayload',
+        message: errorMessages.editorLayout.TOO_MANY_FIELD_SETS()
+      })
+    }
+
+    return errors
+  }
+}

--- a/src/lib/offline-api/validator/field-groups-count.ts
+++ b/src/lib/offline-api/validator/field-groups-count.ts
@@ -2,7 +2,7 @@ import { ApiHook } from '..'
 import errorMessages from './errors'
 import { EditorInterfacePayloadValidator } from './editor-interface'
 import { EditorInterfaces } from '../../entities/content-type'
-import { collectFieldGroupIds } from '../../utils/editor-layout'
+import { collectFieldGroupIds, MAX_FIELD_SETS, MIN_GROUPS } from '../../utils/editor-layout'
 import { PayloadValidationError } from '../../interfaces/errors'
 
 export default class FieldGroupsCountValidator implements EditorInterfacePayloadValidator {
@@ -15,14 +15,14 @@ export default class FieldGroupsCountValidator implements EditorInterfacePayload
     const groupsCount = collectFieldGroupIds(editorLayout).length
     const tabsCount = editorLayout.length
 
-    if (groupsCount < 2) {
+    if (groupsCount < MIN_GROUPS) {
       errors.push({
         type: 'InvalidPayload',
         message: errorMessages.editorLayout.TOO_FEW_FIELD_GROUPS()
       })
     }
 
-    if (groupsCount - tabsCount > 15) {
+    if (groupsCount - tabsCount > MAX_FIELD_SETS) {
       errors.push({
         type: 'InvalidPayload',
         message: errorMessages.editorLayout.TOO_MANY_FIELD_SETS()

--- a/src/lib/offline-api/validator/field-groups-count.ts
+++ b/src/lib/offline-api/validator/field-groups-count.ts
@@ -1,12 +1,12 @@
 import { ApiHook } from '..'
 import errorMessages from './errors'
-import { EditorInterfacePayloadValidator } from './editor-interface';
-import { EditorInterfaces } from '../../entities/content-type';
-import { collectFieldGroupIds } from '../../utils/editor-layout';
-import { PayloadValidationError } from '../../interfaces/errors';
+import { EditorInterfacePayloadValidator } from './editor-interface'
+import { EditorInterfaces } from '../../entities/content-type'
+import { collectFieldGroupIds } from '../../utils/editor-layout'
+import { PayloadValidationError } from '../../interfaces/errors'
 
 export default class FieldGroupsCountValidator implements EditorInterfacePayloadValidator {
-   public hooks = [ApiHook.SaveEditorInterface]
+  public hooks = [ApiHook.SaveEditorInterface]
 
   public validate (editorInterface: EditorInterfaces): PayloadValidationError[] {
     const errors: PayloadValidationError[] = []

--- a/src/lib/offline-api/validator/schema/editor-layout-schema.ts
+++ b/src/lib/offline-api/validator/schema/editor-layout-schema.ts
@@ -1,20 +1,24 @@
 import * as Joi from 'joi'
 
-const field = Joi.object().keys({
+const fieldSchema = Joi.object().keys({
   fieldId: Joi.string().required()
 })
 
-const fieldSet = Joi.object().keys({
-  name: Joi.string().required(),
-  groupId: Joi.string().required(),
-  items: Joi.array().items(field)
-})
+export function createEditorLayoutSchema (tabsIds: string[]) {
+  const fieldSetSchema = Joi.object().keys({
+    name: Joi.string().required(),
+    groupId: Joi.string().required().invalid(...tabsIds),
+    items: Joi.array().items(fieldSchema)
+  })
 
-export function createEditorLayoutSchema () {
   const editorLayoutSchema = Joi.array().items(Joi.object().keys({
     name: Joi.string().required(),
-    groupId: Joi.string().required(),
-    items: Joi.array().items(Joi.alternatives().try(fieldSet, field))
+    groupId: Joi.string().required().valid(...tabsIds),
+    items: Joi.array()
+      .items(Joi.alternatives().conditional(Joi.object({ groupId: Joi.exist() }).unknown(), {
+        then: fieldSetSchema,
+        otherwise: fieldSchema
+      }))
   })).max(5)
 
   return editorLayoutSchema

--- a/src/lib/offline-api/validator/schema/editor-layout-schema.ts
+++ b/src/lib/offline-api/validator/schema/editor-layout-schema.ts
@@ -1,4 +1,5 @@
 import * as Joi from 'joi'
+import { MAX_TABS } from '../../../utils/editor-layout'
 
 const fieldSchema = Joi.object().keys({
   fieldId: Joi.string().required()
@@ -19,7 +20,7 @@ export function createEditorLayoutSchema (tabsIds: string[]) {
         then: fieldSetSchema,
         otherwise: fieldSchema
       }))
-  })).max(5)
+  })).max(MAX_TABS)
 
   return editorLayoutSchema
 }

--- a/src/lib/offline-api/validator/schema/editor-layout-schema.ts
+++ b/src/lib/offline-api/validator/schema/editor-layout-schema.ts
@@ -15,7 +15,7 @@ export function createEditorLayoutSchema () {
     name: Joi.string().required(),
     groupId: Joi.string().required(),
     items: Joi.array().items(Joi.alternatives().try(fieldSet, field))
-  }))
+  })).max(5)
 
   return editorLayoutSchema
 }

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -68,6 +68,12 @@ const validateEditorInterface = function (editorInterface: EditorInterfaces): Pa
   }
 
   return error.details.map((err): PayloadValidationError => {
+    if (err.type === 'array.max' && err.path.length === 0) {
+      return {
+        type: 'InvalidPayload',
+        message: errorMessages.editorLayout.TOO_MANY_TABS()
+      }
+    }
     if (err.type === 'alternatives.match') {
       return {
         type: 'InvalidPayload',

--- a/src/lib/offline-api/validator/schema/schema-validation.ts
+++ b/src/lib/offline-api/validator/schema/schema-validation.ts
@@ -57,7 +57,11 @@ const validateContentType = function (contentType: ContentType): PayloadValidati
 }
 
 const validateEditorInterface = function (editorInterface: EditorInterfaces): PayloadValidationError[] {
-  const validateResult = createEditorLayoutSchema().validate(editorInterface.getEditorLayout(), {
+  const groupControls = editorInterface.getGroupControls() || []
+  const tabsIds = groupControls
+    .filter(control => control.widgetNamespace === 'builtin' && control.widgetId === 'topLevelTab')
+    .map(control => control.groupId)
+  const validateResult = createEditorLayoutSchema(tabsIds).validate(editorInterface.getEditorLayout(), {
     abortEarly: false
   })
 
@@ -74,7 +78,19 @@ const validateEditorInterface = function (editorInterface: EditorInterfaces): Pa
         message: errorMessages.editorLayout.TOO_MANY_TABS()
       }
     }
-    if (err.type === 'alternatives.match') {
+    if (err.type === 'any.only') {
+      return {
+        type: 'InvalidPayload',
+        message: errorMessages.editorLayout.TAB_CONTROL_INVALID(err.context.value)
+      }
+    }
+    if (err.type === 'any.invalid') {
+      return {
+        type: 'InvalidPayload',
+        message: errorMessages.editorLayout.FIELD_SET_CONTROL_INVALID(err.context.value)
+      }
+    }
+    if (err.type === 'any.required') {
       return {
         type: 'InvalidPayload',
         message: errorMessages.editorLayout.FIELD_GROUP_LEVEL_TOO_DEEP()

--- a/src/lib/utils/editor-layout.ts
+++ b/src/lib/utils/editor-layout.ts
@@ -1,3 +1,7 @@
+export const MIN_GROUPS = 2
+export const MAX_TABS = 5
+export const MAX_FIELD_SETS = 15
+
 export interface FieldGroupItem {
   groupId: string
   name?: string

--- a/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
+++ b/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
@@ -430,6 +430,65 @@ describe('editor layout plan validation', function () {
     });
   });
 
+  describe('when saving an editor layout with more than 5 tabs', function () {
+    it('returns an error', async function () {
+      const contentTypes = [{
+        sys: { id: 'page' },
+        name: 'Page',
+        fields: [{ id: 'title', name: 'Page title', type: 'Symbol' }]
+      }];
+
+      const editorInterfaces = {
+        page: {
+          sys: {
+            version: 1
+          },
+          editorLayout: [
+            {
+              groupId: 'content',
+              name: 'Content',
+              items: [{ fieldId: 'title' }]
+            },
+            {
+              groupId: 'content2',
+              name: 'Content',
+              items: []
+            },
+            {
+              groupId: 'content3',
+              name: 'Content',
+              items: []
+            },
+            {
+              groupId: 'content4',
+              name: 'Content',
+              items: []
+            },
+            {
+              groupId: 'content5',
+              name: 'Content',
+              items: []
+            }
+          ]
+        }
+      };
+
+      const errors = await validateBatches(function (migration) {
+        const page = migration.editContentType('page');
+        const editorLayout = page.editEditorLayout();
+
+        editorLayout.createFieldGroup('content6', {
+          name: 'Content6'
+        });
+      }, contentTypes, [], [], [], editorInterfaces);
+
+      expect(errors).to.eql([[{
+        type: 'InvalidPayload',
+        message: 'Editor layout cannot have more than 5 tabs'
+      }]]);
+    });
+  });
+
   describe('field movement', () => {
     let testCts, testEis;
     beforeEach(() => {

--- a/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
+++ b/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
@@ -201,6 +201,13 @@ describe('editor layout plan validation', function () {
               name: 'Content',
               items: [{ fieldId: 'title' }]
             }
+          ],
+          groupControls: [
+            {
+              groupId: 'content',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            }
           ]
         }
       };
@@ -469,6 +476,33 @@ describe('editor layout plan validation', function () {
               name: 'Content',
               items: []
             }
+          ],
+          groupControls: [
+            {
+              groupId: 'content',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            },
+            {
+              groupId: 'content2',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            },
+            {
+              groupId: 'content3',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            },
+            {
+              groupId: 'content4',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            },
+            {
+              groupId: 'content5',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            }
           ]
         }
       };
@@ -485,6 +519,105 @@ describe('editor layout plan validation', function () {
       expect(errors).to.eql([[{
         type: 'InvalidPayload',
         message: 'Editor layout cannot have more than 5 tabs'
+      }]]);
+    });
+  });
+
+  describe('when saving an editor layout with a tab that has fieldset control', function () {
+    it('returns an error', async function () {
+      const contentTypes = [{
+        sys: { id: 'page' },
+        name: 'Page',
+        fields: [{ id: 'title', name: 'Page title', type: 'Symbol' }]
+      }];
+
+      const editorInterfaces = {
+        page: {
+          sys: {
+            version: 1
+          },
+          editorLayout: [
+            {
+              groupId: 'content',
+              name: 'Content',
+              items: [{ fieldId: 'title' }]
+            },
+            {
+              groupId: 'settings',
+              name: 'Settings',
+              items: []
+            }
+          ],
+          groupControls: [
+            {
+              groupId: 'content',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            },
+            {
+              groupId: 'settings',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            }
+          ]
+        }
+      };
+
+      const errors = await validateBatches(function (migration) {
+        const page = migration.editContentType('page');
+        const editorLayout = page.editEditorLayout();
+        editorLayout.changeFieldGroupControl('settings', 'builtin', 'fieldset');
+      }, contentTypes, [], [], [], editorInterfaces);
+
+      expect(errors).to.eql([[{
+        type: 'InvalidPayload',
+        message: 'Editor layout tab "settings" requires a "topLevelTab" widget group control'
+      }]]);
+    });
+  });
+  describe('when saving an editor layout with a field set that has tab control', function () {
+    it('returns an error', async function () {
+      const contentTypes = [{
+        sys: { id: 'page' },
+        name: 'Page',
+        fields: [{ id: 'title', name: 'Page title', type: 'Symbol' }]
+      }];
+
+      const editorInterfaces = {
+        page: {
+          sys: {
+            version: 1
+          },
+          editorLayout: [
+            {
+              groupId: 'content',
+              name: 'Content',
+              items: [{ fieldId: 'title' }, {
+                groupId: 'details',
+                name: 'Details',
+                items: []
+              }]
+            }
+          ],
+          groupControls: [
+            {
+              groupId: 'content',
+              widgetNamespace: 'builtin',
+              widgetId: 'topLevelTab'
+            }
+          ]
+        }
+      };
+
+      const errors = await validateBatches(function (migration) {
+        const page = migration.editContentType('page');
+        const editorLayout = page.editEditorLayout();
+        editorLayout.changeFieldGroupControl('details', 'builtin', 'topLevelTab');
+      }, contentTypes, [], [], [], editorInterfaces);
+
+      expect(errors).to.eql([[{
+        type: 'InvalidPayload',
+        message: 'Editor layout field set "details" cannot have a "topLevelTab" widget group control'
       }]]);
     });
   });


### PR DESCRIPTION
Cover more validation errors for the editor layout:
- too many tabs
- too many field sets
- too few field groups
- tab with a field set control
- field set with a tab control

Plus fix the readme and how editor interface intents are grouped