### PR TITLE
Improve types for builtin editor widget IDs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,32 @@ export interface EditorLayoutMovement {
   afterFieldGroup(groupId?: string): void
 }
 
+type BuiltinEditor =
+  | 'assetLinkEditor'
+  | 'assetLinksEditor'
+  | 'assetGalleryEditor'
+  | 'boolean'
+  | 'datePicker'
+  | 'entryLinkEditor'
+  | 'entryLinksEditor'
+  | 'entryCardEditor'
+  | 'entryCardsEditor'
+  | 'numberEditor'
+  | 'rating'
+  | 'locationEditor'
+  | 'objectEditor'
+  | 'urlEditor'
+  | 'slugEditor'
+  | 'listInput'
+  | 'checkbox'
+  | 'tagEditor'
+  | 'multipleLine'
+  | 'markdown'
+  | 'singleLine'
+  | 'dropdown'
+  | 'radio'
+  | 'richTextEditor'
+
 type FieldType =
   | 'Symbol'
   | 'Text'
@@ -208,8 +234,8 @@ export interface IFieldGroupWidgetSettings {
 }
 
 export interface IEntryEditor {
-  widgetNamespace: 'editor-builtin' | 'builtin' | 'extension' | 'app',
-  widgetId: string,
+  widgetNamespace: 'editor-builtin' | 'builtin' | 'extension' | 'app'
+  widgetId: string
   settings?: IEditorInterfaceOptions
 }
 
@@ -251,7 +277,12 @@ export interface ContentType {
    * @param settings Widget settings
    */
   configureEntryEditor(
-    widgetNamespace: 'editor-builtin' | 'builtin' | 'extension' | 'app',
+    widgetNamespace: 'builtin',
+    widgetId: BuiltinEditor,
+    settings?: IEditorInterfaceOptions
+  ): void
+  configureEntryEditor(
+    widgetNamespace: 'editor-builtin' | 'extension' | 'app',
     widgetId: string,
     settings?: IEditorInterfaceOptions
   ): void
@@ -273,7 +304,13 @@ export interface ContentType {
    */
   changeFieldControl(
     fieldId: string,
-    widgetNamespace: 'builtin' | 'extension' | 'app',
+    widgetNamespace: 'builtin',
+    widgetId: BuiltinEditor,
+    settings: IEditorInterfaceOptions
+  ): void
+  changeFieldControl(
+    fieldId: string,
+    widgetNamespace: 'extension' | 'app',
     widgetId: string,
     settings?: IEditorInterfaceOptions
   ): void


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
Currently its pretty easy to mistype or put the wrong `widgetId` when changing editor interfaces. This PR introduces function overloading to the `index.d.ts` file to restrict this from `string` to the widget IDs listed in your website:
https://www.contentful.com/developers/docs/extensibility/app-framework/editor-interfaces/.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

I'm sick of guessing the wrong `widgetId` and would prefer a nicer developer experience. Copying these changes locally into our production application very clearly shows when there is an invalid `widgetId` for a builtin widget. Examples:

<img width="972" alt="image" src="https://github.com/user-attachments/assets/452d93dd-9242-4005-9f1f-445b5a4244eb" />

This catches these errors before they happen (`number` is not a valid widgetId)
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/a38ae618-613d-4b19-a5b4-f9f8a0b000ef" />


## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
