### PR TITLE
feat(editor-interfaces): support update all editor interfaces in one step [SDK-2577]

### DIFF
--- a/examples/54-update-all-editor-interfaces.js
+++ b/examples/54-update-all-editor-interfaces.js
@@ -1,0 +1,32 @@
+module.exports = function (migration) {
+  const contentType = migration.editContentType('page')
+
+  contentType.updateAllEditorInterfaces({
+    sidebar: [
+      {
+        widgetId: 'content-preview-widget',
+        widgetNamespace: 'sidebar-builtin'
+      },
+      {
+        disabled: true,
+        widgetId: 'incoming-links-widget',
+        widgetNamespace: 'sidebar-builtin'
+      }
+    ],
+    controls: [
+      {
+        fieldId: 'name',
+        widgetId: 'singleLine',
+        widgetNamespace: 'builtin'
+      },
+      {
+        fieldId: 'officialLanguages',
+        settings: {
+          helpText: 'provide a language from the list'
+        },
+        widgetId: 'listInput',
+        widgetNamespace: 'builtin'
+      }
+    ]
+  })
+}

--- a/src/lib/action/editorinterface-update-all.ts
+++ b/src/lib/action/editorinterface-update-all.ts
@@ -1,0 +1,26 @@
+import { EditorInterfaces } from '../entities/content-type'
+import { APIEditorInterfaces } from '../interfaces/content-type'
+import { EntityAction, EntityType } from './action'
+
+export class EditorInterfaceUpdateAllAction extends EntityAction {
+  protected contentTypeId: string
+  protected editorInterfaces: Omit<APIEditorInterfaces, 'sys'>
+
+  constructor(contentTypeId: string, editorInterfaces: Omit<APIEditorInterfaces, 'sys'>) {
+    super()
+    this.contentTypeId = contentTypeId
+    this.editorInterfaces = editorInterfaces
+  }
+
+  getEntityType(): EntityType {
+    return EntityType.EditorInterface
+  }
+
+  getEntityId(): string {
+    return this.contentTypeId
+  }
+
+  async applyTo(editorInterfaces: EditorInterfaces) {
+    editorInterfaces.updateAllEditorInterfaces(this.editorInterfaces)
+  }
+}

--- a/src/lib/entities/content-type.ts
+++ b/src/lib/entities/content-type.ts
@@ -241,6 +241,32 @@ class EditorInterfaces {
     }
   }
 
+  updateAllEditorInterfaces(editorInterfaces: Omit<APIEditorInterfaces, 'sys'>) {
+    if (editorInterfaces.controls) {
+      this._controls = editorInterfaces.controls
+    }
+
+    if (editorInterfaces.sidebar) {
+      this._sidebar = editorInterfaces.sidebar
+    }
+
+    if (editorInterfaces.editor) {
+      this._editor = editorInterfaces.editor
+    }
+
+    if (editorInterfaces.editors) {
+      this._editors = editorInterfaces.editors
+    }
+
+    if (editorInterfaces.editorLayout) {
+      this._editorLayout = editorInterfaces.editorLayout
+    }
+
+    if (editorInterfaces.groupControls) {
+      this._groupControls = editorInterfaces.groupControls
+    }
+  }
+
   addSidebarWidget(
     widgetId: string,
     widgetNamespace: APISidebarWidgetNamespace,

--- a/src/lib/intent/base-intent.ts
+++ b/src/lib/intent/base-intent.ts
@@ -242,6 +242,10 @@ export default abstract class Intent implements IntentInterface {
     return false
   }
 
+  isEditorInterfaceUpdateAll(): boolean {
+    return false
+  }
+
   abstract toActions(): (APIAction | EntityAction)[]
   abstract toPlanMessage(): PlanMessage
 }

