### PR TITLE
fix: allow null value for regexp flags in validation interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -171,7 +171,7 @@ export interface IValidation {
   /** Takes min and/or max parameters and validates the range of a value. */
   range?: { max?: number; min?: number }
   /** Takes a string that reflects a JS regex and flags, validates against a string. See JS reference for the parameters. */
-  regexp?: { pattern: string; flags?: string }
+  regexp?: { pattern: string; flags?: string | null }
   /** Validates that there are no other entries that have the same field value at the time of publication. */
   unique?: true
   /** Validates that a value falls within a certain range of dates. */


### PR DESCRIPTION
## Summary

Creating a diff file for migration returns flags: null when no flags are set in the ui, therefore failing TS typecheck.
Joi configuration allows null as a value, so I believe type definition is lagging behind

## Description

Update types definition file to match the reality.

## Motivation and Context

Fixes annoying type errors on programmatically generated migration files

## Screenshots (if appropriate):
<img width="914" height="399" alt="Screenshot 2025-09-02 at 13 27 28" src="https://github.com/user-attachments/assets/8f44f2a2-1874-426e-b978-1a5264b51910" />

