### PR TITLE
feat: add entryIds parameter to transformEntriesToType

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ For the given (source) content type, transforms all its entries according to the
 - **`sourceContentType : string`** _(required)_ – Content type ID of source entries
 - **`targetContentType : string`** _(required)_ – Targeted Content type ID
 - **`from : array`** _(optional)_ – Array of the source field IDs, returns complete list of fields if not configured
+- **`entryIds : array`** _(optional)_ – Array of entry IDs to limit transformation to specific entries. If not provided, all entries of the source content type will be transformed
 - **`identityKey: function (fields): string`** _(required)_ - Function to create a new entry ID for the target entry
 - **`shouldPublish : bool | 'preserve'`** _(optional)_ – Flag that specifies publishing of target entries, `preserve` will keep current states of the source entries (default `false`)
 - **`updateReferences : bool`** _(optional)_ – Flag that specifies if linking entries should be updated with target entries (default `false`). Note that this flag does not support Rich Text Fields references.

--- a/src/lib/action/entry-transform-to-type.ts
+++ b/src/lib/action/entry-transform-to-type.ts
@@ -9,6 +9,7 @@ class EntryTransformToTypeAction extends APIAction {
   private fromFields?: string[]
   private sourceContentTypeId: string
   private targetContentTypeId: string
+  private entryIds?: string[]
   private transformEntryForLocale: (
     inputFields: any,
     locale: string,
@@ -24,6 +25,7 @@ class EntryTransformToTypeAction extends APIAction {
     this.fromFields = entryTransformation.from
     this.sourceContentTypeId = entryTransformation.sourceContentType
     this.targetContentTypeId = entryTransformation.targetContentType
+    this.entryIds = entryTransformation.entryIds
     this.identityKey = entryTransformation.identityKey
     this.shouldPublish = entryTransformation.shouldPublish || false
     this.removeOldEntries = entryTransformation.removeOldEntries || false
@@ -32,7 +34,10 @@ class EntryTransformToTypeAction extends APIAction {
   }
 
   async applyTo(api: OfflineAPI) {
-    const entries: Entry[] = await api.getEntriesForContentType(this.sourceContentTypeId)
+    const allEntries: Entry[] = await api.getEntriesForContentType(this.sourceContentTypeId)
+    const entries: Entry[] = this.entryIds
+      ? allEntries.filter((entry) => this.entryIds!.includes(entry.id))
+      : allEntries
     const locales: string[] = await api.getLocalesForSpace()
 
     for (const entry of entries) {

--- a/src/lib/interfaces/entry-transform-to-type.ts
+++ b/src/lib/interfaces/entry-transform-to-type.ts
@@ -2,6 +2,7 @@ export default interface TransformEntryToType {
   sourceContentType: string
   targetContentType: string
   from?: string[]
+  entryIds?: string[]
   identityKey: (fromFields: any) => Promise<string>
   shouldPublish?: boolean | 'preserve'
   useLocaleBasedPublishing?: boolean

--- a/test/unit/lib/actions/entry-transform-to-type.spec.ts
+++ b/test/unit/lib/actions/entry-transform-to-type.spec.ts
@@ -560,4 +560,56 @@ describe('Transform Entry to Type Action', function () {
     await api.stopRecordingRequests()
     expect(ids).to.eql(['246'])
   })
+
+  it('transforms only specified entries when entryIds is provided', async function () {
+    const transformation: TransformEntryToType = {
+      sourceContentType: 'dog',
+      targetContentType: 'copycat',
+      from: ['name'],
+      entryIds: ['246'],
+      identityKey: async (fields) => fields.name['en-US'].toString(),
+      transformEntryForLocale: async (fields, locale) => {
+        return { name: 'x' + fields['name'][locale] }
+      }
+    }
+
+    const action = new EntryTransformToTypeAction(transformation)
+    const entries = [
+      new Entry(
+        makeApiEntry({
+          id: '246',
+          contentTypeId: 'dog',
+          version: 1,
+          fields: {
+            name: {
+              'en-US': 'bob'
+            }
+          }
+        })
+      ),
+      new Entry(
+        makeApiEntry({
+          id: '247',
+          contentTypeId: 'dog',
+          version: 1,
+          fields: {
+            name: {
+              'en-US': 'alice'
+            }
+          }
+        })
+      )
+    ]
+    const api = new OfflineApi({ contentTypes: new Map(), entries, locales: ['en-US'] })
+    await api.startRecordingRequests(null)
+
+    await action.applyTo(api)
+    await api.stopRecordingRequests()
+    const batches = await api.getRequestBatches()
+
+    expect(batches[0].requests.length).to.eq(1)
+    const targetData = batches[0].requests[0].data as APIEntry
+    expect(targetData.fields['name']['en-US']).to.eql('xbob')
+    expect(targetData.sys.id).to.eql('bob')
+  })
 })


### PR DESCRIPTION
## Summary

  Add optional `entryIds` parameter to `transformEntriesToType` method to enable filtering transformation to specific entries only.

  ### Description

  This PR introduces an optional `entryIds` parameter to the `transformEntriesToType` configuration object, allowing users to limit the transformation operation to a specific subset of entries
  rather than processing all entries of the source content type.

  ### Changes made:

  - Interface Update: Added `entryIds?: string[]` to the `TransformEntryToType` interface
  - Implementation: Updated `EntryTransformToTypeAction` class to accept and filter entries based on provided IDs
  - Testing: Added comprehensive test case to verify filtering functionality works correctly
  - Documentation: Updated `README.md` with parameter description and usage details

  ### Motivation and Context

  When working with large content types containing many entries, I needed to transform only a specific subset of entries rather than all entries. Previously, the
  `transformEntriesToType` method would process every entry of the source content type, which could be inefficient and potentially risky when only certain entries need transformation.