### PR TITLE
feat: support annotation for experience types [SPA-2047]

### DIFF
--- a/examples/54-create-experience-type.js
+++ b/examples/54-create-experience-type.js
@@ -1,0 +1,90 @@
+module.exports = function (migration) {
+  const experienceType = migration.createContentType('experienceType').name('Experience')
+
+  experienceType
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+
+  experienceType.displayField('title')
+
+  experienceType
+    .createField('slug')
+    .name('Slug')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([{ unique: true }])
+    .disabled(false)
+    .omitted(false)
+
+  experienceType
+    .createField('componentTree')
+    .name('Component Tree')
+    .type('Object')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+
+  experienceType
+    .createField('dataSource')
+    .name('Data Source')
+    .type('Object')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+
+  experienceType
+    .createField('unboundValues')
+    .name('Unbound Values')
+    .type('Object')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+
+  experienceType
+    .createField('componentSettings')
+    .name('Component Settings')
+    .type('Object')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+
+  experienceType
+    .createField('usedComponents')
+    .name('Used Components')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+      validations: [{ linkContentType: ['experienceType'] }],
+      linkType: 'Entry'
+    })
+
+  experienceType.changeFieldControl('title', 'builtin', 'singleLine')
+  experienceType.changeFieldControl('slug', 'builtin', 'slugEditor')
+  experienceType.changeFieldControl('componentTree', 'builtin', 'objectEditor')
+  experienceType.changeFieldControl('dataSource', 'builtin', 'objectEditor')
+  experienceType.changeFieldControl('unboundValues', 'builtin', 'objectEditor')
+  experienceType.changeFieldControl('componentSettings', 'builtin', 'objectEditor')
+  experienceType.changeFieldControl('usedComponents', 'builtin', 'entryLinksEditor')
+
+  experienceType.setAnnotations(['Contentful:ExperienceType'])
+}

--- a/src/lib/interfaces/annotation.ts
+++ b/src/lib/interfaces/annotation.ts
@@ -58,6 +58,7 @@ export class Annotation {
 }
 
 export const availableAnnotations = {
+  // Targeting ContentType
   'Contentful:AggregateRoot': new Annotation({
     id: 'Contentful:AggregateRoot',
     targets: [
@@ -74,6 +75,15 @@ export const availableAnnotations = {
       }
     ]
   }),
+  'Contentful:ExperienceType': new Annotation({
+    id: 'Contentful:ExperienceType',
+    targets: [
+      {
+        type: 'ContentType'
+      }
+    ]
+  }),
+  // Targeting ContentTypeField
   'Contentful:AggregateComponent': new Annotation({
     id: 'Contentful:AggregateComponent',
     targets: [

--- a/src/lib/offline-api/index.ts
+++ b/src/lib/offline-api/index.ts
@@ -11,7 +11,7 @@ import { PayloadValidationError, InvalidActionError } from '../interfaces/errors
 import DisplayFieldValidator from './validator/display-field'
 import SchemaValidator from './validator/schema/index'
 import TypeChangeValidator from './validator/type-change'
-import AnnotationValidator from './validator/annotations'
+import AnnotationsValidator from './validator/annotations'
 import TagsOnEntryValidator from './validator/tags-on-entry'
 import { Intent } from '../interfaces/intent'
 import APIEntry from '../interfaces/api-entry'
@@ -221,7 +221,7 @@ class OfflineAPI {
       new DisplayFieldValidator(),
       new SchemaValidator(),
       new TypeChangeValidator(),
-      new AnnotationValidator(),
+      new AnnotationsValidator(),
       new ResourceLinksValidator()
     )
 

--- a/test/end-to-end/assertions.js
+++ b/test/end-to-end/assertions.js
@@ -95,7 +95,7 @@ module.exports = {
     contentType: {
       create: function (id, params) {
         return (result) => {
-          expect(result.stdout).not.to.be.empty()
+          expect(result.stdout).not.to.be.empty(result.stderr)
 
           const withoutAnsiCodes = stripAnsi(result.stdout)
           expect(withoutAnsiCodes).to.include(`Create Content Type ${id}`)
@@ -108,7 +108,7 @@ module.exports = {
       },
       update: function (id, params) {
         return (result) => {
-          expect(result.stdout).not.to.be.empty()
+          expect(result.stdout).not.to.be.empty(result.stderr)
 
           const withoutAnsiCodes = stripAnsi(result.stdout)
           expect(withoutAnsiCodes).to.include(`Update Content Type ${id}`)
@@ -121,7 +121,7 @@ module.exports = {
       },
       delete: function (id) {
         return (result) => {
-          expect(result.stdout).not.to.be.empty()
+          expect(result.stdout).not.to.be.empty(result.stderr)
 
           const withoutAnsiCodes = stripAnsi(result.stdout)
           expect(withoutAnsiCodes).to.include(`Delete Content Type ${id}`)
@@ -424,6 +424,17 @@ module.exports = {
 
           const withoutAnsiCodes = stripAnsi(result.stdout)
           expect(withoutAnsiCodes).to.include(`Delete Tag ${id}`)
+        }
+      }
+    },
+    annotation: {
+      assign: function (id) {
+        return (result) => {
+          expect(result.stdout).not.to.be.empty(result.stderr)
+
+          const withoutAnsiCodes = stripAnsi(result.stdout)
+
+          expect(withoutAnsiCodes).to.include(`Assign annotation ${id}`)
         }
       }
     }

--- a/test/end-to-end/content-type.spec.js
+++ b/test/end-to-end/content-type.spec.js
@@ -266,4 +266,39 @@ describe('apply content-type migration examples', function () {
         })
       )
   })
+
+  it('applies 54-create-experience-type', function (done) {
+    cli()
+      .run(
+        `--space-id ${SOURCE_TEST_SPACE} --environment-id ${environmentId} ./examples/54-create-experience-type.js`
+      )
+      .on(/\? Do you want to apply the migration \(Y\/n\)/)
+      .respond('Y\n')
+      .expect(assert.plans.contentType.create('experienceType'))
+      .expect(assert.plans.annotation.assign('Contentful:ExperienceType'))
+      .expect(assert.plans.actions.apply())
+      .end(
+        co(function* () {
+          const contentType = yield getDevContentType(
+            SOURCE_TEST_SPACE,
+            environmentId,
+            'experienceType'
+          )
+          expect(contentType.metadata).to.eql({
+            annotations: {
+              ContentType: [
+                {
+                  sys: {
+                    id: 'Contentful:ExperienceType',
+                    type: 'Link',
+                    linkType: 'Annotation'
+                  }
+                }
+              ]
+            }
+          })
+          done()
+        })
+      )
+  })
 })

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -42,6 +42,7 @@ const moveFieldOnContentTypeWithEditorLayout = require('../../examples/51-move-f
 const deleteFieldOnContentTypeWithEditorLayout = require('../../examples/52-delete-field-in-content-type-with-editor-layout')
 const renameFieldOnContentTypeWithEditorLayout = require('../../examples/53-rename-field-in-content-type-with-editor-layout')
 const createRichTextFieldWithValidation = require('../../examples/22-create-rich-text-field-with-validation')
+const createExperienceType = require('../../examples/54-create-experience-type')
 
 const { createMigrationParser } = require('../../built/lib/migration-parser')
 const { DEFAULT_SIDEBAR_LIST } = require('../../built/lib/action/sidebarwidget')
@@ -1376,6 +1377,29 @@ describe('the migration', function () {
           contentTypes: ['contentType1', 'contentType2', 'contentType3']
         }
       ]
+    })
+  })
+
+  // Requires space to be enables for Studio Experiences via org settings
+  it('assigns experience type annotation', async function () {
+    await migrator(createExperienceType)
+    const ct = await request({
+      method: 'GET',
+      url: '/content_types/experienceType'
+    })
+
+    expect(ct.metadata).to.eql({
+      annotations: {
+        ContentType: [
+          {
+            sys: {
+              id: 'Contentful:ExperienceType',
+              type: 'Link',
+              linkType: 'Annotation'
+            }
+          }
+        ]
+      }
     })
   })
 })

