### PR TITLE
fix: entry-derive - check localeBasedPublishing and entry.fieldStatus before publishing [DX-378]

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ The derive function is expected to return an object with the desired target fiel
 
 - **`shouldPublish : bool|'preserve'`** _(optional)_ – If true, both the source and the derived entries will be published. If false, both will remain in draft state. If preserve, will keep current states of the source entries (default `true`)
 
+- **`useLocaleBasedPublishing : bool`** _(optional)_ - If true, the transformed entries will be published with locale based publishing. If `false`, they will remain in draft state. When the value from `shouldPublish` is set to "preserve" items will be published only if the original entry was published in this locale as well (default false)
+
 ##### `deriveLinkedEntries(config)` Example
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -607,6 +607,14 @@ export interface IDeriveLinkedEntriesConfig {
    * The return value must be an object with the same keys as specified in derivedFields. Their values will be written to the respective new entry fields for the current locale (i.e. {nameField: 'myNewValue'})
    */
   deriveEntryForLocale: (inputFields: ContentFields, locale: string) => { [field: string]: any }
+
+  /**
+   * (optional) – If true, the transformed entries will be published with locale based publishing.
+   * If `false`, they will remain in draft state. When the value from `shouldPublish` is set to
+   * "preserve" items will be published only if the original entry was published in this locale
+   *  as well (default false)
+   */
+  useLocaleBasedPublishing?: boolean
 }
 
 type TagVisibility = 'private' | 'public'

