### PR TITLE
feat(types): add configureEntryEditors definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -207,6 +207,12 @@ export interface IFieldGroupWidgetSettings {
   [setting: string]: WidgetSettingsValue
 }
 
+export interface IEntryEditor {
+  widgetNamespace: 'builtin' | 'extension' | 'app',
+  widgetId: string,
+  settings?: IEditorInterfaceOptions
+}
+
 export interface ContentType {
   id: string
   instanceId: string
@@ -249,6 +255,13 @@ export interface ContentType {
     widgetId: string,
     settings?: IEditorInterfaceOptions
   ): void
+
+  /**
+   * Similar to configureEntryEditor, but allows configuring multiple entry editors at once.
+   *
+   * @param entryEditors An array of entry editor configurations.
+   */
+  configureEntryEditors(entryEditors: IEntryEditor[]): void
 
   /**
    * Changes the control of given field's ID.

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,7 +208,7 @@ export interface IFieldGroupWidgetSettings {
 }
 
 export interface IEntryEditor {
-  widgetNamespace: 'builtin' | 'extension' | 'app',
+  widgetNamespace: 'editor-builtin' | 'builtin' | 'extension' | 'app',
   widgetId: string,
   settings?: IEditorInterfaceOptions
 }
@@ -251,7 +251,7 @@ export interface ContentType {
    * @param settings Widget settings
    */
   configureEntryEditor(
-    widgetNamespace: 'builtin' | 'extension' | 'app',
+    widgetNamespace: 'editor-builtin' | 'builtin' | 'extension' | 'app',
     widgetId: string,
     settings?: IEditorInterfaceOptions
   ): void


### PR DESCRIPTION
## Summary

As mentioned in issue #1221, the type definition for `configureEntryEditors` is missing.

I also added `editor-builtin` as an option for `widgetNamespace` for these entry editors. I'm not entirely sure if `builtin` is still a possible choice for these, given that it does seem to require `editor-builtin`, but I've left the choice there.