### PR TITLE
feat: allow specifying certain entryIds for transformation to transformEntriesToType (#1530)

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ For the given (source) content type, transforms all its entries according to the
 - **`sourceContentType : string`** _(required)_ – Content type ID of source entries
 - **`targetContentType : string`** _(required)_ – Targeted Content type ID
 - **`from : array`** _(optional)_ – Array of the source field IDs, returns complete list of fields if not configured
+- **`entryIds : array`** _(optional)_ – Array of entry IDs to limit transformation to specific entries. If not provided, all entries of the source content type will be transformed
 - **`identityKey: function (fields): string`** _(required)_ - Function to create a new entry ID for the target entry
 - **`shouldPublish : bool | 'preserve'`** _(optional)_ – Flag that specifies publishing of target entries, `preserve` will keep current states of the source entries (default `false`)
 - **`updateReferences : bool`** _(optional)_ – Flag that specifies if linking entries should be updated with target entries (default `false`). Note that this flag does not support Rich Text Fields references.

--- a/src/lib/action/entry-transform-to-type.ts
+++ b/src/lib/action/entry-transform-to-type.ts
@@ -9,6 +9,7 @@ class EntryTransformToTypeAction extends APIAction {
   private fromFields?: string[]
   private sourceContentTypeId: string
   private targetContentTypeId: string
+  private entryIds?: string[]
   private transformEntryForLocale: (
     inputFields: any,
     locale: string,
@@ -25,6 +26,7 @@ class EntryTransformToTypeAction extends APIAction {
     this.fromFields = entryTransformation.from
     this.sourceContentTypeId = entryTransformation.sourceContentType
     this.targetContentTypeId = entryTransformation.targetContentType
+    this.entryIds = entryTransformation.entryIds
     this.identityKey = entryTransformation.identityKey
     this.shouldPublish = entryTransformation.shouldPublish || false
     this.removeOldEntries = entryTransformation.removeOldEntries || false
@@ -34,7 +36,10 @@ class EntryTransformToTypeAction extends APIAction {
   }
 
   async applyTo(api: OfflineAPI) {
-    const entries: Entry[] = await api.getEntriesForContentType(this.sourceContentTypeId)
+    const allEntries: Entry[] = await api.getEntriesForContentType(this.sourceContentTypeId)
+    const entries: Entry[] = this.entryIds
+      ? allEntries.filter((entry) => this.entryIds!.includes(entry.id))
+      : allEntries
     const locales: string[] = await api.getLocalesForSpace()
 
     for (const entry of entries) {

--- a/src/lib/interfaces/entry-transform-to-type.ts
+++ b/src/lib/interfaces/entry-transform-to-type.ts
@@ -2,6 +2,7 @@ export default interface TransformEntryToType {
   sourceContentType: string
   targetContentType: string
   from?: string[]
+  entryIds?: string[]
   identityKey: (fromFields: any) => Promise<string>
   shouldPublish?: boolean | 'preserve'
   useLocaleBasedPublishing?: boolean


### PR DESCRIPTION
## Summary

  Add optional `entryIds` parameter to `transformEntriesToType` method to enable filtering transformation to specific entries only.

  ### Description

  This PR introduces an optional `entryIds` parameter to the `transformEntriesToType` configuration object, allowing users to limit the transformation operation to a specific subset of entries
  rather than processing all entries of the source content type.

  ### Changes made:

  - Interface Update: Added `entryIds?: string[]` to the `TransformEntryToType` interface
  - Implementation: Updated `EntryTransformToTypeAction` class to accept and filter entries based on provided IDs
  - Testing: Added comprehensive test case to verify filtering functionality works correctly
  - Documentation: Updated `README.md` with parameter description and usage details

  ### Motivation and Context

  When working with large content types containing many entries, I needed to transform only a specific subset of entries rather than all entries. Previously, the
  `transformEntriesToType` method would process every entry of the source content type, which could be inefficient and potentially risky when only certain entries need transformation.
  
Co-authored-by @patrykkurczyna 