### PR TITLE
fix: explicitly upgrade axios to 1.7.9 [ZEND-5779]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/hoek": "^11.0.4",
-        "axios": "^1.7.7",
+        "axios": "^1.7.9",
         "bluebird": "^3.7.2",
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "@hapi/hoek": "^11.0.4",
-    "axios": "^1.7.7",
+    "axios": "^1.7.9",
     "bluebird": "^3.7.2",
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Explicitly upgrade axios to ^1.7.9 so downstream consumers know that the latest is the acceptable valid version.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

Even though axios was previously bumped to 1.7.9 in the lockfile, 1.7.4 was still marked as valid for downstream consumers, so they wouldn't get the new version without regenerating their lockfile or executing npm audit fix in their projects that use contentful-migration.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