--- a/src/lib/intent/editor-interface-update-all.ts
+++ b/src/lib/intent/editor-interface-update-all.ts
@@ -1,0 +1,61 @@
+import Intent from './base-intent'
+import { PlanMessage } from '../interfaces/plan-message'
+import chalk from 'chalk'
+import { SaveEditorInterfaceAction } from '../action/editorinterface-save'
+import { EditorInterfaceUpdateAllAction } from '../action/editorinterface-update-all'
+
+export default class EditorInterfaceUpdateAllIntent extends Intent {
+  isEditorInterfaceUpdateAll() {
+    return true
+  }
+  isEditorInterfaceIntent() {
+    return true
+  }
+  // I am not sure if this is a groupable intent
+  //   isGroupable() {
+  //     return true
+  //   }
+  //   groupsWith(other: Intent): boolean {
+  //     return other.isGroupable() && other.isEditorInterfaceIntent() && this.isSameContentType(other)
+  //   }
+  endsGroup(): boolean {
+    return true
+  }
+  shouldSave(): boolean {
+    return false
+  }
+  shouldPublish(): boolean {
+    return false
+  }
+  toActions() {
+    return [
+      new EditorInterfaceUpdateAllAction(this.payload.contentTypeId, this.payload.editorInterfaces),
+      new SaveEditorInterfaceAction(this.payload.contentTypeId)
+    ]
+  }
+
+  // TODO
+  toPlanMessage(): PlanMessage {
+    const { widgetId, fieldId, settings, widgetNamespace } = this.payload.editorInterface
+    let createDetails = [chalk`{italic widgetId}: "${widgetId}"`]
+
+    if (widgetNamespace) {
+      createDetails = [...createDetails, chalk`{italic widgetNamespace}: "${widgetNamespace}"`]
+    }
+
+    Object.keys(settings).forEach((settingName) =>
+      createDetails.push(chalk`{italic ${settingName}}: "${settings[settingName].toString()}"`)
+    )
+
+    return {
+      heading: chalk`Update field controls for Content Type {bold.yellow ${this.getContentTypeId()}}`,
+      details: [],
+      sections: [
+        {
+          heading: chalk`Update field {yellow ${fieldId}}`,
+          details: createDetails
+        }
+      ]
+    }
+  }
+}

--- a/src/lib/intent/index.ts
+++ b/src/lib/intent/index.ts
@@ -12,6 +12,7 @@ import ContentTypeDeleteIntent from './content-type-delete'
 import EntryDeriveIntent from './entry-derive'
 import EntryTransformToTypeIntent from './entry-transform-to-type'
 import EditorInterfaceUpdateIntent from './editorinterface-update'
+import EditorInterfaceUpdateAllIntent from './editor-interface-update-all'
 import EditorInterfaceCopyIntent from './editorinterface-copy'
 import EditorInterfaceResetIntent from './editorinterface-reset'
 import SidebarWidgetAddIntent from './sidebarwidget-add'
