### PR TITLE
Fix allowedResources regex validation []

### DIFF
--- a/src/lib/offline-api/validator/schema/allowed-resources-schema.ts
+++ b/src/lib/offline-api/validator/schema/allowed-resources-schema.ts
@@ -15,7 +15,7 @@ export const allowedResourcesSchema = Joi.array()
           contentTypes: Joi.array().min(1).items(Joi.string())
         }),
         otherwise: Joi.object({
-          type: Joi.string().regex(/^[A-Z][a-z]*:[A-Z][a-z]*$/)
+          type: Joi.string().regex(/^[a-zA-Z][a-zA-Z0-9]*:[A-Za-z0-9]+$/)
         })
       }
     )

--- a/test/unit/lib/offline-api/validation/payload-validation-resource-links.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation-resource-links.spec.ts
@@ -292,7 +292,7 @@ describe('payload validation (dependencies)', function () {
         [
           {
             message:
-              'Allowed resource at index 0 on the field "mainCourse" has an invalid property: "type" with value "Foo" fails to match the required pattern: /^[A-Z][a-z]*:[A-Z][a-z]*$/.',
+              'Allowed resource at index 0 on the field "mainCourse" has an invalid property: "type" with value "Foo" fails to match the required pattern: /^[a-zA-Z][a-zA-Z0-9]*:[A-Za-z0-9]+$/.',
             type: 'InvalidPayload'
           }
         ]


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Regex validation for `allowedResources` for NER did not match the regex for [ResourceProvider](https://github.com/contentful/extensibility-api/blob/main/lib/entities/resource-provider/schema.ts#L28) and [ResourceType](https://github.com/contentful/extensibility-api/blob/main/lib/entities/resource-type/validator.ts#L31C72-L31C84) in the extensibility-api

