### PR TITLE
feat: allow external resources to be set

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -161,11 +161,17 @@ export interface IValidation {
   [validation: string]: any
 }
 
-export interface AllowedResource {
+export interface ContentfulEntryResource {
   type: 'Contentful:Entry'
   source: string
   contentTypes: string[]
 }
+
+export interface ExternalResource {
+  type: string
+}
+
+export type AllowedResource = ContentfulEntryResource | ExternalResource
 
 export type WidgetSettingsValue = number | boolean | string | undefined
 


### PR DESCRIPTION
## Summary

Allow adding external resources to allowed resources in the content type to enable [Native External References](https://www.contentful.com/help/orchestration/native-external-references/).

## Motivation and Context

I didn’t update the tests for this as the change is tiny and the test would have required an app to be installed making it much more complicated than the change.
