### PR TITLE
fix(types): change types to expose requestBatchSize []

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export type RunMigrationConfig = {
   rawProxy?: boolean
   yes?: boolean
   retryLimit?: number
+  requestBatchSize?: number
 } & ({ filePath: string } | { migrationFunction: MigrationFunction })
 
 export function runMigration(config: RunMigrationConfig): Promise<any>
@@ -639,6 +640,9 @@ export interface ClientConfig {
   environmentId?: string
   proxy?: string
   rawProxy?: boolean
+  requestBatchSize?: number
+  headers?: Record<string, unknown>
+  retryLimit?: number
 }
 
 export type MakeRequest = (requestConfig: axios.AxiosRequestConfig) => axios.AxiosResponse['data']

--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -1,21 +1,11 @@
 import * as path from 'path'
 import * as os from 'os'
 import { v4 as uuidv4 } from 'uuid'
+import type { ClientConfig } from '../../../index'
 
 // TODO: I'm ugly, maybe change me
 const homedir = process.env.NODE_ENV === 'test' ? '/tmp' : os.homedir()
 const configPath = path.resolve(homedir, '.contentfulrc.json')
-
-interface ClientConfig {
-  accessToken?: string
-  spaceId?: string
-  environmentId?: string
-  proxy?: string
-  rawProxy?: boolean
-  requestBatchSize?: number
-  headers?: Record<string, unknown>
-  retryLimit?: number
-}
 
 function getFileConfig(): ClientConfig {
   try {

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -54,7 +54,11 @@ export default class Fetcher implements APIFetcher {
     const ids: string[] = _.uniq(
       intentList
         .getIntents()
-        .filter((intent) => (!intent.isEditorInterfaceIntent() || intent.requiresContentType()) && !intent.isTagIntent())
+        .filter(
+          (intent) =>
+            (!intent.isEditorInterfaceIntent() || intent.requiresContentType()) &&
+            !intent.isTagIntent()
+        )
         .reduce((ids, intent) => {
           const intentIds = intent.getRelatedContentTypeIds()
           return ids.concat(intentIds)


### PR DESCRIPTION
## Summary

The `requestBatchSize` was not being exposed in all interfaces. Thereore users trying to use `runMigration' would not see it proposed as an option. This PR exposes the param and cleans up types a bit.


