### PR TITLE
feat: add more field group ID / name validation

### DIFF
--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -34,6 +34,14 @@ export default abstract class Intent implements IntentInterface {
     return this.payload.fieldGroupId
   }
 
+  getNewFieldGroupId () {
+    return this.payload.newFieldGroupId
+  }
+
+  getFieldGroupProps () {
+    return this.payload.fieldGroupProps
+  }
+
   requiresAllEntries () {
     return false
   }
@@ -123,6 +131,18 @@ export default abstract class Intent implements IntentInterface {
   }
 
   isFieldGroupDelete () {
+    return false
+  }
+
+  isFieldGroupUpdate () {
+    return false
+  }
+
+  isFieldGroupIdChange () {
+    return false
+  }
+
+  isFieldGroupControlChange () {
     return false
   }
 

--- a/src/lib/intent/composed-intent.ts
+++ b/src/lib/intent/composed-intent.ts
@@ -175,6 +175,14 @@ export default class ComposedIntent implements Intent {
     return null
   }
 
+  getNewFieldGroupId (): string {
+    return null
+  }
+
+  getFieldGroupProps () {
+    return null
+  }
+
   isEditorLayoutCreate (): boolean {
     return false
   }
@@ -192,6 +200,18 @@ export default class ComposedIntent implements Intent {
   }
 
   isFieldGroupDelete (): boolean {
+    return false
+  }
+
+  isFieldGroupUpdate (): boolean {
+    return false
+  }
+
+  isFieldGroupIdChange (): boolean {
+    return false
+  }
+
+  isFieldGroupControlChange (): boolean {
     return false
   }
 

