### PR TITLE
fix: allow null type for validation message

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -4,7 +4,7 @@ import { allowedResourcesSchema } from './allowed-resources-schema'
 const validation = (name, constraint) =>
   Joi.object({
     [name]: constraint,
-    message: Joi.string()
+    message: Joi.string().allow(null)
   })
 
 const range = (type) =>


### PR DESCRIPTION
## Summary

Allow `null` value for validation `message`

## Description

It turns out the `message` value for validations can be set to `null`. This PR updates the Ajv schema to reflect this.

## Motivation and Context

The Ajv schema is not correct for the possible `null` value for `message`

## Screenshots (if appropriate):
