### PR TITLE
Feat - Exit with Non-Zero Code on Migration Cancellation

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -268,6 +268,7 @@ const createRun = ({ shouldThrow }) =>
       }
     } else {
       console.warn(chalk`⚠️  {bold.yellow Migration aborted}`)
+      terminate({ shouldThrow: true })
     }
   }
 


### PR DESCRIPTION
## Summary

This PR adds a non-zero exit code to `contentful space migration` when the user cancels the migration by pressing "n" at the confirmation prompt.

## Description

#1470 has the detailed reasoning behind this PR.

## Motivation and Context

This change allows scripts to reliably detect user-cancelled migrations and take appropriate action.

Closes #1470 

## Caveats

I've never contributed to such CLI tools so I don't know exactly how to build and test this locally. I've run `npm test` in a test space and I had 4 failures (probably because it's a free space).

If someone guides me through how to build and test this locally I'd love to do that. I'd gladly add documetation regarding to that as well.