### PR TITLE
feat: allow NER resource types in allowedResources

### DIFF
--- a/src/lib/offline-api/validator/schema/allowed-resources-schema.ts
+++ b/src/lib/offline-api/validator/schema/allowed-resources-schema.ts
@@ -6,9 +6,17 @@ export const allowedResourcesSchema = Joi.array()
   .max(MAX_ALLOWED_RESOURCES)
   .unique('source')
   .items(
-    Joi.object({
-      type: Joi.string().valid('Contentful:Entry'),
-      source: Joi.string(),
-      contentTypes: Joi.array().min(1).items(Joi.string())
-    })
+    Joi.alternatives().conditional(
+      Joi.object({ type: Joi.string().regex(/^Contentful:/) }).unknown(),
+      {
+        then: Joi.object({
+          type: Joi.string().valid('Contentful:Entry'),
+          source: Joi.string(),
+          contentTypes: Joi.array().min(1).items(Joi.string())
+        }),
+        otherwise: Joi.object({
+          type: Joi.string().regex(/^[A-Z][a-z]*:[A-Z][a-z]*$/)
+        })
+      }
+    )
   )

--- a/test/unit/lib/offline-api/validation/payload-validation-resource-links.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-resource-links.spec.ts
@@ -272,7 +272,7 @@ describe('payload validation (dependencies)', function () {
       ])
     })
 
-    it('should return an error when the type value is referencing a invalid type', async function () {
+    it('returns an error when the type value is referencing a invalid type', async function () {
       const existingCts = []
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('Lunch').description('A Lunch')
@@ -299,7 +299,7 @@ describe('payload validation (dependencies)', function () {
       ])
     })
 
-    it('should return an error when the type value is referencing custom ResourceProvider:ResourceType pair with additional properties', async function () {
+    it('returns an error when the type value is referencing custom ResourceProvider:ResourceType pair with additional properties', async function () {
       const existingCts = []
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('Lunch').description('A Lunch')

--- a/test/unit/lib/offline-api/validation/payload-validation-rich-text-resource-link-embeds.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-rich-text-resource-link-embeds.spec.ts
@@ -184,7 +184,7 @@ describe('payload validation (dependencies)', function () {
       ])
     })
 
-    it('should return an error when the type value is not one of the supported values', async function () {
+    it('should return an error when the type value is not one of the supported values for the Contentful: Provider', async function () {
       const existingCts = []
       const errors = await validateBatches(function (migration) {
         const lunch = migration.createContentType('lunch').name('Lunch').description('A Lunch')


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Allows custom `type` parameter in `allowedResources` to support NER

## Description

If the `type` starts with `Contentful:` we validate whether it is an allowed (internal) ResourceType and whether the additional properties are correct. If it is a custom `type` which is used by NER no additional properties are allowed.
