### PR TITLE
feat: allow validation pattern to be a RegExp or a string []

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,8 +141,8 @@ export interface IValidation {
   size?: { max?: number; min?: number }
   /** Takes min and/or max parameters and validates the range of a value. */
   range?: { max?: number; min?: number }
-  /** Takes a string that reflects a JS regex and flags, validates against a string. See JS reference for the parameters. */
-  regexp?: { pattern: string; flags?: string }
+  /** Takes either a RegExp that is parsed into its source pattern and flags, or a string that reflects a JS regex and flags, which validates against a string. See JS reference for the parameters. */
+  regexp?: { pattern: string; flags?: string } | RegExp
   /** Validates that there are no other entries that have the same field value at the time of publication. */
   unique?: true
   /** Validates that a value falls within a certain range of dates. */

--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -21,27 +21,24 @@ const rangeForDate = () =>
     max: Joi.string().optional().allow(null)
   })
 
+const regexpSchema = () =>
+  Joi.alternatives().try(
+    Joi.object().instance(RegExp),
+    Joi.object({
+      pattern: Joi.string(),
+      flags: Joi.string().allow(null).optional()
+    })
+  )
+
 const linkContentType = validation('linkContentType', Joi.array().items(Joi.string()))
 const inValidation = validation('in', Joi.array())
 const linkMimetypeGroup = validation('linkMimetypeGroup', Joi.array().items(Joi.string()))
 const size = validation('size', range('number'))
 const rangeValidation = validation('range', range('number'))
 
-const regexp = validation(
-  'regexp',
-  Joi.object({
-    pattern: Joi.string(),
-    flags: Joi.string().allow(null).optional()
-  })
-)
+const regexp = validation('regexp', regexpSchema())
 
-const prohibitRegexp = validation(
-  'prohibitRegexp',
-  Joi.object({
-    pattern: Joi.string(),
-    flags: Joi.string().allow(null).optional()
-  })
-)
+const prohibitRegexp = validation('prohibitRegexp', regexpSchema())
 
 const unique = validation('unique', Joi.boolean())
 const dateRange = validation('dateRange', rangeForDate())

--- a/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-field-validations.spec.ts
@@ -186,6 +186,20 @@ describe('payload validation', function () {
       expect(errors).to.eql([[]])
     })
 
+    it('allows actual RegExp', async function () {
+      const errors = await validateBatches(function up(migration) {
+        const person = migration.createContentType('person').name('Person').description('A Person')
+
+        person
+          .createField('fullName')
+          .name('Full Name')
+          .type('Symbol')
+          .validations([{ regexp: /^[A-Za-zs]+$/g }])
+      }, [])
+
+      expect(errors).to.eql([[]])
+    })
+
     it('can validate all blocks and inlines for RichText', async function () {
       const errors = await validateBatches(function up(migration) {
         const novel = migration


### PR DESCRIPTION
## Summary

`regexp` and `preventRegexp` currently only accept a regexp that is represented as a `pattern` string and its `flags`, but it should also be able to accept a RegExp directly, see https://github.com/contentful/contentful-migration/issues/1178 for more details.

## Description
Both `regexp` and `prohibitRegexp` validations will now support either the existing `pattern`/`flags` format or a RegExp directly

<!-- Describe your changes in detail -->