@@ -53,6 +54,7 @@ export {
   EntryDeriveIntent as EntryDerive,
   EntryTransformToTypeIntent as EntryTransformToType,
   EditorInterfaceUpdateIntent as EditorInterfaceUpdate,
+  EditorInterfaceUpdateAllIntent as EditorInterfaceUpdateAll,
   EditorInterfaceCopyIntent as EditorInterfaceCopy,
   EditorInterfaceResetIntent as EditorInterfaceReset,
   SidebarWidgetAddIntent as SidebarWidgetAdd,

--- a/src/lib/interfaces/raw-step.ts
+++ b/src/lib/interfaces/raw-step.ts
@@ -6,7 +6,11 @@ import TransformEntryToType from './entry-transform-to-type'
 import { SidebarWidgetNamespace, SidebarWidgetSettings } from '../action/sidebarwidget'
 import { EntryEditorNamespace, EntryEditorSettings } from '../action/entryeditor-configure'
 import { EntryEditor } from '../action/entryeditors-configure'
-import { APIEditorInterfaceGroupControl, APIEditorLayoutFieldGroupItem } from './content-type'
+import {
+  APIEditorInterfaceGroupControl,
+  APIEditorInterfaces,
+  APIEditorLayoutFieldGroupItem
+} from './content-type'
 import { AnnotationId } from './annotation'
 
 interface RawStep {
@@ -36,6 +40,7 @@ interface RawStepPayload {
   derivation?: EntryDerive
   movement?: Movement
   entryTransformationToType?: TransformEntryToType
+  editorInterfaces?: Omit<APIEditorInterfaces, 'sys'>
   editorInterfaceCopy?: EditorInterfaceCopy
   editorInterfaceReset?: EditorInterfaceReset
   editorInterface?: EditorInterfaceInfo

--- a/src/lib/migration-steps/action-creators.ts
+++ b/src/lib/migration-steps/action-creators.ts
@@ -1,6 +1,7 @@
 import * as Intents from '../intent/index'
 import { TagVisibility } from '../interfaces/api-tag'
 import ContentTransform from '../interfaces/content-transform'
+import { APIEditorInterfaces } from '../interfaces/content-type'
 import EntryDerive from '../interfaces/entry-derive'
 import EntrySetTags from '../interfaces/entry-set-tags'
 import TransformEntryToType from '../interfaces/entry-transform-to-type'
@@ -35,6 +36,27 @@ const actionCreators = {
           props: {
             [property]: value
           }
+        }
+      })
+    },
+    updateAllEditorInterfaces: (
+      contentTypeId: string,
+      instanceId: string,
+      callsite,
+      editorInterfaces: Omit<APIEditorInterfaces, 'sys'>
+    ): Intents.EditorInterfaceUpdateAll => {
+      return new Intents.EditorInterfaceUpdateAll({
+        type: 'contentType/update',
+        meta: {
+          contentTypeInstanceId: `contentType/${contentTypeId}/${instanceId}`,
+          callsite: {
+            file: callsite?.getFileName(),
+            line: callsite?.getLineNumber()
+          }
+        },
+        payload: {
+          contentTypeId: contentTypeId,
+          editorInterfaces
         }
       })
     },

--- a/src/lib/migration-steps/index.ts
+++ b/src/lib/migration-steps/index.ts
@@ -13,7 +13,7 @@ import EntrySetTags from '../interfaces/entry-set-tags'
 import TransformEntryToType from '../interfaces/entry-transform-to-type'
 import { ClientConfig } from '../../bin/lib/config'
 import { deprecatedMethod } from '../utils/deprecated'
-import { APIEditorInterfaceSettings } from '../interfaces/content-type'
+import { APIEditorInterfaces, APIEditorInterfaceSettings } from '../interfaces/content-type'
 
 const createInstanceIdManager = () => {
   const instanceCounts = {}
@@ -467,6 +467,21 @@ class ContentType extends DispatchProxy {
         settings
       )
     )
+    return this
+  }
+
+  updateAllEditorInterfaces(editorInterfaces: Omit<APIEditorInterfaces, 'sys'>) {
+    const callsite = getFirstExternalCaller()
+
+    this.dispatch(
+      actionCreators.contentType.updateAllEditorInterfaces(
+        this.id,
+        this.instanceId,
+        callsite,
+        editorInterfaces
+      )
+    )
+
     return this
   }
 

--- a/test/unit/lib/entities/editor-interface.spec.ts
+++ b/test/unit/lib/entities/editor-interface.spec.ts
@@ -575,5 +575,157 @@ describe('EditorInterfaces', () => {
         }
       ])
     })
