### PR TITLE
chore: send ci alerts to the slack [SDK-2507]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     circleci.com/project-slug: github/contentful/contentful-migration
     github.com/project-slug: contentful/contentful-migration
+    contentful.com/ci-alert-slack: prd-dev-workflows-ci-alerts
 spec:
   type: cli
   lifecycle: production


### PR DESCRIPTION
This PR will enable CI alerts to let the team know when the default branch is broken and needs fixing.

Those alerts will be send to the team internal Slack channel.