--- a/test/integration/migration.spec.js
+++ b/test/integration/migration.spec.js
@@ -1380,7 +1380,7 @@ describe('the migration', function () {
     })
   })
 
-  // Requires space to be enables for Studio Experiences via org settings
+  // Note: Requires space to be enabled for Studio Experiences via org settings
   it('assigns experience type annotation', async function () {
     await migrator(createExperienceType)
     const ct = await request({


### PR DESCRIPTION
## Summary

Add support for annotations used by experience types in the validations of the offline API.

## Description

[TDD] To ensure it is working through this change, this PR includes an example migration, an integration test, and an e2e test which actually tests this local validation layer.

## Test manually
To test the following things locally, check out the CONTRIBUTION.md and add the necessary env variables:
- `CONTENTFUL_SPACE_ID` (space name must be "contentful-migration')
- `CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN` (for e2e & integration test)
- `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` (same as above but other name, used for manual migration run)

1. Run e2e test locally: `npm run build && npm run test:e2e`
2. Run integration test locally: `npm run build && npm run test:integration`
3. Run example migration locally: `node examples/usage-as-lib.js ../../examples/54-create-experience-type.js`

Also, note that the migration creating an experience type requires the proper space enablement being set up in the org settings:
![Screenshot 2024-06-20 at 15 20 54](https://github.com/contentful/contentful-migration/assets/9327071/8b6f0604-0624-4ef5-a282-aa0c1f1b50c1)

I made this change for our integration test environment (org "Ecosystem Integration Tests") to unblock CI.

## Motivation and Context

When trying to create a content type and transform it into an experience type with the proper assignment, users get a validation error on the CLI as the offline API of this repo incorporates a local validation layer that explicitly allows only certain annotations.

## Screenshots (if appropriate):
<img width="448" alt="Screenshot 2024-06-20 at 15 22 01" src="https://github.com/contentful/contentful-migration/assets/9327071/c4ae048e-bad6-4fca-98cf-591b558fde42">