### PR TITLE
fix: Add missing typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -427,7 +427,7 @@ export interface ITransformEntriesConfig {
    *
    * The return value must be an object with the same keys as specified in to. Their values will be written to the respective entry fields for the current locale (i.e. {nameField: 'myNewValue'}). If it returns undefined, this the values for this locale on the entry will be left untouched.
    */
-  transformEntryForLocale: (fromFields: ContentFields, currentLocale: string) => any
+  transformEntryForLocale: (fromFields: ContentFields, currentLocale: string, { id }: { id: string }) => any
   /** (optional) – If true, the transformed entries will be published. If false, they will remain in draft state. When the value is set to "preserve" items will be published only if the original entry was published as well (default true) */
   shouldPublish?: boolean | 'preserve'
 }


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary
Add missing type in `transformEntryForLocale` function

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

This pr https://github.com/contentful/contentful-migration/pull/1212 was merged and released but it missed to add the types in index.d.ts file, this gives following typescript error in client code.

```
Type '(from: any, currentLocale: any, { id: entryId }: { id: any; }) => Promise<any>' is not assignable to type '(fromFields: ContentFields, currentLocale: string) => any'.
  Target signature provides too few arguments. Expected 3 or more, but got 2.ts(2322)
```

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
