### PR TITLE
fix: explicitly upgrade contentful-management to ^11.40.3 [ZEND-5779]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.0.0",
-        "contentful-management": "^11.35.1",
+        "contentful-management": "^11.40.3",
         "didyoumean2": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "inquirer": "^8.1.2",
@@ -997,6 +997,18 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.29.1.tgz",
+      "integrity": "sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
@@ -2713,13 +2725,13 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.35.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.35.1.tgz",
-      "integrity": "sha512-PBOFpeOCzwx7+PQtHhgFRNB8wnlgUKUj+3rTucaMIYot5l9YA4804P9VYWq6Mg8/PJnFjavQrtay6HtqWDyYMw==",
+      "version": "11.40.3",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.40.3.tgz",
+      "integrity": "sha512-4MC2HJ7VAr8+vpyZoWEraWRxh7zHGbEUkMA4oM/wlOv9MX8N8utrokU9Z8hMqtXSwKkOBAYrJorvfxnRgJdVFA==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.7.4",
-        "contentful-sdk-core": "^8.3.1",
+        "axios": "^1.7.9",
+        "contentful-sdk-core": "^9.0.1",
         "fast-copy": "^3.0.0"
       },
       "engines": {
@@ -2727,24 +2739,33 @@
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.3.1.tgz",
-      "integrity": "sha512-HYy4ecFA76ERxz7P0jW7hgDcL8jH+bRckv2QfAwQ4k1yPP9TvxpZwrKnlLM69JOStxVkCXP37HvbjbFnjcoWdg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.0.1.tgz",
+      "integrity": "sha512-Ao/5Y74ERPn6kjzb/8okYPuQJnikMtR+dnv0plLw8IvPomwXonLq3qom0rLSyo5KuvQkBMa9AApy1izunxW4mw==",
       "dependencies": {
-        "fast-copy": "^2.1.7",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "p-throttle": "^4.1.1",
-        "qs": "^6.11.2"
+        "fast-copy": "^3.0.2",
+        "lodash": "^4.17.21",
+        "p-throttle": "^6.1.0",
+        "process": "^0.11.10",
+        "qs": "^6.12.3"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.18.0"
       }
     },
-    "node_modules/contentful-sdk-core/node_modules/fast-copy": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+    "node_modules/contentful-sdk-core/node_modules/p-throttle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.2.0.tgz",
+      "integrity": "sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -4667,9 +4688,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
-      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6764,12 +6785,14 @@
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
     },
     "node_modules/lodash.map": {
       "version": "4.6.0",
@@ -11166,6 +11189,14 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -11211,9 +11242,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dependencies": {
         "side-channel": "^1.0.6"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",
     "chalk": "^4.0.0",
-    "contentful-management": "^11.35.1",
+    "contentful-management": "^11.40.3",
     "didyoumean2": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "inquirer": "^8.1.2",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Explicitly upgrade contentful-management to ^11.40.3 so downstream consumers know that the latest is the acceptable valid version.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Even though contentful-management was previously bumped to 11.40.3 in the lockfile, 11.35.1 was still marked as valid for downstream consumers, so they wouldn't get the new version without regenerating their lockfile or executing `npm audit fix` in their projects that use contentful-migration.