--- a/src/lib/intent/editor-layout/editor-layout-change-field-group-control.ts
+++ b/src/lib/intent/editor-layout/editor-layout-change-field-group-control.ts
@@ -11,6 +11,9 @@ export default class EditorLayoutChangeFieldGroupControlIntent extends Intent {
   isEditorLayoutUpdate () {
     return true
   }
+  isFieldGroupControlChange () {
+    return true
+  }
   isGroupable () {
     return true
   }

--- a/src/lib/intent/editor-layout/editor-layout-change-field-group-id.ts
+++ b/src/lib/intent/editor-layout/editor-layout-change-field-group-id.ts
@@ -10,6 +10,9 @@ export default class EditorLayoutChangeFieldGroupIdIntent extends Intent {
   isEditorLayoutUpdate () {
     return true
   }
+  isFieldGroupIdChange () {
+    return true
+  }
   isGroupable () {
     return true
   }

--- a/src/lib/intent/editor-layout/editor-layout-update-field-group.ts
+++ b/src/lib/intent/editor-layout/editor-layout-update-field-group.ts
@@ -11,6 +11,9 @@ export default class EditorLayoutUpdateFieldGroupIntent extends Intent {
   isEditorLayoutUpdate () {
     return true
   }
+  isFieldGroupUpdate () {
+    return true
+  }
   isGroupable () {
     return true
   }

--- a/src/lib/interfaces/intent.ts
+++ b/src/lib/interfaces/intent.ts
@@ -9,6 +9,8 @@ interface Intent {
   getRelatedContentTypeIds (): string[]
   getFieldId (): string
   getFieldGroupId (): string
+  getNewFieldGroupId (): string
+  getFieldGroupProps (): { [prop: string]: string }
   getRawType (): string
   getTagId (): string
 
@@ -46,6 +48,9 @@ interface Intent {
   isEditorLayoutUpdate (): boolean
   isFieldGroupCreate (): boolean
   isFieldGroupDelete (): boolean
+  isFieldGroupUpdate (): boolean
+  isFieldGroupIdChange (): boolean
+  isFieldGroupControlChange (): boolean
 
   isComposedIntent (): boolean
 

--- a/src/lib/migration-chunks/validation/errors.ts
+++ b/src/lib/migration-chunks/validation/errors.ts
@@ -169,6 +169,21 @@ const errorCreators: ErrorCreators = {
       },
       FIELD_GROUP_ALREADY_EXISTS: (id, ctId) => {
         return `Field group with id "${id}" for content type "${ctId}" already exists.`
+      },
+      FIELD_GROUP_DOES_NOT_EXIST: (fieldGroupId) => {
+        return `Field group "${fieldGroupId}" does not exist`
+      },
+      INVALID_CHARACTER_IN_ID: (id, ctId) => {
+        return `Field group id "${id}" for content type "${ctId}" must consist of only letters and numbers.`
+      },
+      INVALID_FIRST_CHARACTER_IN_ID: (id, ctId) => {
+        return `Field group id "${id}" for content type "${ctId}" must start with a letter.`
+      },
+      ID_TOO_LONG: (id, ctId) => {
+        return `Field group id "${id}" for content type "${ctId}" must not exceed 50 characters.`
+      },
+      NAME_TOO_LONG: (id, ctId) => {
+        return `Name for field group with id "${id}" for content type "${ctId}" must not exceed 50 characters.`
       }
     },
     moveField: {
@@ -214,6 +229,11 @@ const errorCreators: ErrorCreators = {
       },
       MISSING_NEW_FIELD_GROUP: (id) => {
         return `New id for field group "${id}" not specified`
+      }
+    },
+    changeFieldGroupControl: {
+      FIELD_GROUP_DOES_NOT_EXIST: (fieldGroupId) => {
+        return `Field group "${fieldGroupId}" does not exist.`
       }
     }
   },

--- a/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
+++ b/test/unit/lib/migration-chunks/validation/editor-layout.spec.js
@@ -6,98 +6,383 @@ const { expect } = require('chai');
 const validateChunks = require('./validate-chunks').default;
 
 describe('editor layout plan validation', function () {
-  describe('when creating a field group with the same id twice', function () {
-    it('returns an error', async function () {
-      const contentTypes = [{
-        sys: { id: 'page' }
-      }];
+  describe('create field group', function () {
+    describe('when creating a field group with the same id twice', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
 
-      const errors = await validateChunks(function (migration) {
-        const Page = migration.editContentType('page');
-        const editorLayout = Page.createEditorLayout();
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.createEditorLayout();
 
-        editorLayout
-          .createFieldGroup('content', {
-            name: 'Content'
-          });
+          editorLayout
+            .createFieldGroup('content', {
+              name: 'Content'
+            });
 
-        editorLayout
-          .createFieldGroup('content', {
-            name: 'Content'
-          });
-      }, contentTypes);
+          editorLayout
+            .createFieldGroup('content', {
+              name: 'Content'
+            });
+        }, contentTypes);
 
-      expect(errors).to.eql([
-        {
-          type: 'InvalidAction',
-          message: 'Field group with id "content" for content type "page" cannot be created more than once.',
-          details: {
-            step: {
-              type: 'contentType/createEditorLayoutFieldGroup',
-              meta: {
-                contentTypeInstanceId: 'contentType/page/0'
-              },
-              payload: {
-                contentTypeId: 'page',
-                fieldGroupId: 'content',
-                parentFieldGroupId: undefined
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group with id "content" for content type "page" cannot be created more than once.',
+            details: {
+              step: {
+                type: 'contentType/createEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  parentFieldGroupId: undefined
+                }
               }
             }
           }
-        }
-      ]);
+        ]);
+      });
+    });
+    describe('when creating a field group that already exists', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
+
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: [
+              {
+                groupId: 'content',
+                name: 'Content',
+                items: []
+              }
+            ]
+          }
+        };
+
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout
+            .createFieldGroup('content', {
+              name: 'Content'
+            });
+        }, contentTypes, [], editorInterfaces);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group with id "content" for content type "page" already exists.',
+            details: {
+              step: {
+                type: 'contentType/createEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  parentFieldGroupId: undefined
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID contains invalid character', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
+
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: []
+          }
+        };
+
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout
+            .createFieldGroup('group with wrong character', {
+              name: 'Content'
+            });
+        }, contentTypes, [], editorInterfaces);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "group with wrong character" for content type "page" must consist of only letters and numbers.',
+            details: {
+              step: {
+                type: 'contentType/createEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'group with wrong character',
+                  parentFieldGroupId: undefined
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID is empty', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
+
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: []
+          }
+        };
+
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout
+            .createFieldGroup('', {
+              name: 'Content'
+            });
+        }, contentTypes, [], editorInterfaces);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "" for content type "page" must consist of only letters and numbers.',
+            details: {
+              step: {
+                type: 'contentType/createEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: '',
+                  parentFieldGroupId: undefined
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID starts with number', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
+
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: []
+          }
+        };
+
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout
+            .createFieldGroup('1group', {
+              name: 'Content'
+            });
+        }, contentTypes, [], editorInterfaces);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "1group" for content type "page" must start with a letter.',
+            details: {
+              step: {
+                type: 'contentType/createEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: '1group',
+                  parentFieldGroupId: undefined
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID is too long', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
+
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: []
+          }
+        };
+
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout
+            .createFieldGroup('fieldGroupWithIdThatContainsTheRightCharactersButIsTooLong', {
+              name: 'Content'
+            });
+        }, contentTypes, [], editorInterfaces);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "fieldGroupWithIdThatContainsTheRightCharactersButIsTooLong" for content type "page" must not exceed 50 characters.',
+            details: {
+              step: {
+                type: 'contentType/createEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'fieldGroupWithIdThatContainsTheRightCharactersButIsTooLong',
+                  parentFieldGroupId: undefined
+                }
+              }
+            }
+          }
+        ]);
+      });
     });
   });
