### PR TITLE
Fix/do not write errors to file when used as library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13046,9 +13046,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
     },
     "node_modules/side-channel": {
@@ -25245,9 +25245,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
     },
     "side-channel": {


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

We are using this package to migrate our content models. Whenever a runtime error occurs in one of our backends based on Lambda functions, the whole handler errors out because of an unhandled promise rejection caused by the Lambda's filesystem being mounted as readonly and thus not allowing the error files to be written.

## Description

In order to fix this issue, the PR adjusts two things:
- Error files will not be written in case the function is used as a library/imported from another location (`shouldThrow === true`).
- The writing of error files will be awaited so that any possible exception raised will not result in an unhandled promise rejection.

## Motivation and Context

When used as a library, the error files are probably irrelevant, except for debugging purposes, or might - as in our case - even be harmful, as depending on the runtime environment, no filesystem is available.

## Todos

This is rather a proposal than an actual finished implementation, as I do not have the time and knowledge, to build and verify the changes.

-   [x] Provide proposal
-   [ ] Verify implementation
-   [ ] Add/adjust tests
