### PR TITLE
Export type declarations to support use as library

### DIFF
--- a/tsconfig-dev.json
+++ b/tsconfig-dev.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "esModuleInterop":true,
     "module": "commonjs",
+    "declaration": true,
     "lib": [
       "es2015",
       "es2016",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "esModuleInterop":true,
     "module": "commonjs",
+    "declaration": true,
     "lib": [
       "es2015",
       "es2016",


### PR DESCRIPTION
## Summary

Add the `"declaration": true` flag to tsconfig.json and tsconfig-dev.json.

## Description

This flag instructs the typescript compiler to output .d.ts files alongside the javascript in `built`. These can be used by typescript projects that consume contentful-migration as a dependency.

## Motivation and Context

I'm working on updates to deluan/contentful-migrate right now, and am
finding that I need to recreate a lot of type information that already
exists in this library. In addition to being a lot of work, duplicating
that information makes my work fragile. It can easily become out of sync
when the types inside contentful-migration change.

If you add this flag, the type declarations (.d.ts files) will become
part of the npm package, letting me depend on them without rewriting
them by hand.

In #213, @chrislambe comments:
> It looks like the interface we want is defined [in the source]. Any
> reason we can't just use that instead of duplicating it?

The answer to his question is that the declarations are not made
available in the npm package. This PR will fix his problem as well as
mine.
