### PR TITLE
feat: add entry id in the transformEntries field

### DIFF
--- a/src/lib/action/entry-transform.ts
+++ b/src/lib/action/entry-transform.ts
@@ -28,7 +28,7 @@ class EntryTransformAction extends APIAction {
     const entries: Entry[] = await api.getEntriesForContentType(this.contentTypeId)
     const locales: string[] = await api.getLocalesForSpace()
     for (const entry of entries) {
-      const inputs = _.pick(entry.fields, this.fromFields)
+      const inputs = _.pick({id: entry.id, ...entry.fields}, this.fromFields)
       let changesForThisEntry = false
       for (const locale of locales) {
         let outputsForCurrentLocale


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Add entry id in the `transformEntries` function.

<!-- Give a short summary what your PR is introducing/fixing. -->

This pull request adds the possibility to select the entry id in the `transformEntries` function, retrieving it in the `fromFields` parameter. The goal is to able to use the id to transform entries, for example in the context of using a CSV file with entries ID and the values that need to be set for each entry on a specific field.

<!-- Describe your changes in detail -->

## Motivation and Context

An issue on the subject is open.
https://github.com/contentful/contentful-migration/issues/1029