### PR TITLE
Bug fix for makeRequest base URL logic

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -65,7 +65,14 @@ export const createMakeRequest = (
   })
 
   const makeBaseUrl = (url: string) => {
-    const parts = ['spaces', spaceId, 'environments', environmentId, trim(url, '/')]
+    const parts = [
+      'https://api.contentful.com',
+      'spaces',
+      spaceId,
+      'environments',
+      environmentId,
+      trim(url, '/')
+    ]
 
     return parts.filter((x) => x !== '').join('/')
   }


### PR DESCRIPTION
## Summary

Fix the URL passed to Axios by makeRequest

## Description

When you use the makeRequest function in a JS migration script, I encountered a URL not found error because the current makeBaseUrl function does not prepend the protocol and domain to the URL.

## Motivation and Context

I'm trying to set up a CI/CD pipeline for a Contentful project. I need the makeRequest function for a migration.

-   [x] Implemented feature
-   [ ] Feature with pending implementation
