### PR TITLE
Fix/make request url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contentful-migration",
-  "version": "0.0.0-development",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contentful-migration",
-      "version": "0.0.0-development",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@hapi/hoek": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-migration",
-  "version": "0.0.0-development",
+  "version": "0.0.0",
   "description": "Migration tooling for contentful",
   "author": "Contentful GmbH",
   "license": "MIT",
@@ -40,7 +40,10 @@
     "test:unit:debug": "NODE_ENV=test mocha debug --require test/setup-unit.js --recursive 'test/unit/**/**/*.spec.{js,ts}'",
     "test:integration:debug": "NODE_ENV=test mocha debug --require test/integration/setup.js 'test/integration/**/*.spec.js'",
     "test:e2e:debug": "NODE_ENV=test mocha debug 'test/end-to-end/**/*.spec.js'",
-    "cm": "git-cz"
+    "cm": "git-cz",
+    "unpublish-library": "npm unpublish @ks/contentful-migration --force",
+    "update-version": "npm version patch --force",
+    "publish-library": "npm run build && npm run update-version && npm run unpublish-library && npm publish"
   },
   "files": [
     "README.md",

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -65,7 +65,14 @@ export const createMakeRequest = (
   })
 
   const makeBaseUrl = (url: string) => {
-    const parts = ['spaces', spaceId, 'environments', environmentId, trim(url, '/')]
+    const parts = [
+      'https://api.contentful.com',
+      'spaces',
+      spaceId,
+      'environments',
+      environmentId,
+      trim(url, '/')
+    ]
 
     return parts.filter((x) => x !== '').join('/')
   }


### PR DESCRIPTION
## Summary

 Fix the URL passed to Axios by `makeRequest`

## Description

When you use the `makeRequest` function in a JS migration script, I encountered a URL not found error because the current `makeBaseUrl` function does not prepend the protocol and domain to the URL.

## Motivation and Context

I'm trying to set up a CI/CD pipeline for a Contentful project. I need the `makeRequest` function for a migration.

-   [x] Implemented feature
-   [ ] Feature with pending implementation
