### PR TITLE
feat: bump limit of allowed sources

### DIFF
--- a/src/lib/offline-api/validator/schema/field-validations-schema.ts
+++ b/src/lib/offline-api/validator/schema/field-validations-schema.ts
@@ -56,19 +56,24 @@ const assetImageDimensions = validation(
 
 const assetFileSize = validation('assetFileSize', range('number'))
 
+const resourceLinkNode = () =>
+  Joi.object({
+    validations: Joi.array().items(size),
+    allowedResources: allowedResourcesSchema
+  })
+
 const nodes = validation(
   'nodes',
   Joi.object({
     'embedded-entry-block': Joi.array(),
     'embedded-entry-inline': Joi.array(),
+    'embedded-resource-inline': resourceLinkNode(),
     'embedded-asset-block': Joi.array(),
-    'embedded-resource-block': Joi.object({
-      validations: Joi.array().items(size),
-      allowedResources: allowedResourcesSchema
-    }),
+    'embedded-resource-block': resourceLinkNode(),
     'entry-hyperlink': Joi.array(),
     'asset-hyperlink': Joi.array(),
-    hyperlink: Joi.array()
+    hyperlink: Joi.array(),
+    'resource-hyperlink': resourceLinkNode()
   })
 )
 
@@ -100,7 +105,9 @@ const enabledNodeTypes = validation(
       'hyperlink',
       'entry-hyperlink',
       'asset-hyperlink',
-      'embedded-entry-inline'
+      'resource-hyperlink',
+      'embedded-entry-inline',
+      'embedded-resource-inline'
     )
   )
 )

--- a/src/lib/utils/resource-links.ts
+++ b/src/lib/utils/resource-links.ts
@@ -1,4 +1,4 @@
-export const MAX_ALLOWED_RESOURCES = 3
+export const MAX_ALLOWED_RESOURCES = 20
 export const MAX_RESOURCE_LINKS = 3
 
 export const RICH_TEXT_RESOURCE_LINK_NODES = ['embedded-resource-block']

--- a/test/unit/lib/offline-api/validation/payload-validation-resource-links.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-resource-links.spec.ts
@@ -2,7 +2,10 @@
 
 import { expect } from 'chai'
 import validateBatches from './validate-batches'
-import { MAX_RESOURCE_LINKS } from '../../../../../src/lib/utils/resource-links'
+import {
+  MAX_ALLOWED_RESOURCES,
+  MAX_RESOURCE_LINKS
+} from '../../../../../src/lib/utils/resource-links'
 
 const VALID_ALLOWED_RESOURCE = {
   type: 'Contentful:Entry',
@@ -136,29 +139,19 @@ describe('payload validation (dependencies)', function () {
           .createField('mainCourse')
           .name('Main Course')
           .type('ResourceLink')
-          .allowedResources([
-            {
+          .allowedResources(
+            [...Array(MAX_ALLOWED_RESOURCES + 1).keys()].map((value) => ({
               ...VALID_ALLOWED_RESOURCE,
-              source: 'crn:contentful:::content:spaces/cooking-space-1'
-            },
-            {
-              ...VALID_ALLOWED_RESOURCE,
-              source: 'crn:contentful:::content:spaces/cooking-space-2'
-            },
-            {
-              ...VALID_ALLOWED_RESOURCE,
-              source: 'crn:contentful:::content:spaces/cooking-space-3'
-            },
-            { ...VALID_ALLOWED_RESOURCE, source: 'crn:contentful:::content:spaces/cooking-space-4' }
-          ])
+              source: `crn:contentful:::content:spaces/cooking-space-${value + 1}`
+            }))
+          )
       }, existingCts)
 
       expect(errors).to.eql([
         [
           {
             type: 'InvalidPayload',
-            message:
-              'The property "allowedResources" on the field "mainCourse" must have at most 3 items.'
+            message: `The property "allowedResources" on the field "mainCourse" must have at most ${MAX_ALLOWED_RESOURCES} items.`
           }
         ]
       ])

--- a/test/unit/lib/offline-api/validation/payload-validation-rich-text-resource-link-embeds.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-rich-text-resource-link-embeds.spec.ts
@@ -326,8 +326,7 @@ describe('payload validation (dependencies)', function () {
       expect(errors).to.eql([
         [
           {
-            message:
-              'The property "validations.1.nodes.embedded-resource-block.allowedResources" on the field "menu" must have at most 3 items.',
+            message: `The property "validations.1.nodes.embedded-resource-block.allowedResources" on the field "menu" must have at most ${MAX_ALLOWED_RESOURCES} items.`,
             type: 'InvalidPayload'
           }
         ]


### PR DESCRIPTION
## Summary

This bumps the limit to be in sync with the one enforced through the API.