### PR TITLE
feat: align output and add E2E tests for field grouping

### DIFF
--- a/examples/xx-delete-editor-layout-field-set.js
+++ b/examples/xx-delete-editor-layout-field-set.js
@@ -3,5 +3,11 @@
 module.exports = function (migration) {
   const page = migration.editContentType('page');
   const editorLayout = page.editEditorLayout();
+
+  editorLayout.createFieldGroup('toBeDeleted', {
+    name: 'To be deleted'
+  });
+  editorLayout.deleteFieldGroup('toBeDeleted');
+
   editorLayout.deleteFieldGroup('seo');
 };

--- a/examples/xx-delete-editor-layout-tab.js
+++ b/examples/xx-delete-editor-layout-tab.js
@@ -3,4 +3,10 @@ module.exports = function (migration) {
   const page = migration.editContentType('page');
   const editorLayout = page.editEditorLayout();
   editorLayout.deleteFieldGroup('settings');
+
+  const metadata = editorLayout.editFieldGroup('metadata');
+  metadata.createFieldGroup('toBeDeleted', {
+    name: 'To be deleted'
+  });
+  editorLayout.deleteFieldGroup('toBeDeleted');
 };

--- a/examples/xx-move-field-in-existing-editor-layout.js
+++ b/examples/xx-move-field-in-existing-editor-layout.js
@@ -1,0 +1,12 @@
+// TODO: rename file before merging to master
+
+module.exports = function (migration) {
+  const myType = migration.editContentType('mytype');
+  const editorLayout = myType.editEditorLayout();
+
+  editorLayout.moveField('fieldA').toTheTopOfFieldGroup('firsttab');
+  editorLayout.moveField('fieldB').afterFieldGroup('fieldset');
+  editorLayout.moveField('fieldC').afterField('fieldB');
+  editorLayout.moveField('fieldE').beforeField('fieldC');
+  editorLayout.moveField('fieldE').toTheBottomOfFieldGroup();
+};

--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -114,6 +114,10 @@ export default abstract class Intent implements IntentInterface {
     return false
   }
 
+  isEditorLayoutUpdate () {
+    return false
+  }
+
   isFieldGroupCreate () {
     return false
   }

--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -106,6 +106,14 @@ export default abstract class Intent implements IntentInterface {
     return false
   }
 
+  isEditorLayoutCreate () {
+    return false
+  }
+
+  isEditorLayoutDelete () {
+    return false
+  }
+
   isFieldGroupCreate () {
     return false
   }

--- a/src/lib/intent/composed-intent.ts
+++ b/src/lib/intent/composed-intent.ts
@@ -178,6 +178,14 @@ export default class ComposedIntent implements Intent {
     return null
   }
 
+  isEditorLayoutCreate (): boolean {
+    return false
+  }
+
+  isEditorLayoutDelete (): boolean {
+    return false
+  }
+
   isFieldGroupCreate (): boolean {
     return false
   }

