### PR TITLE
fix(annotations): group annotate intents with ct and field updates

### DIFF
--- a/examples/46-can-set-display-field-before-annotations.js
+++ b/examples/46-can-set-display-field-before-annotations.js
@@ -1,0 +1,17 @@
+module.exports = function (migration) {
+  const annotatedContentType = migration
+    .createContentType('annotatedWithDisplayField')
+    .name('Blog Post')
+    .displayField('name')
+    .setAnnotations(['Contentful:AggregateRoot'])
+
+  annotatedContentType
+    .createField('name')
+    .name('name')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([{ unique: true }])
+    .disabled(false)
+    .omitted(false)
+}

--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -70,6 +70,10 @@ export default abstract class Intent implements IntentInterface {
     return false
   }
 
+  isContentTypeAnnotate() {
+    return false
+  }
+
   isFieldCreate() {
     return false
   }
@@ -168,11 +172,7 @@ export default abstract class Intent implements IntentInterface {
   }
 
   isAboutEditorLayout() {
-    return (
-      this.isEditorLayoutCreate() ||
-      this.isEditorLayoutDelete() ||
-      this.isEditorLayoutUpdate()
-    )
+    return this.isEditorLayoutCreate() || this.isEditorLayoutDelete() || this.isEditorLayoutUpdate()
   }
 
   isComposedIntent() {

--- a/src/lib/intent/content-type-annotate.ts
+++ b/src/lib/intent/content-type-annotate.ts
@@ -5,11 +5,16 @@ import { ContentTypeAnnotateAction } from '../action/content-type-annotate'
 import { AnnotationLink } from '../interfaces/annotation'
 
 export default class ContentTypeAnnotateIntent extends Intent {
+  isContentTypeAnnotate() {
+    return true
+  }
+
   groupsWith(other: Intent): boolean {
     const sameContentType = other.getContentTypeId() === this.getContentTypeId()
     return (
       (other.isContentTypeUpdate() ||
         other.isContentTypeCreate() ||
+        other.isContentTypeAnnotate() ||
         other.isFieldCreate() ||
         other.isFieldUpdate() ||
         other.isFieldMove()) &&

--- a/src/lib/intent/content-type-update.ts
+++ b/src/lib/intent/content-type-update.ts
@@ -14,6 +14,7 @@ export default class ContentTypeUpdateIntent extends Intent {
     return (
       (other.isContentTypeUpdate() ||
         other.isContentTypeCreate() ||
+        other.isContentTypeAnnotate() ||
         other.isFieldCreate() ||
         other.isFieldUpdate() ||
         other.isFieldMove()) &&

--- a/src/lib/intent/field-create.ts
+++ b/src/lib/intent/field-create.ts
@@ -13,6 +13,7 @@ export default class FieldCreateIntent extends Intent {
     return (
       (other.isContentTypeUpdate() ||
         other.isContentTypeCreate() ||
+        other.isContentTypeAnnotate() ||
         other.isFieldCreate() ||
         other.isFieldUpdate() ||
         other.isFieldMove()) &&

--- a/src/lib/intent/field-move.ts
+++ b/src/lib/intent/field-move.ts
@@ -13,6 +13,7 @@ export default class FieldMoveIntent extends Intent {
     return (
       (other.isContentTypeUpdate() ||
         other.isContentTypeCreate() ||
+        other.isContentTypeAnnotate() ||
         other.isFieldCreate() ||
         other.isFieldUpdate() ||
         other.isFieldMove()) &&

--- a/src/lib/intent/field-update.ts
+++ b/src/lib/intent/field-update.ts
@@ -14,6 +14,7 @@ export default class FieldUpdateIntent extends Intent {
     return (
       (other.isContentTypeUpdate() ||
         other.isContentTypeCreate() ||
+        other.isContentTypeAnnotate() ||
         other.isFieldCreate() ||
         other.isFieldUpdate() ||
         other.isFieldMove()) &&

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -35,6 +35,7 @@ const assignContentTypeAnnotations = require('../../examples/42-assign-content-t
 const assignFieldAnnotations = require('../../examples/43-assign-field-annotations')
 const clearFieldAnnotations = require('../../examples/44-clear-field-annotations')
 const clearContentTypeAnnotations = require('../../examples/45-clear-content-type-annotations')
+const canSetDisplayFieldBeforeAnnotations = require('../../examples/46-can-set-display-field-before-annotations')
 
 const { createMigrationParser } = require('../../built/lib/migration-parser')
 const { DEFAULT_SIDEBAR_LIST } = require('../../built/lib/action/sidebarwidget')
@@ -1160,5 +1161,28 @@ describe('the migration', function () {
     })
 
     expect(ct.metadata).to.be.undefined()
+  })
+
+  it('can set displayField before annotations', async function () {
+    await migrator(canSetDisplayFieldBeforeAnnotations)
+    const ct = await request({
+      method: 'GET',
+      url: '/content_types/annotatedWithDisplayField'
+    })
+
+    expect(ct.displayField).to.eql('name')
+    expect(ct.metadata).to.eql({
+      annotations: {
+        ContentType: [
+          {
+            sys: {
+              id: 'Contentful:AggregateRoot',
+              type: 'Link',
+              linkType: 'Annotation'
+            }
+          }
+        ]
+      }
+    })
   })
 })


### PR DESCRIPTION
This is to fix a bug a customer reported when using `setAnnotations`. Depending on the order in which you manipulate a content type in your migration script, the migration would either throw a validation error when interacting with the API or work as expected. 

The following worked well:

```js
module.exports = function(migration) {
  const annotatedContentType = migration
    .createContentType('annotatedWithDisplayField')
    .name('Blog Post')
    .setAnnotations(['Contentful:AggregateRoot'])
    .displayField('name')

  annotatedContentType
    .createField('name')
    .name('name')
    .type('Symbol')
    .localized(false)
    .required(true)
    .validations([{ unique: true }])
    .disabled(false)
    .omitted(false)
}
```

Whereas this did not and would throw a 422:

```js
module.exports = function(migration) {
  const annotatedContentType = migration
    .createContentType('annotatedWithDisplayField')
    .name('Blog Post')
    .displayField('name')
    .setAnnotations(['Contentful:AggregateRoot'])

  annotatedContentType
    .createField('name')
    .name('name')
    .type('Symbol')
    .localized(false)
    .required(true)
    .validations([{ unique: true }])
    .disabled(false)
    .omitted(false)
}
```

The reason for that is related to the internal request generation logic: We group different intents (e.g. create content type and update properties on it) into request batches so that we don't accidentally make invalid requests e.g. trying to create a contentType with a given `displayField` without yet having created the display field itself. Internally, we define which intents should be grouped with which others via the `groupsWith` method on intent objects. The newly introduced `contentTypeAnnotate` intent was missing in those definitions for other intents, e.g. field updates, which always should be grouped.

This PR adds this group check.