### PR TITLE
feat: read host from ctfl config [PHX-2748]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -427,7 +427,11 @@ export interface ITransformEntriesConfig {
    *
    * The return value must be an object with the same keys as specified in to. Their values will be written to the respective entry fields for the current locale (i.e. {nameField: 'myNewValue'}). If it returns undefined, this the values for this locale on the entry will be left untouched.
    */
-  transformEntryForLocale: (fromFields: ContentFields, currentLocale: string, { id }: { id: string }) => any
+  transformEntryForLocale: (
+    fromFields: ContentFields,
+    currentLocale: string,
+    { id }: { id: string }
+  ) => any
   /** (optional) – If true, the transformed entries will be published. If false, they will remain in draft state. When the value is set to "preserve" items will be published only if the original entry was published as well (default true) */
   shouldPublish?: boolean | 'preserve'
 }
@@ -643,6 +647,7 @@ export interface ClientConfig {
   requestBatchSize?: number
   headers?: Record<string, unknown>
   retryLimit?: number
+  host?: string
 }
 
 export type MakeRequest = (requestConfig: axios.AxiosRequestConfig) => axios.AxiosResponse['data']

--- a/src/bin/lib/config.ts
+++ b/src/bin/lib/config.ts
@@ -10,13 +10,19 @@ const configPath = path.resolve(homedir, '.contentfulrc.json')
 function getFileConfig(): ClientConfig {
   try {
     const config = require(configPath)
+    let clientConfig: ClientConfig = {}
+
+    if (config.host) {
+      clientConfig.host = config.host
+    }
     if (config.cmaToken) {
-      return { accessToken: config.cmaToken }
+      clientConfig.accessToken = config.cmaToken
     }
     if (config.managementToken) {
-      return { accessToken: config.managementToken }
+      clientConfig.accessToken = config.managementToken
     }
-    return {}
+
+    return clientConfig
   } catch (e) {
     return {}
   }


### PR DESCRIPTION
Currently, contentful-migration is not reading the host variable from contentful config making it impossible to run migration against other server than the main production.

In this PR I am have added reading of the host and setting it for our client