--- a/src/lib/action/entry-derive.ts
+++ b/src/lib/action/entry-derive.ts
@@ -40,7 +40,15 @@ class EntryDeriveAction extends APIAction {
 
   private async publishEntry(api: OfflineAPI, entry: Entry, locales: string[]) {
     if (this.useLocaleBasedPublishing) {
-      await api.localeBasedPublishEntry(entry.id, locales)
+      // Publish only locales that were already published if shouldPublish is 'preserve'
+      const localesToPublish =
+        this.shouldPublish === 'preserve' && entry.fieldStatus
+          ? Object.entries(entry.fieldStatus['*'])
+              .filter(([, status]) => status === 'published')
+              .map(([locale]) => locale)
+          : locales
+
+      await api.localeBasedPublishEntry(entry.id, localesToPublish)
     } else {
       await api.publishEntry(entry.id)
     }


### PR DESCRIPTION
### Bug:
When passing `shouldPublish: "preserve"` param to `deriveLinkedEntries()`, because of this [line](https://github.com/contentful/contentful-migration/blob/main/src/lib/utils/should-publish-local-changes.ts#L26), if **any** locale has been published, then **all** locales will be published 😲.

### Bonus: Docs improvement
- add `useLocaleBasedPublishing` description to README, has existed for ~7 months but was not documented.


### Bonus: Typescript types
- add `useLocaleBasedPublishing` to index.d.ts for `IDeriveLinkedEntriesConfig`, again this has existed for ~7 months but was not part of the type.

### Bug Resolution:
in `deriveLinkedEntries()`'s `publishEntry()`, run an extra check to ensure that only locales that were previously published, should be published.  Draft and Changed locales should not be published.

```js
if (this.useLocaleBasedPublishing) {
  // Publish only locales that were already published if shouldPublish is 'preserve'
  const localesToPublish =
    this.shouldPublish === 'preserve' && entry.fieldStatus
      ? Object.entries(entry.fieldStatus['*'])
          .filter(([, status]) => status === 'published')
          .map(([locale]) => locale)
      : locales
```

### Steps to reproduce:
1. Setup:
- ensure your space as `localeBasedPublishing` enabled!
- **Content type `dog`, with fields: `name`, `breed` and `owner`, all short text** 
<img width="934" height="393" alt="Screenshot 2025-09-23 at 2 55 15 PM" src="https://github.com/user-attachments/assets/627838d1-6e56-4b27-ab0e-75ebe7eda02f" />

- **Create two Entries of type `dog`, **Kona** & **Ziggy**, each with 3 locales: `en-US`, `es` and `de`.** 
  - Note the published/changed/draft statuses for each locale are different

<img width="1914" height="885" alt="Screenshot 2025-09-25 at 11 35 26 AM" src="https://github.com/user-attachments/assets/88c9b507-6ff9-4dc3-8386-c5e64dba095e" />

2. Generate migration based on [15-derive-entry-n-to-1.js](https://github.com/contentful/contentful-migration/blob/main/examples/15-derive-entry-n-to-1.js).  **Be sure to pass the `shouldPublish: preserve` param!**.
```typescript
// In this example, we want to turn the dog's owner field into its own entry
// and link it back to the dog. To do this, we create an "owner"
// content type and a link field on the "dog" content type.
// The link field is a singular Entry link field. (See example 20 if you want to create an Array link field.)
// In the identity function, we define the criterion for when a new owner should
// be created: If the name joined by a hyphen is the same, then the same owner entry is
// linked.
// In the deriveLinkedEntries function, we define what values should go into the new
// owner entries. We don't create any values for the locale 'en-US' on the derived entries.

const deriveEntriesMigration = (migration, context) => {
  const owner = migration
    .createContentType("owner")
    .name("Owner")
    .description("An owner of a dog");
  owner.createField("firstName").type("Symbol").name("First Name");
  owner.createField("lastName").type("Symbol").name("Last Name");
  owner.displayField("firstName");

  const dog = migration.editContentType("dog");
  dog.createField("ownerRef").type("Link").linkType("Entry").name("The Owner");

  migration.deriveLinkedEntries({
    contentType: "dog",
    derivedContentType: "owner",
    from: ["owner"],
    toReferenceField: "ownerRef",
    derivedFields: ["firstName", "lastName"],
    identityKey: async (fromFields) => {
      return fromFields.owner["en-US"].toLowerCase().replace(" ", "-");
    },
    shouldPublish: "preserve",  // This is the bug!  Even though we pass this, this param is not being respected.
    deriveEntryForLocale: async (inputFields, locale) => {
      if (!inputFields.owner[locale]) {
        return;
      }
      const [firstName, lastName] = inputFields.owner[locale].split(" ");

      return {
        firstName,
        lastName,
      };
    },
  });

  dog.deleteField("owner");
  dog.changeFieldId("ownerRef", "owner");
};

module.exports = deriveEntriesMigration;
```

3. Generate & execute migration with
```bash
$ contentful-migration --space-id <spaceId> \
--access-token <accessToken> \
./migrations/20250923_deriveEntries_add_owner_ref_to_dog.ts
```

```bash
# output
The following migration has been planned

Environment: master

Create Content Type owner
  - name: "Owner"
  - description: "An owner of a dog"
  - displayField: "firstName"

  Create field firstName
    - type: "Symbol"
    - name: "First Name"

  Create field lastName
    - type: "Symbol"
    - name: "Last Name"

Publish Content Type owner
Update Content Type dog

  Create field ownerRef
    - type: "Link"
    - linkType: "Entry"
    - name: "The Owner"

Publish Content Type dog
Derive entries from dog
  - from: owner
  - to: firstName,lastName
  - via: ownerRef
Update Content Type dog

  Delete field owner

Publish Content Type dog
Update Content Type dog

  Rename field ownerRef to owner
? Do you want to apply the migration (Y/n)
✔ Create Content Type owner
✔ Update Content Type dog
✔ Derive entries from dog
✔ Update Content Type dog
✔ Update Content Type dog
🎉  Migration successful
 contentful-migration-playground git:(main) ✗ 🌺
```

4. Observe that all locales are published for both `Kona` and `Ziggy` entries 🫢 !
 
<img width="1920" height="886" alt="Screenshot 2025-09-25 at 11 38 05 AM" src="https://github.com/user-attachments/assets/11cc573d-d34c-4b79-9c08-f04c64af4ed9" />
