### PR TITLE
rich text example: enabledMarks & enabledNodeTypes

### DIFF
--- a/examples/22-create-rich-text-field-with-validation.js
+++ b/examples/22-create-rich-text-field-with-validation.js
@@ -47,26 +47,39 @@ module.exports = function (migration) {
         }
       },
       {
+        enabledMarks: [
+          'bold',
+          'italic',
+          'underline',
+          'code',
+          'superscript',
+          'subscript'
+        ],
+        message:
+          'Only bold, italic, underline, code, superscript, and subscript marks are allowed'
+      },
+      {
         enabledNodeTypes: [
           'heading-1',
           'heading-2',
           'heading-3',
           'heading-4',
           'heading-5',
+          'heading-6',
           'ordered-list',
           'unordered-list',
           'hr',
           'blockquote',
           'embedded-entry-block',
           'embedded-asset-block',
+          'table',
           'hyperlink',
           'entry-hyperlink',
           'asset-hyperlink',
-          'embedded-entry-inline',
-          'embedded-resource-block'
+          'embedded-entry-inline'
         ],
         message:
-          'Only heading 1, heading 2, heading 3, heading 4, heading 5, ordered list, unordered list, horizontal rule, quote, block entry, block embedded resource, asset, link to Url, link to entry, link to asset, and inline entry nodes are allowed'
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed'
       }
     ])
 }

--- a/examples/22-create-rich-text-field-with-validation.js
+++ b/examples/22-create-rich-text-field-with-validation.js
@@ -47,16 +47,8 @@ module.exports = function (migration) {
         }
       },
       {
-        enabledMarks: [
-          'bold',
-          'italic',
-          'underline',
-          'code',
-          'superscript',
-          'subscript'
-        ],
-        message:
-          'Only bold, italic, underline, code, superscript, and subscript marks are allowed'
+        enabledMarks: ['bold', 'italic', 'underline', 'code', 'superscript', 'subscript'],
+        message: 'Only bold, italic, underline, code, superscript, and subscript marks are allowed'
       },
       {
         enabledNodeTypes: [
@@ -76,10 +68,11 @@ module.exports = function (migration) {
           'hyperlink',
           'entry-hyperlink',
           'asset-hyperlink',
-          'embedded-entry-inline'
+          'embedded-entry-inline',
+          'embedded-resource-block'
         ],
         message:
-          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed'
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, block embedded resource, asset, link to Url, link to entry, link to asset, and inline entry nodes are allowed'
       }
     ])
 }

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -1320,26 +1320,28 @@ describe('the migration', function () {
     })
 
     expect(ct.fields[0].type).to.eql('RichText')
-    expect(ct.fields[0].validations[1].enabledNodeTypes).to.eql([
+    expect(ct.fields[0].validations[2].enabledNodeTypes).to.eql([
       'heading-1',
       'heading-2',
       'heading-3',
       'heading-4',
       'heading-5',
+      'heading-6',
       'ordered-list',
       'unordered-list',
       'hr',
       'blockquote',
       'embedded-entry-block',
       'embedded-asset-block',
+      'table',
       'hyperlink',
       'entry-hyperlink',
       'asset-hyperlink',
       'embedded-entry-inline',
       'embedded-resource-block'
     ])
-    expect(ct.fields[0].validations[1].message).to.eql(
-      'Only heading 1, heading 2, heading 3, heading 4, heading 5, ordered list, unordered list, horizontal rule, quote, block entry, block embedded resource, asset, link to Url, link to entry, link to asset, and inline entry nodes are allowed'
+    expect(ct.fields[0].validations[2].message).to.eql(
+      'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, block embedded resource, asset, link to Url, link to entry, link to asset, and inline entry nodes are allowed'
     )
     expect(ct.fields[0].validations[0].nodes['embedded-entry-block']).to.eql([
       {


### PR DESCRIPTION
Added missing marks and nodeTypes to example 22 to improve it as a reference

## Summary

Example 22 (create-rich-text-field-with-validation) expanded to include marks such as "bold", and missing node-types such as "table".

## Description

I created a new rich text field with everything enabled, then used the contentful cli tool to generate a migration based on that; the output of which I used to fill in the blank spots of the example code.

## Motivation and Context

To improve the example as a reference. I recently had a teammate struggle to find examples of adding table support to rich text using this library—looking at this example I found that it was missing just a few items to serve as a complete reference.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