--- a/src/lib/intent/composed-intent.ts
+++ b/src/lib/intent/composed-intent.ts
@@ -47,9 +47,6 @@ export default class ComposedIntent implements Intent {
   isEditorInterfaceUpdate (): boolean {
     return false
   }
-  isEditorLayoutUpdate (): boolean {
-    return false
-  }
   isContentTypeUpdate (): boolean {
     return false
   }
@@ -186,6 +183,10 @@ export default class ComposedIntent implements Intent {
     return false
   }
 
+  isEditorLayoutUpdate (): boolean {
+    return false
+  }
+
   isFieldGroupCreate (): boolean {
     return false
   }
@@ -232,6 +233,8 @@ export default class ComposedIntent implements Intent {
     const onlyFieldUpdatesByField = groupBy(onlyFieldUpdates, (intent) => intent.getFieldId())
     const createdFieldUpdatesByField = groupBy(createdFieldUpdates, (intent) => intent.getFieldId())
 
+    const editorLayoutUpdates = this.intents.filter((intent) => intent.isEditorLayoutUpdate())
+
     const topLevelDetails = flatten(contentTypeOrTagUpdates.map((updateIntent) => updateIntent.toPlanMessage().details))
 
     const sidebarUpdates = flatten(this.intents
@@ -251,6 +254,7 @@ export default class ComposedIntent implements Intent {
       }
       createSections.push(nextUpdateSection)
     }
+
     for (const createIntent of fieldCreates) {
       const fieldId = createIntent.getFieldId()
       const [createSection] = createIntent.toPlanMessage().sections
@@ -275,6 +279,11 @@ export default class ComposedIntent implements Intent {
 
     for (const moveIntent of fieldMoves) {
       const planMessage = moveIntent.toPlanMessage()
+      createSections = createSections.concat(planMessage.sections)
+    }
+
+    for (const updateIntent of editorLayoutUpdates) {
+      const planMessage = updateIntent.toPlanMessage()
       createSections = createSections.concat(planMessage.sections)
     }
 

--- a/src/lib/intent/editor-layout/editor-layout-change-field-group-control.ts
+++ b/src/lib/intent/editor-layout/editor-layout-change-field-group-control.ts
@@ -8,12 +8,15 @@ export default class EditorLayoutChangeFieldGroupControlIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutUpdate () {
+    return true
+  }
   isGroupable () {
     return true
   }
   groupsWith (other): boolean {
     return other.isGroupable()
-      && other.isEditorInterfaceIntent()
+      && other.isEditorLayoutUpdate()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {
@@ -35,14 +38,17 @@ export default class EditorLayoutChangeFieldGroupControlIntent extends Intent {
     ]
   }
   toPlanMessage (): PlanMessage {
-    const details = entries(this.payload.props).map(([key, value]) => {
+    const details = entries(this.payload.groupControl).map(([key, value]) => {
       return chalk`{italic ${key}}: ${JSON.stringify(value)}`
     })
 
     return {
-      heading: chalk`Update group control for field group {yellow ${this.payload.fieldGroupId}} for content type {bold.yellow ${this.getContentTypeId()}}`,
-      sections: [],
-      details
+      heading: chalk`Update editor layout for content type {bold.yellow ${this.getContentTypeId()}}`,
+      sections: [{
+        heading: chalk`Update group controls for field group {yellow ${this.getFieldGroupId()}}`,
+        details
+      }],
+      details: []
     }
   }
 }

--- a/src/lib/intent/editor-layout/editor-layout-change-field-group-id.ts
+++ b/src/lib/intent/editor-layout/editor-layout-change-field-group-id.ts
@@ -7,12 +7,15 @@ export default class EditorLayoutChangeFieldGroupIdIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutUpdate () {
+    return true
+  }
   isGroupable () {
     return true
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorInterfaceIntent()
+      && other.isEditorLayoutUpdate()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/intent/editor-layout/editor-layout-create-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-create-field-group.ts
@@ -7,6 +7,9 @@ export default class EditorLayoutCreateFieldGroupIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutUpdate () {
+    return true
+  }
   isFieldGroupCreate () {
     return true
   }
@@ -15,7 +18,7 @@ export default class EditorLayoutCreateFieldGroupIntent extends Intent {
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorInterfaceIntent()
+      && other.isEditorLayoutUpdate()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {
@@ -37,10 +40,11 @@ export default class EditorLayoutCreateFieldGroupIntent extends Intent {
     ]
   }
   toPlanMessage (): PlanMessage {
+    const parentInfo = this.payload.parentFieldGroupId ? chalk` in field group {yellow ${this.payload.parentFieldGroupId}}` : ''
     return {
       heading: chalk`Update editor layout for content type {bold.yellow ${this.getContentTypeId()}}`,
       sections: [{
-        heading: chalk`Create field group {yellow ${this.payload.fieldGroupId}}`,
+        heading: chalk`Create field group {yellow ${this.getFieldGroupId()}}${parentInfo}`,
         details: []
       }],
       details: []

--- a/src/lib/intent/editor-layout/editor-layout-create.ts
+++ b/src/lib/intent/editor-layout/editor-layout-create.ts
@@ -11,6 +11,9 @@ export default class EditorLayoutCreateIntent extends Intent {
     // We need the fields to build the initial editor layout
     return true
   }
+  isEditorLayoutCreate () {
+    return true
+  }
   isGroupable () {
     return false
   }

--- a/src/lib/intent/editor-layout/editor-layout-delete-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-delete-field-group.ts
@@ -7,6 +7,9 @@ export default class EditorLayoutDeleteFieldGroupIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutUpdate () {
+    return true
+  }
   isFieldGroupDelete () {
     return true
   }
@@ -15,7 +18,7 @@ export default class EditorLayoutDeleteFieldGroupIntent extends Intent {
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorInterfaceIntent()
+      && other.isEditorLayoutUpdate()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {
@@ -37,9 +40,12 @@ export default class EditorLayoutDeleteFieldGroupIntent extends Intent {
   }
   toPlanMessage (): PlanMessage {
     return {
-      heading: chalk`Delete field group {yellow ${this.payload.fieldGroupId}} in editor layout for content type {bold.yellow ${this.getContentTypeId()}}`,
-      details: [],
-      sections: []
+      heading: chalk`Update editor layout for content type {bold.yellow ${this.getContentTypeId()}}`,
+      sections: [{
+        heading: chalk`Delete field group {yellow ${this.getFieldGroupId()}}`,
+        details: []
+      }],
+      details: []
     }
   }
 }

--- a/src/lib/intent/editor-layout/editor-layout-delete.ts
+++ b/src/lib/intent/editor-layout/editor-layout-delete.ts
@@ -7,6 +7,9 @@ export default class EditorLayoutDeleteIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutDelete () {
+    return true
+  }
   isGroupable () {
     return false
   }

--- a/src/lib/intent/editor-layout/editor-layout-move-field.ts
+++ b/src/lib/intent/editor-layout/editor-layout-move-field.ts
@@ -8,6 +8,10 @@ export default class EditorLayoutMoveFieldIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  requiresContentType () {
+    // We need the fields to validate field IDs
+    return true
+  }
   isGroupable () {
     return true
   }

--- a/src/lib/intent/editor-layout/editor-layout-move-field.ts
+++ b/src/lib/intent/editor-layout/editor-layout-move-field.ts
@@ -8,6 +8,9 @@ export default class EditorLayoutMoveFieldIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutUpdate () {
+    return true
+  }
   requiresContentType () {
     // We need the fields to validate field IDs
     return true
@@ -17,7 +20,7 @@ export default class EditorLayoutMoveFieldIntent extends Intent {
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorInterfaceIntent()
+      && other.isEditorLayoutUpdate()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {

--- a/src/lib/intent/editor-layout/editor-layout-update-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-update-field-group.ts
@@ -8,12 +8,15 @@ export default class EditorLayoutUpdateFieldGroupIntent extends Intent {
   isEditorInterfaceIntent () {
     return true
   }
+  isEditorLayoutUpdate () {
+    return true
+  }
   isGroupable () {
     return true
   }
   groupsWith (other: Intent): boolean {
     return other.isGroupable()
-      && other.isEditorInterfaceIntent()
+      && other.isEditorLayoutUpdate()
       && this.isSameContentType(other)
   }
   endsGroup (): boolean {
@@ -35,7 +38,7 @@ export default class EditorLayoutUpdateFieldGroupIntent extends Intent {
     ]
   }
   toPlanMessage (): PlanMessage {
-    const details = entries(this.payload.props).map(([key, value]) => {
+    const details = entries(this.payload.fieldGroupProps).map(([key, value]) => {
       return chalk`{italic ${key}}: ${JSON.stringify(value)}`
     })
 

--- a/src/lib/interfaces/intent.ts
+++ b/src/lib/interfaces/intent.ts
@@ -41,6 +41,8 @@ interface Intent {
   isTagUpdate (): boolean
   isTagDelete (): boolean
   isEntrySetTags (): boolean
+  isEditorLayoutCreate (): boolean
+  isEditorLayoutDelete (): boolean
   isFieldGroupCreate (): boolean
   isFieldGroupDelete (): boolean
 

--- a/src/lib/interfaces/intent.ts
+++ b/src/lib/interfaces/intent.ts
@@ -43,6 +43,7 @@ interface Intent {
   isEntrySetTags (): boolean
   isEditorLayoutCreate (): boolean
   isEditorLayoutDelete (): boolean
+  isEditorLayoutUpdate (): boolean
   isFieldGroupCreate (): boolean
   isFieldGroupDelete (): boolean
 

--- a/src/lib/migration-chunks/validation/editor-layout.ts
+++ b/src/lib/migration-chunks/validation/editor-layout.ts
@@ -66,8 +66,12 @@ class NonExistingDeletes implements EditorLayoutValidation {
     }
 
     const fieldGroupId = getScopedFieldGroupId(intent)
+    const fieldGroupExists =
+      context.remoteFieldGroups.has(fieldGroupId) ||
+      context.createdFieldGroups.has(fieldGroupId) ||
+      context.deletedFieldGroups.has(fieldGroupId)
 
-    if (context.remoteFieldGroups.has(fieldGroupId) || context.deletedFieldGroups.has(fieldGroupId)) {
+    if (fieldGroupExists) {
       return
     }
 

--- a/src/lib/migration-chunks/validation/editor-layout.ts
+++ b/src/lib/migration-chunks/validation/editor-layout.ts
@@ -15,6 +15,8 @@ const VALID_MOVEMENT_DIRECTIONS = [...RELATIVE_MOVEMENTS, ...ABSOLUTE_MOVEMENTS]
 
 interface ValidationContext {
   fields: FieldsContext,
+  remoteEditorLayouts: Set<string>
+  createdEditorLayouts: Set<string>
   remoteFieldGroups: Set<string>
   createdFieldGroups: Set<string>
   deletedFieldGroups: Set<string>
@@ -26,6 +28,34 @@ interface EditorLayoutValidation {
 }
 
 class DuplicateCreate implements EditorLayoutValidation {
+  validate (intent: Intent, context: ValidationContext) {
+    if (!intent.isEditorLayoutCreate()) {
+      return
+    }
+
+    if (!context.createdEditorLayouts.has(intent.getContentTypeId())) {
+      return
+    }
+
+    return editorLayoutErrors.createEditorLayout.EDITOR_LAYOUT_ALREADY_CREATED(intent.getContentTypeId())
+  }
+}
+
+class AlreadyExistingCreates implements EditorLayoutValidation {
+  validate (intent: Intent, context: ValidationContext) {
+    if (!intent.isEditorLayoutCreate()) {
+      return
+    }
+
+    if (!context.remoteEditorLayouts.has(intent.getContentTypeId())) {
+      return
+    }
+
+    return editorLayoutErrors.createEditorLayout.EDITOR_LAYOUT_ALREADY_EXISTS(intent.getContentTypeId())
+  }
+}
+
+class DuplicateFieldGroupCreate implements EditorLayoutValidation {
   validate (intent: Intent, context: ValidationContext) {
     if (!intent.isFieldGroupCreate()) {
       return
@@ -42,7 +72,7 @@ class DuplicateCreate implements EditorLayoutValidation {
   }
 }
 
-class AlreadyExistingCreates implements EditorLayoutValidation {
+class AlreadyExistingFieldGroupCreates implements EditorLayoutValidation {
   validate (intent: Intent, context: ValidationContext) {
     if (!intent.isFieldGroupCreate()) {
       return
@@ -195,6 +225,8 @@ class InvalidFielGroupIdChange implements EditorLayoutValidation {
 const checks: EditorLayoutValidation[] = [
   new DuplicateCreate(),
   new AlreadyExistingCreates(),
+  new DuplicateFieldGroupCreate(),
+  new AlreadyExistingFieldGroupCreates(),
   new NonExistingDeletes(),
   new DuplicateDeletes(),
   new InvalidFieldMove(),
@@ -211,9 +243,11 @@ function generateScopedId (ctId: string, id: string) {
 
 export default function (intents: Intent[], editorInterfaces: Map<string, EditorInterfaces>, fieldsContext: FieldsContext): InvalidActionError[] {
   let remoteFieldGroups = []
+  const remoteEditorLayouts = new Set<string>()
   editorInterfaces.forEach((editorInterfaces, ctId) => {
     const editorLayout = editorInterfaces.getEditorLayout()
     if (editorLayout) {
+      remoteEditorLayouts.add(ctId)
       remoteFieldGroups = remoteFieldGroups.concat(collectFieldGroupIds(editorLayout).map(id => `${ctId}.${id}`))
     }
   })
@@ -221,6 +255,8 @@ export default function (intents: Intent[], editorInterfaces: Map<string, Editor
 
   let context: ValidationContext = {
     fields: fieldsContext, // all currently existing fields as collected by field validation
+    remoteEditorLayouts, // all currently (in the current iteration step) existing editor layouts
+    createdEditorLayouts: new Set<string>(), // all by now (in previous iteration steps) created editor layouts
     remoteFieldGroups: new Set(remoteFieldGroups), // all currently (in the current iteration step) existing field groups
     createdFieldGroups: new Set<string>(), // all by now (in previous iteration steps) created field groups
     deletedFieldGroups: new Set<string>(), // all by now (in previous iteration steps) deleted field groups
@@ -253,6 +289,15 @@ export default function (intents: Intent[], editorInterfaces: Map<string, Editor
 
       // do not update context
       continue
+    }
+
+    if (intent.isEditorLayoutCreate()) {
+      context.createdEditorLayouts.add(intent.getContentTypeId())
+    }
+
+    if (intent.isEditorLayoutDelete()) {
+      context.remoteEditorLayouts.delete(intent.getContentTypeId())
+      context.createdEditorLayouts.delete(intent.getContentTypeId())
     }
 
     const fieldGroupId = getScopedFieldGroupId(intent)

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -155,6 +155,14 @@ const errorCreators: ErrorCreators = {
 
   },
   editorLayout: {
+    createEditorLayout: {
+      EDITOR_LAYOUT_ALREADY_CREATED: (ctId) => {
+        return `Editor layout for content type "${ctId}" cannot be created more than once.`
+      },
+      EDITOR_LAYOUT_ALREADY_EXISTS: (ctId) => {
+        return `Editor layout for content type "${ctId}" already exists.`
+      }
+    },
     createFieldGroup: {
       FIELD_GROUP_ALREADY_CREATED: (id, ctId) => {
         return `Field group with id "${id}" for content type "${ctId}" cannot be created more than once.`

--- a/test/end-to-end/assertions.js
+++ b/test/end-to-end/assertions.js
@@ -2,6 +2,7 @@
 
 const stripAnsi = require('strip-ansi');
 const { expect } = require('chai');
+const chalk = require('chalk');
 
 module.exports = {
   errors: {
@@ -127,12 +128,36 @@ module.exports = {
       }
     },
     editorLayout: {
-      create: function (ctId, params) {
+      create: function (ctId) {
         return result => {
           expect(result.stdout).not.to.be.empty();
 
           const withoutAnsiCodes = stripAnsi(result.stdout);
           expect(withoutAnsiCodes).to.include(`Create editor layout for content type ${ctId}`);
+        };
+      },
+      changeFieldGroupId: function (oldFieldGroupId, newFieldGroupId) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Change field group id from ${oldFieldGroupId} to ${newFieldGroupId}`);
+        };
+      },
+      createFieldGroup: function (fieldGroupId) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Create field group ${fieldGroupId}`);
+        };
+      },
+      createFieldGroupInParent: function (fieldGroupId, parentFieldGroupId) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Create field group ${fieldGroupId} in field group ${parentFieldGroupId}`);
         };
       },
       delete: function (ctId) {
@@ -143,12 +168,60 @@ module.exports = {
           expect(withoutAnsiCodes).to.include(`Delete editor layout for content type ${ctId}`);
         };
       },
-      deleteFieldGroup: function (ctId, fieldGroupId) {
+      deleteFieldGroup: function (fieldGroupId) {
         return result => {
           expect(result.stdout).not.to.be.empty();
 
           const withoutAnsiCodes = stripAnsi(result.stdout);
-          expect(withoutAnsiCodes).to.include(`Delete field group ${fieldGroupId} in editor layout for content type ${ctId}`);
+          expect(withoutAnsiCodes).to.include(`Delete field group ${fieldGroupId}`);
+        };
+      },
+      moveFieldToTheFirstPositionInFieldGroup: function (fieldId, pivot) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Move field ${fieldId} to the first position ${pivot ? `of group ${pivot}` : 'of its group'}`);
+        };
+      },
+      moveFieldToTheLastPositionInFieldGroup: function (fieldId, pivot) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Move field ${fieldId} to the last position ${pivot ? `of group ${pivot}` : 'of its group'}`);
+        };
+      },
+      moveFieldAfterField: function (fieldId, pivot) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Move field ${fieldId} after field ${pivot}`);
+        };
+      },
+      moveFieldBeforeField: function (fieldId, pivot) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Move field ${fieldId} before field ${pivot}`);
+        };
+      },
+      moveFieldAfterFieldGroup: function (fieldId, pivot) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Move field ${fieldId} after field group ${pivot}`);
+        };
+      },
+      moveFieldBeforeFieldGroup: function (fieldId, pivot) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Move field ${fieldId} before field group ${pivot}`);
         };
       },
       update: function (ctId) {
@@ -157,6 +230,32 @@ module.exports = {
 
           const withoutAnsiCodes = stripAnsi(result.stdout);
           expect(withoutAnsiCodes).to.include(`Update editor layout for content type ${ctId}`);
+        };
+      },
+      updateFieldGroup: function (fieldGroupId, params) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Update field group ${fieldGroupId}`);
+          if (params != null) {
+            return Object.keys(params).forEach((param) => {
+              expect(withoutAnsiCodes).to.include(`- ${param}: ${JSON.stringify(params[param])}`);
+            });
+          }
+        };
+      },
+      updateGroupControls: function (fieldGroupId, widgetNamespace, widgetId, settings) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Update group controls for field group ${fieldGroupId}`);
+          expect(withoutAnsiCodes).to.include(`- widgetId: ${JSON.stringify(widgetId)}`);
+          expect(withoutAnsiCodes).to.include(`- widgetNamespace: ${JSON.stringify(widgetNamespace)}`);
+          if (settings) {
+            expect(withoutAnsiCodes).to.include(`- settings: ${JSON.stringify(settings)}`);
+          }
         };
       }
     },

--- a/test/end-to-end/assertions.js
+++ b/test/end-to-end/assertions.js
@@ -2,7 +2,6 @@
 
 const stripAnsi = require('strip-ansi');
 const { expect } = require('chai');
-const chalk = require('chalk');
 
 module.exports = {
   errors: {

--- a/test/end-to-end/assertions.js
+++ b/test/end-to-end/assertions.js
@@ -126,6 +126,40 @@ module.exports = {
         };
       }
     },
+    editorLayout: {
+      create: function (ctId, params) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Create editor layout for content type ${ctId}`);
+        };
+      },
+      delete: function (ctId) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Delete editor layout for content type ${ctId}`);
+        };
+      },
+      deleteFieldGroup: function (ctId, fieldGroupId) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Delete field group ${fieldGroupId} in editor layout for content type ${ctId}`);
+        };
+      },
+      update: function (ctId) {
+        return result => {
+          expect(result.stdout).not.to.be.empty();
+
+          const withoutAnsiCodes = stripAnsi(result.stdout);
+          expect(withoutAnsiCodes).to.include(`Update editor layout for content type ${ctId}`);
+        };
+      }
+    },
     field: {
       create: function (id, params) {
         return result => {

--- a/test/end-to-end/editor-layout.spec.js
+++ b/test/end-to-end/editor-layout.spec.js
@@ -35,6 +35,21 @@ describe('apply editor layout migration examples', function () {
       .expect(assert.plans.field.create('title', { type: 'Symbol', name: 'Page title' }))
       .expect(assert.plans.editorLayout.create('page'))
       .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.createFieldGroup('content'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('content', { name: 'Content' }))
+      .expect(assert.plans.editorLayout.updateGroupControls('content', 'builtin', 'topLevelTab', {
+        helpText: 'Main content'
+      }))
+      .expect(assert.plans.editorLayout.createFieldGroup('settings'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('settings', { name: 'Settings' }))
+      .expect(assert.plans.editorLayout.createFieldGroupInParent('seo', 'settings'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('seo', { name: 'SEO' }))
+      .expect(assert.plans.editorLayout.updateGroupControls('seo', 'builtin', 'fieldset', {
+        helpText: 'Search related fields',
+        collapsedByDefault: false
+      }))
+      .expect(assert.plans.editorLayout.createFieldGroup('metadata'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('metadata', { name: 'Metadata' }))
       .expect(assert.plans.actions.abort())
       .end(done);
   });
@@ -47,6 +62,21 @@ describe('apply editor layout migration examples', function () {
       .expect(assert.plans.field.create('title', { type: 'Symbol', name: 'Page title' }))
       .expect(assert.plans.editorLayout.create('page'))
       .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.createFieldGroup('content'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('content', { name: 'Content' }))
+      .expect(assert.plans.editorLayout.updateGroupControls('content', 'builtin', 'topLevelTab', {
+        helpText: 'Main content'
+      }))
+      .expect(assert.plans.editorLayout.createFieldGroup('settings'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('settings', { name: 'Settings' }))
+      .expect(assert.plans.editorLayout.createFieldGroupInParent('seo', 'settings'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('seo', { name: 'SEO' }))
+      .expect(assert.plans.editorLayout.updateGroupControls('seo', 'builtin', 'fieldset', {
+        helpText: 'Search related fields',
+        collapsedByDefault: false
+      }))
+      .expect(assert.plans.editorLayout.createFieldGroup('metadata'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('metadata', { name: 'Metadata' }))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
@@ -104,7 +134,11 @@ describe('apply editor layout migration examples', function () {
     cli()
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-tab.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
-      .expect(assert.plans.editorLayout.deleteFieldGroup('page', 'settings'))
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('settings'))
+      .expect(assert.plans.editorLayout.createFieldGroup('toBeDeleted'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('toBeDeleted', { name: 'To be deleted' }))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('toBeDeleted'))
       .expect(assert.plans.actions.abort())
       .end(done);
   });
@@ -112,7 +146,11 @@ describe('apply editor layout migration examples', function () {
     cli()
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-tab.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
-      .expect(assert.plans.editorLayout.deleteFieldGroup('page', 'settings'))
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('settings'))
+      .expect(assert.plans.editorLayout.createFieldGroup('toBeDeleted'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('toBeDeleted', { name: 'To be deleted' }))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('toBeDeleted'))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
@@ -141,6 +179,10 @@ describe('apply editor layout migration examples', function () {
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-field-set.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
       .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.createFieldGroup('toBeDeleted'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('toBeDeleted', { name: 'To be deleted' }))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('toBeDeleted'))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('seo'))
       .expect(assert.plans.actions.abort())
       .end(done);
   });
@@ -149,6 +191,10 @@ describe('apply editor layout migration examples', function () {
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-field-set.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
       .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.createFieldGroup('toBeDeleted'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('toBeDeleted', { name: 'To be deleted' }))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('toBeDeleted'))
+      .expect(assert.plans.editorLayout.deleteFieldGroup('seo'))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
@@ -173,6 +219,7 @@ describe('apply editor layout migration examples', function () {
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-change-field-group-id-editor-layout.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
       .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.changeFieldGroupId('metadata', 'info'))
       .expect(assert.plans.actions.abort())
       .end(done);
   });
@@ -181,6 +228,7 @@ describe('apply editor layout migration examples', function () {
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-change-field-group-id-editor-layout.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
       .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.editorLayout.changeFieldGroupId('metadata', 'info'))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
@@ -234,6 +282,17 @@ describe('apply editor layout migration examples', function () {
       .expect(assert.plans.field.create('fieldE', { type: 'Symbol', name: 'Field D' }))
       .expect(assert.plans.editorLayout.create('mytype'))
       .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.editorLayout.createFieldGroup('firsttab'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('firsttab', { name: 'First Tab' }))
+      .expect(assert.plans.editorLayout.createFieldGroup('secondtab'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('secondtab', { name: 'Second Tab' }))
+      .expect(assert.plans.editorLayout.createFieldGroupInParent('fieldset', 'secondtab'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('fieldset', { name: 'Field Set' }))
+      .expect(assert.plans.editorLayout.moveFieldToTheFirstPositionInFieldGroup('fieldA', 'fieldset'))
+      .expect(assert.plans.editorLayout.moveFieldBeforeFieldGroup('fieldB', 'fieldset'))
+      .expect(assert.plans.editorLayout.moveFieldAfterField('fieldC', 'fieldA'))
+      .expect(assert.plans.editorLayout.moveFieldBeforeField('fieldE', 'fieldC'))
+      .expect(assert.plans.editorLayout.moveFieldToTheLastPositionInFieldGroup('fieldE'))
       .expect(assert.plans.actions.abort())
       .end(done);
   });
@@ -249,6 +308,17 @@ describe('apply editor layout migration examples', function () {
       .expect(assert.plans.field.create('fieldE', { type: 'Symbol', name: 'Field D' }))
       .expect(assert.plans.editorLayout.create('mytype'))
       .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.editorLayout.createFieldGroup('firsttab'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('firsttab', { name: 'First Tab' }))
+      .expect(assert.plans.editorLayout.createFieldGroup('secondtab'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('secondtab', { name: 'Second Tab' }))
+      .expect(assert.plans.editorLayout.createFieldGroupInParent('fieldset', 'secondtab'))
+      .expect(assert.plans.editorLayout.updateFieldGroup('fieldset', { name: 'Field Set' }))
+      .expect(assert.plans.editorLayout.moveFieldToTheFirstPositionInFieldGroup('fieldA', 'fieldset'))
+      .expect(assert.plans.editorLayout.moveFieldBeforeFieldGroup('fieldB', 'fieldset'))
+      .expect(assert.plans.editorLayout.moveFieldAfterField('fieldC', 'fieldA'))
+      .expect(assert.plans.editorLayout.moveFieldBeforeField('fieldE', 'fieldC'))
+      .expect(assert.plans.editorLayout.moveFieldToTheLastPositionInFieldGroup('fieldE'))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'mytype');
@@ -280,6 +350,11 @@ describe('apply editor layout migration examples', function () {
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-move-field-in-existing-editor-layout.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
       .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.editorLayout.moveFieldToTheFirstPositionInFieldGroup('fieldA', 'firsttab'))
+      .expect(assert.plans.editorLayout.moveFieldAfterFieldGroup('fieldB', 'fieldset'))
+      .expect(assert.plans.editorLayout.moveFieldAfterField('fieldC', 'fieldB'))
+      .expect(assert.plans.editorLayout.moveFieldBeforeField('fieldE', 'fieldC'))
+      .expect(assert.plans.editorLayout.moveFieldToTheLastPositionInFieldGroup('fieldE'))
       .expect(assert.plans.actions.abort())
       .end(done);
   });
@@ -288,6 +363,11 @@ describe('apply editor layout migration examples', function () {
       .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-move-field-in-existing-editor-layout.js`)
       .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
       .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.editorLayout.moveFieldToTheFirstPositionInFieldGroup('fieldA', 'firsttab'))
+      .expect(assert.plans.editorLayout.moveFieldAfterFieldGroup('fieldB', 'fieldset'))
+      .expect(assert.plans.editorLayout.moveFieldAfterField('fieldC', 'fieldB'))
+      .expect(assert.plans.editorLayout.moveFieldBeforeField('fieldE', 'fieldC'))
+      .expect(assert.plans.editorLayout.moveFieldToTheLastPositionInFieldGroup('fieldE'))
       .expect(assert.plans.actions.apply())
       .end(co(function * () {
         const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'mytype');

--- a/test/end-to-end/editor-layout.spec.js
+++ b/test/end-to-end/editor-layout.spec.js
@@ -1,0 +1,318 @@
+'use strict';
+
+const Bluebird = require('bluebird');
+const co = Bluebird.coroutine;
+
+const { createDevEnvironment, deleteDevEnvironment, getDevEditorInterface } = require('../helpers/client');
+
+const uuid = require('uuid');
+const cli = require('./cli');
+const assert = require('./assertions');
+const { expect } = require('chai');
+const ENVIRONMENT_ID = uuid.v4();
+
+const SOURCE_TEST_SPACE = process.env.CONTENTFUL_SPACE_ID;
+
+describe('apply editor layout migration examples', function () {
+  this.timeout(30000);
+  let environmentId;
+
+  before(co(function * () {
+    this.timeout(30000);
+    environmentId = yield createDevEnvironment(SOURCE_TEST_SPACE, ENVIRONMENT_ID);
+  }));
+
+  after(co(function * () {
+    yield deleteDevEnvironment(SOURCE_TEST_SPACE, environmentId);
+  }));
+
+  it('aborts xx-create-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-create-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.contentType.create('page', { name: 'Page' }))
+      .expect(assert.plans.field.create('name', { type: 'Symbol', name: 'Internal name' }))
+      .expect(assert.plans.field.create('title', { type: 'Symbol', name: 'Page title' }))
+      .expect(assert.plans.editorLayout.create('page'))
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-create-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-create-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.contentType.create('page', { name: 'Page' }))
+      .expect(assert.plans.field.create('name', { type: 'Symbol', name: 'Internal name' }))
+      .expect(assert.plans.field.create('title', { type: 'Symbol', name: 'Page title' }))
+      .expect(assert.plans.editorLayout.create('page'))
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
+        expect(editorInterfaces.editorLayout).to.eql([
+          {
+            groupId: 'content',
+            name: 'Content',
+            items: [{ fieldId: 'name' }, { fieldId: 'title' }]
+          },
+          {
+            groupId: 'settings',
+            name: 'Settings',
+            items: [{ groupId: 'seo', name: 'SEO', items: [] }]
+          },
+          {
+            groupId: 'metadata',
+            name: 'Metadata',
+            items: []
+          }
+        ]);
+        expect(editorInterfaces.groupControls).to.eql([
+          {
+            groupId: 'content',
+            widgetId: 'topLevelTab',
+            widgetNamespace: 'builtin',
+            settings: {
+              helpText: 'Main content'
+            }
+          },
+          {
+            groupId: 'settings',
+            widgetId: 'topLevelTab',
+            widgetNamespace: 'builtin'
+          },
+          {
+            groupId: 'seo',
+            widgetId: 'fieldset',
+            widgetNamespace: 'builtin',
+            settings: {
+              helpText: 'Search related fields',
+              collapsedByDefault: false
+            }
+          },
+          {
+            groupId: 'metadata',
+            widgetId: 'topLevelTab',
+            widgetNamespace: 'builtin'
+          }
+        ]);
+        done();
+      }));
+  });
+
+  it('aborts xx-delete-editor-layout-tab migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-tab.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.editorLayout.deleteFieldGroup('page', 'settings'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-delete-editor-layout-tab migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-tab.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.editorLayout.deleteFieldGroup('page', 'settings'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
+        expect(editorInterfaces.editorLayout).to.eql([
+          {
+            groupId: 'content',
+            name: 'Content',
+            items: [
+              { fieldId: 'name' },
+              { fieldId: 'title' },
+              { groupId: 'seo', name: 'SEO', items: [] }
+            ]
+          },
+          {
+            groupId: 'metadata',
+            name: 'Metadata',
+            items: []
+          }
+        ]);
+        done();
+      }));
+  });
+
+  it('aborts xx-delete-editor-layout-field-set migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-field-set.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-delete-editor-layout-field-set migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout-field-set.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
+        expect(editorInterfaces.editorLayout).to.eql([
+          {
+            groupId: 'content',
+            name: 'Content',
+            items: [{ fieldId: 'name' }, { fieldId: 'title' }]
+          },
+          {
+            groupId: 'metadata',
+            name: 'Metadata',
+            items: []
+          }
+        ]);
+        done();
+      }));
+  });
+
+  it('aborts xx-change-field-group-id-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-change-field-group-id-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-change-field-group-id-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-change-field-group-id-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.editorLayout.update('page'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
+        expect(editorInterfaces.editorLayout).to.eql([
+          {
+            groupId: 'content',
+            name: 'Content',
+            items: [{ fieldId: 'name' }, { fieldId: 'title' }]
+          },
+          {
+            groupId: 'info',
+            name: 'Metadata',
+            items: []
+          }
+        ]);
+        done();
+      }));
+  });
+
+  it('aborts xx-delete-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.editorLayout.delete('page'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-delete-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-delete-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.editorLayout.delete('page'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'page');
+        expect(editorInterfaces.editorLayout).to.be.undefined();
+        expect(editorInterfaces.groupControls).to.be.undefined();
+        done();
+      }));
+  });
+
+  it('aborts xx-move-field-in-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-move-field-in-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.contentType.create('mytype', { name: 'My type' }))
+      .expect(assert.plans.field.create('fieldA', { type: 'Symbol', name: 'Field A' }))
+      .expect(assert.plans.field.create('fieldB', { type: 'Symbol', name: 'Field B' }))
+      .expect(assert.plans.field.create('fieldC', { type: 'Symbol', name: 'Field C' }))
+      .expect(assert.plans.field.create('fieldD', { type: 'Symbol', name: 'Field D' }))
+      .expect(assert.plans.field.create('fieldE', { type: 'Symbol', name: 'Field D' }))
+      .expect(assert.plans.editorLayout.create('mytype'))
+      .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-move-field-in-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-move-field-in-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.contentType.create('mytype', { name: 'My type' }))
+      .expect(assert.plans.field.create('fieldA', { type: 'Symbol', name: 'Field A' }))
+      .expect(assert.plans.field.create('fieldB', { type: 'Symbol', name: 'Field B' }))
+      .expect(assert.plans.field.create('fieldC', { type: 'Symbol', name: 'Field C' }))
+      .expect(assert.plans.field.create('fieldD', { type: 'Symbol', name: 'Field D' }))
+      .expect(assert.plans.field.create('fieldE', { type: 'Symbol', name: 'Field D' }))
+      .expect(assert.plans.editorLayout.create('mytype'))
+      .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'mytype');
+        expect(editorInterfaces.editorLayout).to.eql([
+          {
+            name: 'First Tab',
+            items: [{ fieldId: 'fieldD' }],
+            groupId: 'firsttab'
+          },
+          {
+            name: 'Second Tab',
+            items: [
+              { fieldId: 'fieldB' },
+              {
+                name: 'Field Set',
+                items: [{ fieldId: 'fieldA' }, { fieldId: 'fieldC' }, { fieldId: 'fieldE' }],
+                groupId: 'fieldset'
+              }
+            ],
+            groupId: 'secondtab'
+          }
+        ]);
+        done();
+      }));
+  });
+
+  it('aborts xx-move-field-in-existing-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-move-field-in-existing-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('n\n')
+      .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.actions.abort())
+      .end(done);
+  });
+  it('applies xx-move-field-in-existing-editor-layout migration', function (done) {
+    cli()
+      .run(`--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/xx-move-field-in-existing-editor-layout.js`)
+      .on(/\? Do you want to apply the migration \(Y\/n\)/).respond('y\n')
+      .expect(assert.plans.editorLayout.update('mytype'))
+      .expect(assert.plans.actions.apply())
+      .end(co(function * () {
+        const editorInterfaces = yield getDevEditorInterface(SOURCE_TEST_SPACE, environmentId, 'mytype');
+        expect(editorInterfaces.editorLayout).to.eql([
+          {
+            name: 'First Tab',
+            items: [{ fieldId: 'fieldA' }, { fieldId: 'fieldD' }],
+            groupId: 'firsttab'
+          },
+          {
+            name: 'Second Tab',
+            items: [
+              {
+                name: 'Field Set',
+                items: [],
+                groupId: 'fieldset'
+              },
+              { fieldId: 'fieldB' },
+              { fieldId: 'fieldC' },
+              { fieldId: 'fieldE' }
+            ],
+            groupId: 'secondtab'
+          }
+        ]);
+        done();
+      }));
+  });
+});

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -29,7 +29,8 @@ const modifyTag = require('../../examples/29-modify-tag');
 const deleteTag = require('../../examples/30-delete-tag');
 const setTagsForEntries = require('../../examples/31-set-tags-for-entries');
 const createEditorLayout = require('../../examples/xx-create-editor-layout');
-const moveFieldInEditorLayout = require('../../examples/xx-move-field-in-editor-layout');
+const moveFieldInExistingEditorLayout = require('../../examples/xx-move-field-in-existing-editor-layout');
+const moveFieldInNewEditorLayout = require('../../examples/xx-move-field-in-editor-layout');
 const deleteEditorLayoutFieldSet = require('../../examples/xx-delete-editor-layout-field-set');
 const changeFieldGroupId = require('../../examples/xx-change-field-group-id-editor-layout');
 const deleteEditorLayout = require('../../examples/xx-delete-editor-layout');
@@ -1027,8 +1028,8 @@ describe('the migration', function () {
     expect(editorInterface.groupControls).to.be.undefined();
   });
 
-  it('moves fields in editor layout', async function () {
-    await migrator(moveFieldInEditorLayout);
+  it('moves fields in newly created editor layout', async function () {
+    await migrator(moveFieldInNewEditorLayout);
 
     const editorInterface = await request({
       method: 'GET',
@@ -1050,6 +1051,37 @@ describe('the migration', function () {
             items: [{ fieldId: 'fieldA' }, { fieldId: 'fieldC' }, { fieldId: 'fieldE' }],
             groupId: 'fieldset'
           }
+        ],
+        groupId: 'secondtab'
+      }
+    ]);
+  });
+
+  it('moves fields in existing editor layout', async function () {
+    await migrator(moveFieldInExistingEditorLayout);
+
+    const editorInterface = await request({
+      method: 'GET',
+      url: '/content_types/mytype/editor_interface'
+    });
+
+    expect(editorInterface.editorLayout).to.eql([
+      {
+        name: 'First Tab',
+        items: [{ fieldId: 'fieldA' }, { fieldId: 'fieldD' }],
+        groupId: 'firsttab'
+      },
+      {
+        name: 'Second Tab',
+        items: [
+          {
+            name: 'Field Set',
+            items: [],
+            groupId: 'fieldset'
+          },
+          { fieldId: 'fieldB' },
+          { fieldId: 'fieldC' },
+          { fieldId: 'fieldE' }
         ],
         groupId: 'secondtab'
       }

--- a/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
+++ b/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
@@ -156,7 +156,7 @@ describe('editor layout plan validation', function () {
 
       const errors = await validateChunks(function (migration) {
         const Page = migration.editContentType('page');
-        const editorLayout = Page.createEditorLayout();
+        const editorLayout = Page.editEditorLayout();
 
         editorLayout.deleteFieldGroup('content');
         editorLayout.deleteFieldGroup('content');


### PR DESCRIPTION
## Summary

Update field grouping migration.

## Description

* Add E2E tests
* Unify and group field grouping plan messages
* Fix: fetch content type when moving fields for field ID validation
* Fix: allow deleting a newly created field group
* Fix: throw error when attempting to create an editor layout if it already exists

## Motivation and Context

We added the field grouping migration in multiple steps. Instead of creating overhead by iterating on the output several times this PR aligns the output and adds matching E2E tests after finishing the functionality.