-  describe('when creating a field group that already exists', function () {
-    it('returns an error', async function () {
-      const contentTypes = [{
-        sys: { id: 'page' }
-      }];
+  describe('update field group', function () {
+    describe('when field group name is too long', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
 
-      const editorInterfaces = {
-        page: {
-          sys: {
-            version: 1
-          },
-          editorLayout: [
-            {
-              groupId: 'content',
-              name: 'Content',
-              items: []
-            }
-          ]
-        }
-      };
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: []
+          }
+        };
 
-      const errors = await validateChunks(function (migration) {
-        const Page = migration.editContentType('page');
-        const editorLayout = Page.editEditorLayout();
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
 
-        editorLayout
-          .createFieldGroup('content', {
-            name: 'Content'
-          });
-      }, contentTypes, [], editorInterfaces);
+          editorLayout
+            .createFieldGroup('content', {
+              name: 'Field group name that is indeed quite a bit too long'
+            });
+        }, contentTypes, [], editorInterfaces);
 
-      expect(errors).to.eql([
-        {
-          type: 'InvalidAction',
-          message: 'Field group with id "content" for content type "page" already exists.',
-          details: {
-            step: {
-              type: 'contentType/createEditorLayoutFieldGroup',
-              meta: {
-                contentTypeInstanceId: 'contentType/page/0'
-              },
-              payload: {
-                contentTypeId: 'page',
-                fieldGroupId: 'content',
-                parentFieldGroupId: undefined
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Name for field group with id "content" for content type "page" must not exceed 50 characters.',
+            details: {
+              step: {
+                type: 'contentType/updateEditorLayoutFieldGroup',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  fieldGroupProps: {
+                    name: 'Field group name that is indeed quite a bit too long'
+                  }
+                }
               }
             }
           }
-        }
-      ]);
+        ]);
+      });
+    });
+  });
+  describe('change field group control', function () {
+    describe('when field group ID does not exist', function () {
+      it('returns an error', async function () {
+        const contentTypes = [{
+          sys: { id: 'page' }
+        }];
+
+        const editorInterfaces = {
+          page: {
+            sys: {
+              version: 1
+            },
+            editorLayout: []
+          }
+        };
+
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupControl('content', 'builtin', 'topLevelTab');
+        }, contentTypes, [], editorInterfaces);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group "content" does not exist.',
+            details: {
+              step: {
+                type: 'contentType/updateGroupControl',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  groupControl: {
+                    settings: undefined,
+                    widgetId: 'topLevelTab',
+                    widgetNamespace: 'builtin'
+                  }
+                }
+              }
+            }
+          }
+        ]);
+      });
     });
   });
   describe('when deleting a field group that doesn\'t exist', function () {
@@ -424,6 +709,126 @@ describe('editor layout plan validation', function () {
         ]);
       });
     });
