### PR TITLE
feat(field-validations-schema): added strikethrough validation option

### DIFF
--- a/examples/22-create-rich-text-field-with-validation.js
+++ b/examples/22-create-rich-text-field-with-validation.js
@@ -47,8 +47,17 @@ module.exports = function (migration) {
         }
       },
       {
-        enabledMarks: ['bold', 'italic', 'underline', 'code', 'superscript', 'subscript'],
-        message: 'Only bold, italic, underline, code, superscript, and subscript marks are allowed'
+        enabledMarks: [
+          'bold',
+          'italic',
+          'underline',
+          'code',
+          'superscript',
+          'subscript',
+          'strikethrough'
+        ],
+        message:
+          'Only bold, italic, underline, code, superscript, subscript, and strikethrough marks are allowed'
       },
       {
         enabledNodeTypes: [

--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -75,7 +75,15 @@ const nodes = validation(
 const enabledMarks = validation(
   'enabledMarks',
   Joi.array().items(
-    Joi.string().valid('bold', 'italic', 'code', 'underline', 'superscript', 'subscript')
+    Joi.string().valid(
+      'bold',
+      'italic',
+      'code',
+      'underline',
+      'superscript',
+      'subscript',
+      'strikethrough'
+    )
   )
 )
 


### PR DESCRIPTION
re #1321

## Summary

Adds the new strikethrough options into the validation

## Description

- Adds strikethrough option to validation schema
- Updates example to include strikethrough 

## Motivation and Context

- enables us to use new rich text strikethrough option in our validation schema

