### PR TITLE
feat: upgrade CMA.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.0.0",
-        "contentful-management": "^11.2.0",
+        "contentful-management": "^11.5.7",
         "didyoumean2": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "inquirer": "^8.1.2",
@@ -4008,13 +4008,13 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.2.0.tgz",
-      "integrity": "sha512-v1s9eBXDWroDQ5WFDM53hsbB7seg6tAHtNzKwhgdNSyBPd6iFvLEnvVMxfLL3pebUe7NXeGNKEXgM/8ioG6FBA==",
+      "version": "11.5.7",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.7.tgz",
+      "integrity": "sha512-baCf6fhCfSOeuh9xmnhjLEBm/no1xYMvQDxA0DDJ7P4EncngsHckasOokr5KhVylVPybW3Efi2YYnZx70eObcg==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.4.0",
+        "axios": "^1.6.2",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
@@ -19836,13 +19836,13 @@
       }
     },
     "contentful-management": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.2.0.tgz",
-      "integrity": "sha512-v1s9eBXDWroDQ5WFDM53hsbB7seg6tAHtNzKwhgdNSyBPd6iFvLEnvVMxfLL3pebUe7NXeGNKEXgM/8ioG6FBA==",
+      "version": "11.5.7",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.7.tgz",
+      "integrity": "sha512-baCf6fhCfSOeuh9xmnhjLEBm/no1xYMvQDxA0DDJ7P4EncngsHckasOokr5KhVylVPybW3Efi2YYnZx70eObcg==",
       "requires": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.4.0",
+        "axios": "^1.6.2",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",
     "chalk": "^4.0.0",
-    "contentful-management": "^11.2.0",
+    "contentful-management": "^11.5.7",
     "didyoumean2": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "inquirer": "^8.1.2",


### PR DESCRIPTION
## Summary

Bump CMA.js to include axios dependency vuln fix from https://github.com/contentful/contentful-management.js/pull/2055