+    describe('when field group ID contains invalid character', function () {
+      it('returns an error', async function () {
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupId('content', 'group with wrong character');
+        }, testCts, [], testEis);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "group with wrong character" for content type "page" must consist of only letters and numbers.',
+            details: {
+              step: {
+                type: 'contentType/changeEditorLayoutFieldGroupId',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  newFieldGroupId: 'group with wrong character'
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID is empty', function () {
+      it('returns an error', async function () {
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupId('content', '');
+        }, testCts, [], testEis);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "" for content type "page" must consist of only letters and numbers.',
+            details: {
+              step: {
+                type: 'contentType/changeEditorLayoutFieldGroupId',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  newFieldGroupId: ''
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID starts with number', function () {
+      it('returns an error', async function () {
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupId('content', '1group');
+        }, testCts, [], testEis);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "1group" for content type "page" must start with a letter.',
+            details: {
+              step: {
+                type: 'contentType/changeEditorLayoutFieldGroupId',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  newFieldGroupId: '1group'
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
+    describe('when field group ID is too long', function () {
+      it('returns an error', async function () {
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupId('content', 'fieldGroupWithIdThatContainsTheRightCharactersButIsTooLong');
+        }, testCts, [], testEis);
+
+        expect(errors).to.eql([
+          {
+            type: 'InvalidAction',
+            message: 'Field group id "fieldGroupWithIdThatContainsTheRightCharactersButIsTooLong" for content type "page" must not exceed 50 characters.',
+            details: {
+              step: {
+                type: 'contentType/changeEditorLayoutFieldGroupId',
+                meta: {
+                  contentTypeInstanceId: 'contentType/page/0'
+                },
+                payload: {
+                  contentTypeId: 'page',
+                  fieldGroupId: 'content',
+                  newFieldGroupId: 'fieldGroupWithIdThatContainsTheRightCharactersButIsTooLong'
+                }
+              }
+            }
+          }
+        ]);
+      });
+    });
     describe('when renaming is valid', () => {
       it('succeeds', async () => {
         const errors = await validateChunks(function (migration) {
@@ -431,6 +836,46 @@ describe('editor layout plan validation', function () {
           const editorLayout = Page.editEditorLayout();
 
           editorLayout.changeFieldGroupId('content', 'main');
+        }, testCts, [], testEis);
+        expect(errors).to.eql([]);
+      });
+      it('registers new ID for validation', async () => {
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupId('content', 'main');
+          editorLayout.changeFieldGroupId('main', 'main');
+        }, testCts, [], testEis);
+        expect(errors).to.eql(
+          [
+            {
+              message: 'New field group id "main" is the same as original',
+              type: 'InvalidAction',
+              details: {
+                step: {
+                  meta: {
+                    contentTypeInstanceId: 'contentType/page/0'
+                  },
+                  payload: {
+                    contentTypeId: 'page',
+                    fieldGroupId: 'main',
+                    newFieldGroupId: 'main'
+                  },
+                  type: 'contentType/changeEditorLayoutFieldGroupId'
+                }
+              }
+            }
+          ]
+        );
+      });
+      it('deregisters old ID for validation', async () => {
+        const errors = await validateChunks(function (migration) {
+          const Page = migration.editContentType('page');
+          const editorLayout = Page.editEditorLayout();
+
+          editorLayout.changeFieldGroupId('content', 'main');
+          editorLayout.createFieldGroup('content', { name: 'Content' });
         }, testCts, [], testEis);
         expect(errors).to.eql([]);
       });


### PR DESCRIPTION
## Summary

Add more validations for field group IDs and names to field grouping migration.

## Description

* Validate field group ID format when creating field group or changing field group ID
* Validate field group name length when updating field group
* Check if field group exists when changing group controls
* Update field group IDs used for validation when changing field group ID
