### PR TITLE
Update exported signature of MigrationFunction

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -665,4 +665,4 @@ export type MigrationContext = ClientConfig & {
 /**
  * The shape of the migration function that should be exported.
  */
-export type MigrationFunction = (migration: Migration, context?: MigrationContext) => void
+export type MigrationFunction = (migration: Migration, context: MigrationContext) => void


### PR DESCRIPTION
## Summary

Changing of MigrationFunction type. The context parameter should not be declared as optional.

## Description

This PR removes the optional setting on the context parameter. This will hint typescript that the parameter will always be there. My research of your codebase indicates that the context will always be provided. 

I assume that your intent with marking the context as optional, is to not force other developers to have context parameter present in their migration function signature. But that is not what is happening. Typescript is okay with "missing" parameters, but marking it optional as is, will force developers to null check the context object before using. This seems to be not needed.

## Motivation and Context

Improves typescript type checking.

## Todos

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
Typescript before change with context parameter
![image](https://github.com/contentful/contentful-migration/assets/263403/5d276dea-96d2-44c3-bd49-0649ed02d0b6)

Typescript after change with context parameter
![image](https://github.com/contentful/contentful-migration/assets/263403/af9a9302-7fb2-4c9e-b57b-3e05053663b7)

Typescript after change with **no** context parameter
![image](https://github.com/contentful/contentful-migration/assets/263403/cf8ad4f3-5952-4d68-9692-10e32f167141)


