### PR TITLE
Update axios to 1.6.2 to remove vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/hoek": "^10.0.1",
-        "axios": "^1.5.1",
+        "axios": "^1.6.2",
         "bluebird": "^3.7.2",
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
@@ -3106,9 +3106,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -19156,9 +19156,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@hapi/hoek": "^10.0.1",
-    "axios": "^1.5.1",
+    "axios": "^1.6.2",
     "bluebird": "^3.7.2",
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",


### PR DESCRIPTION
## Summary

See: https://github.com/contentful/contentful-migration/issues/1267

## Description

Upgrade axios to latest available version

## Motivation and Context

Using contentful-migration introduces a vulnerable transitive dependency into any user that uses this library. This fix will mitigate this.