### PR TITLE
docs: fix deleteTag() README to match CMA behavior [AIS-500]

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Uses the same options as [`createTag`](#createtagid-opts).
 
 #### `deleteTag(id)`
 
-Deletes the tag with the provided id and returns `undefined`. Note that this deletes the tag even if it is still attached to entries or assets.
+Deletes the tag with the provided id and returns `undefined`. This sends a delete request directly to the Contentful Management API. It does not remove the tag from any entries or assets first, and it does not republish affected content. If the tag is still assigned to any entry or asset, the Management API rejects the request with `ActionPreconditionsFailed` ("Tag is referenced by another entity"). Use [`setTagsForEntries`](#settagsforentriesconfig) to remove the tag from entries (and republish as needed) before deleting it.
 
 #### `setTagsForEntries(config)`
 


### PR DESCRIPTION
## Purpose

The README claimed `deleteTag()` deletes a tag even while it is still attached to entries or assets. In reality the Management API rejects that call with `ActionPreconditionsFailed` when the tag is still referenced, which a support customer hit directly.

## Approach

- Corrected `deleteTag(id)` docs to state it forwards a plain `DELETE /tags/{id}` to the CMA, with no local check of tag usage and no automatic unassignment or republishing.
- Documented the real failure mode (`ActionPreconditionsFailed`) and pointed to `setTagsForEntries` as the way to clear tag usage before calling `deleteTag()`.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
