### PR TITLE
feat!: add breaking release rule and trigger v5.0.0 [DX-787]

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,10 @@
         {
           "releaseRules": [
             {
+              "breaking": true,
+              "release": "major"
+            },
+            {
               "type": "build",
               "scope": "deps",
               "release": "patch"


### PR DESCRIPTION
## Summary
- Adds the missing `breaking: true → major` release rule to `@semantic-release/commit-analyzer` config

## Test plan
- [x] CI passes
- [ ] After merge, semantic-release triggers v5.0.0 on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: Node < 22 is no longer supported. Consumers must upgrade to Node >= 22 before upgrading to this version. contentful-management has been upgraded to v12.