### PR TITLE
chore: bump cma.js to latest [ZEND-5523]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.0.0",
-        "contentful-management": "^11.15.0",
+        "contentful-management": "^11.35.1",
         "didyoumean2": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "inquirer": "^8.1.2",
@@ -4693,12 +4693,12 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.31.4",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.31.4.tgz",
-      "integrity": "sha512-gN2wz4lHw4hfh0aQ9X5uirfa0F5gJDgTOyJceSPa86+xPR0T0DfPVNrGeXg0w+HXXTgLmWl+LiinXvCPNW9wTA==",
+      "version": "11.35.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.35.1.tgz",
+      "integrity": "sha512-PBOFpeOCzwx7+PQtHhgFRNB8wnlgUKUj+3rTucaMIYot5l9YA4804P9VYWq6Mg8/PJnFjavQrtay6HtqWDyYMw==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.7.2",
+        "axios": "^1.7.4",
         "contentful-sdk-core": "^8.3.1",
         "fast-copy": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",
     "chalk": "^4.0.0",
-    "contentful-management": "^11.15.0",
+    "contentful-management": "^11.35.1",
     "didyoumean2": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "inquirer": "^8.1.2",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Bump CMA to latest version to remove axios security vuln in <1.7.4

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