+
+    it('updates all editor interfaces', () => {
+      const editorInterfaces = makeEditorInterface({
+        controls: [
+          {
+            fieldId: 'name',
+            widgetId: 'singleLine',
+            widgetNamespace: 'builtin'
+          },
+          {
+            fieldId: 'officialLanguages',
+            settings: {
+              helpText: 'provide a language from the list'
+            },
+            widgetId: 'listInput',
+            widgetNamespace: 'builtin'
+          }
+        ]
+      })
+
+      editorInterfaces.updateAllEditorInterfaces({
+        sidebar: [
+          {
+            widgetId: 'content-preview-widget',
+            widgetNamespace: 'sidebar-builtin'
+          },
+          {
+            disabled: true,
+            widgetId: 'incoming-links-widget',
+            widgetNamespace: 'sidebar-builtin'
+          }
+        ],
+        controls: [
+          {
+            fieldId: 'name',
+            widgetId: 'singleLine',
+            widgetNamespace: 'builtin'
+          },
+          {
+            fieldId: 'officialLanguages',
+            settings: {
+              helpText: 'changed helpText'
+            },
+            widgetId: 'checkbox',
+            widgetNamespace: 'builtin'
+          }
+        ]
+      })
+
+      const fieldControls = editorInterfaces.getControls()
+      const sidebar = editorInterfaces.getSidebar()
+
+      expect(fieldControls.length).to.eql(2)
+      expect(fieldControls).to.eql([
+        {
+          fieldId: 'name',
+          widgetId: 'singleLine',
+          widgetNamespace: 'builtin'
+        },
+        {
+          fieldId: 'officialLanguages',
+          settings: {
+            helpText: 'changed helpText'
+          },
+          widgetId: 'checkbox',
+          widgetNamespace: 'builtin'
+        }
+      ])
+      expect(sidebar?.length).to.eql(2)
+      expect(sidebar).to.eql([
+        {
+          widgetId: 'content-preview-widget',
+          widgetNamespace: 'sidebar-builtin'
+        },
+        {
+          disabled: true,
+          widgetId: 'incoming-links-widget',
+          widgetNamespace: 'sidebar-builtin'
+        }
+      ])
+    })
+
+    it('update all editor interfaces: preserves editor interfaces that are not provided in the payload', () => {
+      const editorInterfaces = makeEditorInterface({
+        sidebar: [
+          {
+            widgetId: 'content-preview-widget',
+            widgetNamespace: 'sidebar-builtin'
+          },
+          {
+            disabled: true,
+            widgetId: 'incoming-links-widget',
+            widgetNamespace: 'sidebar-builtin'
+          }
+        ],
+        controls: [
+          {
+            fieldId: 'name',
+            widgetId: 'singleLine',
+            widgetNamespace: 'builtin'
+          },
+          {
+            fieldId: 'officialLanguages',
+            settings: {
+              helpText: 'changed helpText'
+            },
+            widgetId: 'checkbox',
+            widgetNamespace: 'builtin'
+          }
+        ]
+      })
+
+      editorInterfaces.updateAllEditorInterfaces({
+        controls: [
+          {
+            fieldId: 'officialLanguages',
+            settings: {
+              helpText: 'provide a language from the list'
+            },
+            widgetId: 'listInput',
+            widgetNamespace: 'builtin'
+          }
+        ]
+      })
+
+      const fieldControls = editorInterfaces.getControls()
+      const sidebar = editorInterfaces.getSidebar()
+
+      expect(fieldControls.length).to.eql(1)
+      expect(fieldControls).to.eql([
+        {
+          fieldId: 'officialLanguages',
+          settings: {
+            helpText: 'provide a language from the list'
+          },
+          widgetId: 'listInput',
+          widgetNamespace: 'builtin'
+        }
+      ])
+      expect(sidebar?.length).to.eql(2)
+      expect(sidebar).to.eql([
+        {
+          widgetId: 'content-preview-widget',
+          widgetNamespace: 'sidebar-builtin'
+        },
+        {
+          disabled: true,
+          widgetId: 'incoming-links-widget',
+          widgetNamespace: 'sidebar-builtin'
+        }
+      ])
+    })
   })
 })


### PR DESCRIPTION
## Summary

Support `migration.updateAllEditorInterfaces()` migration step 

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

We need a method that allows updating all the editor interfaces at the same time, the method will be required to include editor interfaces as part of the migration files generated by the merge app 

## Todos
