### PR TITLE
fix: add resource editor types to builtin editor type definition [DX-351]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,8 @@ type BuiltinEditor =
   | 'dropdown'
   | 'radio'
   | 'richTextEditor'
+  | 'resourceLinkEditor'
+  | 'resourceLinksEditor'
 
 type FieldType =
   | 'Symbol'


### PR DESCRIPTION
## Summary

Add both `resourceLinkEditor` and `resourceLinksEditor` to the valid types for the built-in editor type definition.

