### PR TITLE
fix: use management token as fallback

### DIFF
--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -10,7 +10,13 @@ const configPath = path.resolve(homedir, '.contentfulrc.json')
 function getFileConfig(): ClientConfig {
   try {
     const config = require(configPath)
-    return config.cmaToken ? { accessToken: config.cmaToken } : {}
+    if (config.cmaToken) {
+      return { accessToken: config.cmaToken }
+    }
+    if (config.managementToken) {
+      return { accessToken: config.managementToken }
+    }
+    return {}
   } catch (e) {
     return {}
   }

--- a/test/unit/bin/lib/config.spec.ts
+++ b/test/unit/bin/lib/config.spec.ts
@@ -34,15 +34,13 @@ describe('Config', function () {
     expect(config.accessToken).to.eql('cmaToken')
   })
 
-  // This behavior may be adjusted in the future as some tools which wrap contentful-migration use
-  // managementToken instead of cmaToken and we may want it to be picked up to ensure compatibility
-  it('does not pick up managementToken even if no cmaToken is provided', function () {
+  it('picks up managementToken if no cmaToken is provided', function () {
     writeFileSync(
       resolve('/tmp', '.contentfulrc.json'),
       JSON.stringify({ managementToken: 'managementToken' })
     )
     const config = getConfig({})
-    expect(config.accessToken).to.eql(undefined)
+    expect(config.accessToken).to.eql('managementToken')
   })
 
   it('prefers env config over contentfulrc.json', function () {


### PR DESCRIPTION
Picks up the initiative from https://github.com/contentful/contentful-migration/pull/1096 and the related issue https://github.com/contentful/contentful-migration/issues/1095.

Use `managementToken` as fallback if no `cmaToken` is provided in `.contentfulrc`. We want to keep the `cmaToken` to ensure backwards compatibility, but allow for `managementToken` as well as it is the new default in `contentful-cli`.