### PR TITLE
fix: increase content type max fields to 100 [ZEND-6191]

### DIFF
--- a/src/lib/offline-api/validator/schema/content-type-schema.ts
+++ b/src/lib/offline-api/validator/schema/content-type-schema.ts
@@ -1,6 +1,6 @@
 import * as Joi from 'joi'
 
-const MAX_FIELDS = 50
+const MAX_FIELDS = 100
 const contentTypeSchema = Joi.object().keys({
   name: Joi.string().required(),
   description: Joi.string().allow(''),

--- a/test/unit/lib/offline-api/validation/payload-validation.spec.ts
+++ b/test/unit/lib/offline-api/validation/payload-validation.spec.ts
@@ -37,7 +37,7 @@ describe('payload validation', function () {
         const lunch = migration.createContentType('lunch')
         lunch.name('A lunch')
 
-        for (let i = 0; i < 51; i++) {
+        for (let i = 0; i < 101; i++) {
           lunch.createField(`menu${i}`).type('Symbol').name(`menu${i}`)
         }
       }, [])
@@ -45,7 +45,7 @@ describe('payload validation', function () {
         [
           {
             type: 'InvalidPayload',
-            message: 'Content type "lunch" cannot have more than 50 fields.'
+            message: 'Content type "lunch" cannot have more than 100 fields.'
           }
         ]
       ])


### PR DESCRIPTION
## Summary

Increases _maximum possible fields allowed_ from 50 to 100.

## Description

Change `content-type-schema` variable.
